### PR TITLE
Extra builtins types: Word/Float/Char

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -15,6 +15,7 @@ import System.Directory
 
 import qualified Language.Haskell.Exts.SrcLoc     as Hs
 import qualified Language.Haskell.Exts.Syntax     as Hs
+import qualified Language.Haskell.Exts.Build      as Hs
 import qualified Language.Haskell.Exts.Pretty     as Hs
 import qualified Language.Haskell.Exts.Parser     as Hs
 import qualified Language.Haskell.Exts.ExactPrint as Hs
@@ -111,20 +112,24 @@ isOp _                         = False
 
 -- Builtins ---------------------------------------------------------------
 
-data Prim = Nat | List | Unit | Cons | Nil
+data Prim = Unit
+          | Nat | Float | Word64
+          | Char
+          | List | Cons | Nil
   deriving (Show, Eq)
 
 type Builtins = Map QName Prim
 
 getBuiltins :: TCM Builtins
 getBuiltins = Map.fromList . concat <$> mapM getB
-                [ (builtinNat,  Nat)
-                , (builtinList, List)
-                , (builtinUnit, Unit)
-                , (builtinCons, Cons)
-                , (builtinNil,  Nil)
-                ]
+  [ builtinUnit |-> Unit
+  , builtinNat |-> Nat, builtinFloat |-> Float
+  , builtinWord64 |-> Word64
+  , builtinChar |-> Char
+  , builtinList |-> List , builtinCons |-> Cons , builtinNil |-> Nil
+  ]
   where
+    (|->) = (,)
     getB (b, t) = getBuiltin' b >>= \ case
       Nothing          -> return []
       Just (Def q _)   -> return [(q, t)]
@@ -132,18 +137,25 @@ getBuiltins = Map.fromList . concat <$> mapM getB
       Just _           -> __IMPOSSIBLE__
 
 compilePrim :: Prim -> Hs.QName ()
-compilePrim Nat  = Hs.UnQual () (hsName "Integer")
-compilePrim List = Hs.Special () (Hs.ListCon ())
-compilePrim Unit = Hs.Special () (Hs.UnitCon ())
-compilePrim Cons = Hs.Special () (Hs.Cons ())
-compilePrim Nil  = Hs.Special () (Hs.ListCon ())
+compilePrim = \case
+  Unit   -> special Hs.UnitCon
+  Nat    -> unqual "Integer"
+  Float  -> unqual "Double"
+  Word64 -> unqual "Word64"
+  Char   -> unqual "Char"
+  List   -> special Hs.ListCon
+  Cons   -> special Hs.Cons
+  Nil    -> special Hs.ListCon
+  where
+    unqual n  = Hs.UnQual () $ hsName n
+    special c = Hs.Special () $ c ()
 
 -- Compiling things -------------------------------------------------------
 
 compile :: Options -> Builtins -> IsMain -> Definition -> TCM CompiledDef
 compile _ builtins _ def = getUniqueCompilerPragma pragmaName (defName def) >>= \ case
-  Nothing -> return []
   Just _  -> compile' builtins def
+  Nothing -> return []
 
 compile' :: Builtins -> Definition -> TCM CompiledDef
 compile' builtins def =
@@ -231,7 +243,10 @@ compileTerm builtins v =
     Var x es   -> (`app` es) . Hs.Var () . Hs.UnQual () . hsName =<< showTCM (Var x [])
     Def f es   -> (`app` es) . Hs.Var () =<< hsQName builtins f
     Con h i es -> (`app` es) . Hs.Con () =<< hsQName builtins (conName h)
-    Lit (LitNat _ n) -> return $ Hs.Lit () $ Hs.Int () n (show n)
+    Lit (LitNat _ n) -> return $ Hs.intE n
+    Lit (LitFloat _ d) -> return $ Hs.Lit () $ Hs.Frac () (toRational d) (show d)
+    Lit (LitWord64 _ w) -> return $ Hs.Lit () $ Hs.PrimWord () (fromIntegral w) (show w)
+    Lit (LitChar _ c) -> return $ Hs.charE c
     Lam v b | visible v -> hsLambda (absName b) <$> underAbstraction_ b (compileTerm builtins)
     Lam _ b -> underAbstraction_ b (compileTerm builtins)
     t -> genericDocError =<< text "bad term:" <?> prettyTCM t
@@ -378,4 +393,3 @@ writeModule opts _ isMain m defs0 = do
     liftIO $ writeFile hsFile output
 
 main = runAgda [Backend backend]
