### PR TITLE
added a shell.nix generated by cabal2nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,29 @@
+{ nixpkgs ? import <nixpkgs> {}, compiler ? "default", doBenchmark ? false }:
+
+let
+
+  inherit (nixpkgs) pkgs;
+
+  f = { mkDerivation, Agda, base, containers, stdenv }:
+      mkDerivation {
+        pname = "agda2hs";
+        version = "0.1";
+        src = ./.;
+        isLibrary = false;
+        isExecutable = true;
+        executableHaskellDepends = [ Agda base containers ];
+        description = "Compiling Agda code to readable Haskell";
+        license = stdenv.lib.licenses.bsd3;
+      };
+
+  haskellPackages = if compiler == "default"
+                       then pkgs.haskellPackages
+                       else pkgs.haskell.packages.${compiler};
+
+  variant = if doBenchmark then pkgs.haskell.lib.doBenchmark else pkgs.lib.id;
+
+  drv = variant (haskellPackages.callPackage f {});
+
+in
+
+  if pkgs.lib.inNixShell then drv.env else drv


### PR DESCRIPTION
Just adding a shell.nix which makes it easy to let nix bring in dependencies to support this work flow:
```
agda2hs $ nix-shell
nix-shell:agda2hs $ cabal v2-build
```