### PR TITLE
Automatic builtin imports + checking them

### DIFF
--- a/HsUtils.hs
+++ b/HsUtils.hs
@@ -1,0 +1,95 @@
+module HsUtils where
+
+import Language.Haskell.Exts.SrcLoc
+import Language.Haskell.Exts.Syntax
+import Language.Haskell.Exts.Comments
+import Language.Haskell.Exts.Pretty
+
+import Agda.Syntax.Position
+import Agda.Utils.FileName
+import Agda.Utils.List
+import Agda.Utils.Maybe.Strict (toStrict)
+
+-- Names ------------------------------------------------------------------
+
+isInfix :: String -> Maybe String
+isInfix ('_' : f) = do
+  (op, '_') <- initLast f
+  return op
+isInfix _ = Nothing
+
+hsName :: String -> Name ()
+hsName x
+  | Just op <- isInfix x = Symbol () op
+  | otherwise            = Ident () x
+
+isOp :: QName () -> Bool
+isOp (UnQual _ Symbol{}) = True
+isOp (Special _ Cons{})  = True
+isOp _                         = False
+
+-- Utilities for building Haskell constructs
+
+pp :: Pretty a => a -> String
+pp = prettyPrintWithMode defaultMode{ spacing = False }
+
+-- exactPrint really looks at the line numbers (and we're using the locations from the agda source
+-- to report Haskell parse errors at the right location), so shift everything to start at line 1.
+moveToTop :: Annotated ast => (ast SrcSpanInfo, [Comment]) -> (ast SrcSpanInfo, [Comment])
+moveToTop (x, cs) = (subtractLine l <$> x, [ Comment b (sub l r) str | Comment b r str <- cs ])
+  where l = startLine (ann x) - 1
+        subtractLine :: Int -> SrcSpanInfo -> SrcSpanInfo
+        subtractLine l (SrcSpanInfo s ss) = SrcSpanInfo (sub l s) (map (sub l) ss)
+
+        sub :: Int -> SrcSpan -> SrcSpan
+        sub l (SrcSpan f l0 c0 l1 c1) = SrcSpan f (l0 - l) c0 (l1 - l) c1
+
+pApp :: QName () -> [Pat ()] -> Pat ()
+pApp c@(UnQual () (Symbol () _)) [p, q] = PInfixApp () p c q
+pApp c@(Special () Cons{}) [p, q] = PInfixApp () p c q
+pApp c ps = PApp () c ps
+
+eApp :: Exp () -> [Exp ()] -> Exp ()
+eApp f (a : b : as) | Just op <- getOp f = foldl (App ()) (InfixApp () a op b) as
+  where getOp (Var _ x) | isOp x = Just $ QVarOp () x
+        getOp (Con _ c) | isOp c = Just $ QConOp () c
+        getOp _                  = Nothing
+eApp f es = foldl (App ()) f es
+
+tApp :: Type () -> [Type ()] -> Type ()
+tApp (TyCon () (Special () ListCon{})) [a] = TyList () a
+tApp t vs = foldl (TyApp ()) t vs
+
+hsLambda :: String -> Exp () -> Exp ()
+hsLambda x e =
+  case e of
+    Lambda l ps b -> Lambda l (p : ps) b
+    _             -> Lambda () [p] e
+  where
+    p = PVar () $ hsName x
+
+getExplicitImports :: ImportSpec l -> [String]
+getExplicitImports = map pp . \case 
+  IVar _ n -> [n]
+  IAbs _ _ n -> [n]
+  IThingAll _ n -> [n]
+  IThingWith _ n ns -> n : map cname ns
+
+cname :: CName l -> Name l
+cname (VarName _ n) = n
+cname (ConName _ n) = n
+
+cloc :: CName l -> l
+cloc (VarName l _) = l
+cloc (ConName l _) = l
+
+srcSpanToRange :: SrcSpan -> Range
+srcSpanToRange (SrcSpan file l1 c1 l2 c2) =
+  intervalToRange (toStrict $ Just $ mkAbsolute file) $ Interval (pos l1 c1) (pos l2 c2)
+  where pos l c = Pn () 0 (fromIntegral l) (fromIntegral c)
+
+srcLocToRange :: SrcLoc -> Range
+srcLocToRange (SrcLoc file l c) = srcSpanToRange (SrcSpan file l c l c)
+
+srcSpanInfoToRange :: SrcSpanInfo -> Range
+srcSpanInfoToRange = srcSpanToRange . srcInfoSpan