-

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Compiles a subset of Agda to readable Haskell code. See Test.agda for an example
 - Map instance arguments to Haskell type classes (definitions and use) [#3](https://github.com/agda/agda2hs/pull/3)
 - `where` clauses
 - Higher-rank polymorphism
-- More builtin types (`Double`, `Word64`)
 - Strings (compile to `Data.Text`)
 - Compile `case_of_ λ where` to Haskell `case`
 - `with`?

--- a/test/Test.agda
+++ b/test/Test.agda
@@ -1,40 +1,48 @@
-
 module _ where
 
 open import Agda.Builtin.List
 open import Agda.Builtin.Nat
+open import Agda.Builtin.Float
+open import Agda.Builtin.Word
+open import Agda.Builtin.Char
 open import Agda.Builtin.Equality
 
 variable
   a b : Set
 
+-- ** Foreign HS code
+
+-- language extensions
 {-# FOREIGN AGDA2HS
 {-# LANGUAGE LambdaCase #-}
 #-}
 
+-- imports
 {-# FOREIGN AGDA2HS
 import Prelude hiding (map, sum, (++))
 import Data.Monoid
+import Data.Word
 #-}
+
+-- ** Datatypes & functions
 
 data Exp (v : Set) : Set where
   Plus : Exp v → Exp v → Exp v
   Int : Nat → Exp v
   Var : v → Exp v
-
 {-# COMPILE AGDA2HS Exp #-}
 
 eval : (a → Nat) → Exp a → Nat
 eval env (Plus a b) = eval env a + eval env b
 eval env (Int n) = n
 eval env (Var x) = env x
-
 {-# COMPILE AGDA2HS eval #-}
+
+-- ** Natural numbers
 
 sum : List Nat → Nat
 sum []       = 0
 sum (x ∷ xs) = x + sum xs
-
 {-# COMPILE AGDA2HS sum #-}
 
 {-# FOREIGN AGDA2HS
@@ -49,27 +57,54 @@ bla n = n * 4
 -}
 #-}
 
+-- ** Extra builtins
+
+ex_float : Float
+ex_float = 0.0
+{-# COMPILE AGDA2HS ex_float #-}
+
+postulate
+  toInteger : Word64 → Nat
+  fromInteger : Nat → Word64
+
+ex_word : Word64
+ex_word = fromInteger 0
+{-# COMPILE AGDA2HS ex_word #-}
+
+ex_char : Char
+ex_char = 'a'
+{-# COMPILE AGDA2HS ex_char #-}
+
+postulate
+  toEnum : Nat → Char
+
+d : Char
+d = toEnum 100
+{-# COMPILE AGDA2HS d #-}
+
+-- ** Polymorphic functions
+
 _++_ : List a → List a → List a
 []       ++ ys = ys
 (x ∷ xs) ++ ys = x ∷ (xs ++ ys)
-
 {-# COMPILE AGDA2HS _++_ #-}
 
 map : (a → b) → List a → List b
 map f [] = []
 map f (x ∷ xs) = f x ∷ map f xs
-
 {-# COMPILE AGDA2HS map #-}
+
+-- ** Lambdas
 
 plus3 : List Nat → List Nat
 plus3 = map (λ n → n + 3)
-
 {-# COMPILE AGDA2HS plus3 #-}
 
 doubleLambda : Nat → Nat → Nat
 doubleLambda = λ a b → a + 2 * b
-
 {-# COMPILE AGDA2HS doubleLambda #-}
+
+-- ** Proofs
 
 assoc : (a b c : Nat) → a + (b + c) ≡ (a + b) + c
 assoc zero    b c = refl
@@ -78,4 +113,3 @@ assoc (suc a) b c rewrite assoc a b c = refl
 thm : ∀ xs ys → sum (xs ++ ys) ≡ sum xs + sum ys
 thm []       ys = refl
 thm (x ∷ xs) ys rewrite thm xs ys | assoc x (sum xs) (sum ys) = refl
-

--- a/test/golden/Test.hs
+++ b/test/golden/Test.hs
@@ -4,6 +4,7 @@ module Test where
 
 import Prelude hiding (map, sum, (++))
 import Data.Monoid
+import Data.Word
 
 data Exp v = Plus (Exp v) (Exp v)
            | Int Integer
@@ -27,6 +28,18 @@ bla n = n * 4
    line
    comment
 -}
+
+ex_float :: Double
+ex_float = 0.0
+
+ex_word :: Word64
+ex_word = fromInteger 0
+
+ex_char :: Char
+ex_char = 'a'
+
+d :: Char
+d = toEnum 100
 
 (++) :: [a] -> [a] -> [a]
 [] ++ ys = ys


### PR DESCRIPTION
This introduces new built-in types for `Data.Word.Word64`, `Double` and `Char` without any fancy business for adding primitives (one can of course just postulate a function with the same name as the Haskell one).