### PR TITLE
Take LANGUAGE pragmas into account when parsing FOREIGN blocks

### DIFF
--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -1,6 +1,10 @@
 
 module AllTests where
 
+import Pragmas
 import Test
 
-{-# FOREIGN AGDA2HS import Test #-}
+{-# FOREIGN AGDA2HS
+import Pragmas
+import Test
+#-}

--- a/test/Pragmas.agda
+++ b/test/Pragmas.agda
@@ -1,0 +1,15 @@
+
+module Pragmas where
+
+-- Check that Haskell code is parsed with the correct language pragmas
+{-# FOREIGN AGDA2HS
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE LambdaCase #-}
+#-}
+
+{-# FOREIGN AGDA2HS
+foo :: Bool -> a -> (a, Int)
+foo = \ case
+  False -> (, 0)
+  True  -> (, 1)
+#-}

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -1,4 +1,5 @@
 module AllTests where
 
+import Pragmas
 import Test
 

--- a/test/golden/Pragmas.hs
+++ b/test/golden/Pragmas.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Pragmas where
+
+foo :: Bool -> a -> (a, Int)
+foo = \ case
+  False -> (, 0)
+  True  -> (, 1)
+


### PR DESCRIPTION
Also adds `-X` command-line flags for global language extensions