--- a/HsUtils.hs
+++ b/HsUtils.hs
@@ -1,5 +1,8 @@
 module HsUtils where
 
+import Data.Data
+import Data.Generics.Schemes (listify)
+
 import Language.Haskell.Exts.SrcLoc
 import Language.Haskell.Exts.Syntax
 import Language.Haskell.Exts.Comments
@@ -93,3 +96,12 @@ srcLocToRange (SrcLoc file l c) = srcSpanToRange (SrcSpan file l c l c)
 
 srcSpanInfoToRange :: SrcSpanInfo -> Range
 srcSpanInfoToRange = srcSpanToRange . srcInfoSpan
+
+allUsedTypes :: Data a => a -> [Type ()]
+allUsedTypes = listify (const True)
+
+usedTypesOf :: Data a => String -> a -> [Type ()]
+usedTypesOf s = listify $ (== s) . pp
+
+usesWord64 :: Data a => a -> Bool
+usesWord64 = not . null . usedTypesOf "Word64"

--- a/Main.hs
+++ b/Main.hs
@@ -58,8 +58,6 @@ import HsUtils
 data Options = Options { optOutDir     :: FilePath,
                          optExtensions :: [Hs.Extension] }
 
-data Options = Options { outDir :: FilePath }
-
 defaultOptions :: Options
 defaultOptions = Options{ optOutDir = ".", optExtensions = [] }
 
@@ -384,7 +382,7 @@ imports modules = concat [imps | (_, (Hs.Module _ _ _ imps _, _)) <- modules]
 
 addImports :: [Hs.ImportDecl Hs.SrcSpanInfo] -> [CompiledDef] -> TCM [Hs.ImportDecl ()]
 addImports is defs = do
-  return [importWord64 | not (null defs || any isImportWord64 is)] 
+  return [importWord64 | usesWord64 defs && not (any isImportWord64 is)]
   where
     importWord64 :: Hs.ImportDecl ()
     importWord64 = Hs.ImportDecl ()

--- a/agda2hs.cabal
+++ b/agda2hs.cabal
@@ -20,6 +20,7 @@ source-repository head
 
 executable agda2hs
   main-is:             Main.hs
+  other-modules:       HsUtils
   build-depends:       base >= 4.10 && < 4.15,
                        Agda >= 2.6 && < 2.6.2,
                        containers >= 0.6 && < 0.7,

--- a/agda2hs.cabal
+++ b/agda2hs.cabal
@@ -26,7 +26,8 @@ executable agda2hs
                        containers >= 0.6 && < 0.7,
                        directory >= 1.2.6.2 && < 1.4,
                        filepath >= 1.4.1.0 && < 1.5,
-                       haskell-src-exts >= 1.23 && < 1.25
+                       haskell-src-exts >= 1.23 && < 1.25,
+                       syb >= 0.7
   default-language:    Haskell2010
   default-extensions:  LambdaCase,
                        RecordWildCards

--- a/test/Test.agda
+++ b/test/Test.agda
@@ -13,7 +13,10 @@ open import Prelude
 {-# FOREIGN AGDA2HS
 import Prelude hiding (map, sum, (++))
 import Data.Monoid
-import Data.Word
+-- import Data.Word
+
+-- import Data.Word (Word64)
+import qualified Data.Word as Word64
 #-}
 
 -- ** Datatypes & functions

--- a/test/golden/Test.hs
+++ b/test/golden/Test.hs
@@ -2,9 +2,13 @@
 
 module Test where
 
+import Data.Word (Word64)
 import Prelude hiding (map, sum, (++))
 import Data.Monoid
-import Data.Word
+-- import Data.Word
+
+-- import Data.Word (Word64)
+import qualified Data.Word as Word64
 
 data Exp v = Plus (Exp v) (Exp v)
            | Int Integer


### PR DESCRIPTION
  * Moves Haskell utilities to separate `HsUtils.hs` file

  * Also adds quasiquoter for `hs-src-exts` things (spliced in expressions/patterns)