### PR TITLE
Fix #14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,8 @@
 install :
 	cabal new-install --overwrite-policy=always
 
-repl : test/*.agda
-	for f in $^; do cp $${f} .; done
-	cabal new-repl # e.g. `:set args AllTests.agda...main...:r...main`
-	for f in $^; do f1=$${f##*/}; f2=$${f1%.*}; rm -f $${f2}.agda $${f2}.hs; done
+repl :
+	cabal new-repl # e.g. `:set args --no-default-libraries -itest -otest/build test/AllTests.agda ... main ... :r ... main`
 
 test :
 	cabal new-install --overwrite-policy=always --installdir=test --install-method=copy

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -1,10 +1,12 @@
 
 module AllTests where
 
+import Issue14
 import Pragmas
 import Test
 
 {-# FOREIGN AGDA2HS
+import Issue14
 import Pragmas
 import Test
 #-}

--- a/test/Issue14.agda
+++ b/test/Issue14.agda
@@ -1,0 +1,20 @@
+
+module Issue14 where
+
+open import Agda.Builtin.Nat
+open import Prelude
+
+-- Wrong name for shadowed lambda
+constid : a → b → b
+constid x = λ x → x
+
+{-# COMPILE AGDA2HS constid #-}
+
+sectionTest₁ : Nat → Nat → Nat
+sectionTest₁ n = _+ n
+
+sectionTest₂ : Nat → Nat → Nat
+sectionTest₂ section = _+ section
+
+{-# COMPILE AGDA2HS sectionTest₁ #-}
+{-# COMPILE AGDA2HS sectionTest₂ #-}

--- a/test/Issue14.hs
+++ b/test/Issue14.hs
@@ -1,0 +1,11 @@
+module Issue14 where
+
+constid :: a -> b -> b
+constid x = \ x -> x
+
+sectionTest₁ :: Integer -> Integer -> Integer
+sectionTest₁ n = \ section -> section + n
+
+sectionTest₂ :: Integer -> Integer -> Integer
+sectionTest₂ section = \ section -> section + section₁
+

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -1,5 +1,6 @@
 module AllTests where
 
+import Issue14
 import Pragmas
 import Test
 

--- a/test/golden/Issue14.hs
+++ b/test/golden/Issue14.hs
@@ -1,0 +1,11 @@
+module Issue14 where
+
+constid :: a -> b -> b
+constid x = \ x -> x
+
+sectionTest₁ :: Integer -> Integer -> Integer
+sectionTest₁ n = \ section -> section + n
+
+sectionTest₂ :: Integer -> Integer -> Integer
+sectionTest₂ section = \ section₁ -> section₁ + section
+


### PR DESCRIPTION
The scope needs to be updated when going under binders to force the printer to not rename user-written variables.

Fixes #14 