### PR TITLE
Numbers

### DIFF
--- a/HsUtils.hs
+++ b/HsUtils.hs
@@ -118,5 +118,5 @@ allUsedTypes = listify (const True)
 usedTypesOf :: Data a => String -> a -> [Type ()]
 usedTypesOf s = listify $ (== s) . pp
 
-usesWord64 :: Data a => a -> Bool
-usesWord64 = not . null . usedTypesOf "Word64"
+uses :: Data a => String -> a -> Bool
+uses ty = not . null . usedTypesOf ty

--- a/Main.hs
+++ b/Main.hs
@@ -186,7 +186,8 @@ isSpecialType = show >>> \ case
 
 isSpecialName :: QName -> Maybe (Hs.QName ())
 isSpecialName = show >>> \ case
-    "Agda.Builtin.Nat.Nat"         -> unqual "Integer"
+    "Agda.Builtin.Nat.Nat"         -> unqual "Natural"
+    "Agda.Builtin.Int.Int"         -> unqual "Integer"
     "Agda.Builtin.Float.Float"     -> unqual "Double"
     "Agda.Builtin.Bool.Bool.false" -> unqual "False"
     "Agda.Builtin.Bool.Bool.true"  -> unqual "True"
@@ -585,7 +586,8 @@ imports :: [Ranged Code] -> [Hs.ImportDecl Hs.SrcSpanInfo]
 imports modules = concat [imps | (_, (Hs.Module _ _ _ imps _, _)) <- modules]
 
 autoImports :: [(String, String)]
-autoImports = [("Word64", "Data.Word")]
+autoImports = [("Word64",  "Data.Word"),
+               ("Natural", "Numeric.Natural")]
 
 addImports :: [Hs.ImportDecl Hs.SrcSpanInfo] -> [CompiledDef] -> TCM [Hs.ImportDecl ()]
 addImports is defs = do
@@ -659,7 +661,9 @@ writeModule opts _ isMain m defs0 = do
     -- Check user-supplied imports
     checkImports imps
     -- Add automatic imports for builtin types (if any)
-    autoImports <- unlines . map pp <$> addImports imps defs0
+    let unlines' [] = []
+        unlines' ss = unlines ss ++ "\n"
+    autoImports <- unlines' . map pp <$> addImports imps defs0
     -- The comments makes it hard to generate and pretty print a full module
     let hsFile = moduleFileName opts m
         output = concat

--- a/Main.hs
+++ b/Main.hs
@@ -191,6 +191,7 @@ isSpecialName :: QName -> Maybe (Hs.QName ())
 isSpecialName = show >>> \ case
     "Agda.Builtin.Nat.Nat"         -> unqual "Natural"
     "Agda.Builtin.Int.Int"         -> unqual "Integer"
+    "Agda.Builtin.Word.Word64"     -> unqual "Word"
     "Agda.Builtin.Float.Float"     -> unqual "Double"
     "Agda.Builtin.Bool.Bool.false" -> unqual "False"
     "Agda.Builtin.Bool.Bool.true"  -> unqual "True"
@@ -602,8 +603,7 @@ imports :: [Ranged Code] -> [Hs.ImportDecl Hs.SrcSpanInfo]
 imports modules = concat [imps | (_, (Hs.Module _ _ _ imps _, _)) <- modules]
 
 autoImports :: [(String, String)]
-autoImports = [("Word64",  "Data.Word"),
-               ("Natural", "Numeric.Natural")]
+autoImports = [("Natural", "Numeric.Natural")]
 
 addImports :: [Hs.ImportDecl Hs.SrcSpanInfo] -> [CompiledDef] -> TCM [Hs.ImportDecl ()]
 addImports is defs = do

--- a/lib/Haskell/Prelude.agda
+++ b/lib/Haskell/Prelude.agda
@@ -12,6 +12,7 @@ import Agda.Builtin.String as Str
 open import Agda.Builtin.Strict
 open import Agda.Builtin.FromNat      public using (fromNat)
 open import Agda.Builtin.FromNeg      public using (fromNeg)
+open import Agda.Builtin.Word         public renaming (Word64 to Word)
 
 open import Haskell.Prim
 open Haskell.Prim public using (if_then_else_; iNumberNat)

--- a/lib/Haskell/Prelude.agda
+++ b/lib/Haskell/Prelude.agda
@@ -10,6 +10,14 @@ open import Agda.Builtin.Char         public
 open import Agda.Builtin.FromString   public
 import Agda.Builtin.String as Str
 open import Agda.Builtin.Strict
+open import Agda.Builtin.FromNat      public using (fromNat)
+open import Agda.Builtin.FromNeg      public using (fromNeg)
+
+import Haskell.Prim
+open Haskell.Prim
+open Haskell.Prim public using (if_then_else_; iNumberNat)
+
+open import Haskell.Prim.Integer public
 
 -- Problematic features
 --  - [Partial]:  Could pass implicit/instance arguments to prove totality.
@@ -148,11 +156,6 @@ private
 
 --------------------------------------------------
 -- Booleans
-
-infix -2 if_then_else_
-if_then_else_ : Bool → a → a → a
-if true  then t else f = t
-if false then t else f = f
 
 infixr 3 _&&_
 _&&_ : Bool → Bool → Bool

--- a/lib/Haskell/Prelude.agda
+++ b/lib/Haskell/Prelude.agda
@@ -2,8 +2,8 @@
 module Haskell.Prelude where
 
 open import Agda.Builtin.Unit         public
+open import Agda.Builtin.Nat as Nat   public hiding (_==_; _<_)
 open import Agda.Builtin.List         public
-open import Agda.Builtin.Nat   as Nat public hiding (_==_; _<_)
 open import Agda.Builtin.Bool         public
 open import Agda.Builtin.Float        public
 open import Agda.Builtin.Char         public
@@ -13,11 +13,16 @@ open import Agda.Builtin.Strict
 open import Agda.Builtin.FromNat      public using (fromNat)
 open import Agda.Builtin.FromNeg      public using (fromNeg)
 
-import Haskell.Prim
-open Haskell.Prim
+open import Haskell.Prim
 open Haskell.Prim public using (if_then_else_; iNumberNat)
 
-open import Haskell.Prim.Integer public
+open import Haskell.Prim.Integer
+open Haskell.Prim.Integer public using (Integer; iNumberInteger; iNegativeInteger)
+
+open import Haskell.Prim.Int renaming (Int64 to Int)
+open Haskell.Prim.Int public using (iNumberInt; iNegativeInt) renaming (Int64 to Int)
+
+open import Haskell.Prim.Word
 
 -- Problematic features
 --  - [Partial]:  Could pass implicit/instance arguments to prove totality.
@@ -413,6 +418,15 @@ instance
   iEqNat : Eq Nat
   iEqNat ._==_ = Nat._==_
 
+  iEqInteger : Eq Integer
+  iEqInteger ._==_ = eqInteger
+
+  iEqInt : Eq Int
+  iEqInt ._==_ = eqInt
+
+  iEqWord : Eq Word64
+  iEqWord ._==_ = eqWord
+
   iEqBool : Eq Bool
   iEqBool ._==_ false false = true
   iEqBool ._==_ true  true  = true
@@ -481,11 +495,22 @@ record Ord (a : Set) : Set where
 
 open Ord ⦃ ... ⦄ public
 
+private
+  compareFromLt : ⦃ Eq a ⦄ → (a → a → Bool) → a → a → Ordering
+  compareFromLt _<_ x y = if x < y then LT else if x == y then EQ else GT
+
 instance
   iOrdNat : Ord Nat
-  iOrdNat .compare n m = if      n Nat.< m then LT
-                         else if n == m    then EQ
-                                           else GT
+  iOrdNat .compare = compareFromLt Nat._<_
+
+  iOrdInteger : Ord Integer
+  iOrdInteger .compare = compareFromLt ltInteger
+
+  iOrdInt : Ord Int
+  iOrdInt .compare = compareFromLt ltInt
+
+  iOrdWord : Ord Word64
+  iOrdWord .compare = compareFromLt ltWord
 
   iOrdBool : Ord Bool
   iOrdBool .compare false true  = LT

--- a/lib/Haskell/Prim.agda
+++ b/lib/Haskell/Prim.agda
@@ -1,0 +1,35 @@
+
+-- Basic things needed by other primitive modules.
+
+module Haskell.Prim where
+
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Unit
+open import Agda.Builtin.FromNat
+
+private
+  variable
+    a b c d : Set
+
+
+--------------------------------------------------
+-- Booleans
+
+infix -2 if_then_else_
+
+if_then_else_ : Bool → a → a → a
+if false then x else y = y
+if true  then x else y = x
+
+data IsTrue : Bool → Set where
+  instance itsTrue : IsTrue true
+
+
+--------------------------------------------------
+-- Numbers
+
+instance
+  iNumberNat : Number Nat
+  iNumberNat .Number.Constraint _ = ⊤
+  iNumberNat .fromNat n = n

--- a/lib/Haskell/Prim/Int.agda
+++ b/lib/Haskell/Prim/Int.agda
@@ -1,0 +1,103 @@
+
+-- Agda doesn't have an Int64 type (only Word64). With some work we
+-- can represent signed ints using Word64.
+
+module Haskell.Prim.Int where
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Word renaming (primWord64ToNat to w2n; primWord64FromNat to n2w)
+open import Agda.Builtin.Bool
+open import Agda.Builtin.List
+open import Agda.Builtin.Char
+open import Agda.Builtin.FromNat
+open import Agda.Builtin.FromNeg
+open import Agda.Builtin.Unit
+open import Agda.Builtin.Int using (pos; negsuc)
+
+open import Haskell.Prim
+open import Haskell.Prim.Word
+open import Haskell.Prim.Integer
+
+
+--------------------------------------------------
+-- Definition
+
+data Int64 : Set where
+  int64 : Word64 → Int64
+
+private
+  intToWord : Int64 → Word64
+  intToWord (int64 a) = a
+
+  intToNat : Int64 → Nat
+  intToNat a = w2n (intToWord a)
+
+
+--------------------------------------------------
+-- Literals
+
+private
+  2⁶⁴ : Nat
+  2⁶⁴ = 18446744073709551616
+
+  2⁶³ : Nat
+  2⁶³ = 9223372036854775808
+
+  maxInt : Nat
+  maxInt = 2⁶³ - 1
+
+instance
+  iNumberInt : Number Int64
+  iNumberInt .Number.Constraint n = IsTrue (n < 2⁶³)
+  iNumberInt .fromNat n = int64 (n2w n)
+
+  iNegativeInt : Negative Int64
+  iNegativeInt .Negative.Constraint n = IsTrue (n < 1 + 2⁶³)
+  iNegativeInt .fromNeg n = int64 (n2w (2⁶⁴ - n))
+
+
+--------------------------------------------------
+-- Arithmetic
+
+private
+  isNegative : Int64 → Bool
+  isNegative (int64 w) = maxInt < w2n w
+
+eqInt : Int64 → Int64 → Bool
+eqInt (int64 a) (int64 b) = w2n a == w2n b
+
+negateInt : Int64 → Int64
+negateInt (int64 a) = int64 (n2w (2⁶⁴ - w2n a))
+
+intToInteger : Int64 → Integer
+intToInteger a = if isNegative a then negsuc (intToNat (negateInt a) - 1) else pos (intToNat a)
+
+private
+  ltPosInt : Int64 → Int64 → Bool
+  ltPosInt (int64 a) (int64 b) = ltWord a b
+
+ltInt : Int64 → Int64 → Bool
+ltInt a b with isNegative a | isNegative b
+... | true  | false = true
+... | false | true  = false
+... | true  | true  = ltPosInt (negateInt b) (negateInt a)
+... | false | false = ltPosInt a b
+
+addInt : Int64 → Int64 → Int64
+addInt (int64 a) (int64 b) = int64 (addWord a b)
+
+subInt : Int64 → Int64 → Int64
+subInt a b = addInt a (negateInt b)
+
+mulInt : Int64 → Int64 → Int64
+mulInt (int64 a) (int64 b) = int64 (mulWord a b)
+
+showInt : Int64 → List Char
+showInt a = showInteger (intToInteger a)
+
+absInt : Int64 → Int64
+absInt a = if isNegative a then negateInt a else a
+
+signInt : Int64 → Int64
+signInt a = if      isNegative a then -1
+            else if eqInt a 0    then 0 else 1

--- a/lib/Haskell/Prim/Integer.agda
+++ b/lib/Haskell/Prim/Integer.agda
@@ -1,0 +1,94 @@
+
+module Haskell.Prim.Integer where
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Bool
+open import Agda.Builtin.List
+open import Agda.Builtin.String
+open import Agda.Builtin.Char
+open import Agda.Builtin.Unit
+open import Agda.Builtin.FromNat
+open import Agda.Builtin.FromNeg
+
+import Agda.Builtin.Int
+open Agda.Builtin.Int public using () renaming (Int to Integer)
+open Agda.Builtin.Int renaming (Int to Integer)
+
+open import Haskell.Prim
+
+
+--------------------------------------------------
+-- Literals
+
+private
+  negNat : Nat → Integer
+  negNat 0       = pos 0
+  negNat (suc n) = negsuc n
+
+instance
+  iNumberInteger : Number Integer
+  iNumberInteger .Number.Constraint _ = ⊤
+  iNumberInteger .fromNat n = pos n
+
+  iNegativeInteger : Negative Integer
+  iNegativeInteger .Negative.Constraint _ = ⊤
+  iNegativeInteger .fromNeg n = negNat n
+
+
+--------------------------------------------------
+-- Arithmetic
+
+private
+  subNat : Nat → Nat → Integer
+  subNat n m = if n < m then negsuc (m - suc n) else pos (n - m)
+
+negateInteger : Integer → Integer
+negateInteger (pos 0)       = pos 0
+negateInteger (pos (suc n)) = negsuc n
+negateInteger (negsuc n)    = pos (suc n)
+
+addInteger : Integer → Integer → Integer
+addInteger (pos    n) (pos    m) = pos (n + m)
+addInteger (pos    n) (negsuc m) = subNat n (suc m)
+addInteger (negsuc n) (pos    m) = subNat m (suc n)
+addInteger (negsuc n) (negsuc m) = negsuc (n + m + 1)
+
+subInteger : Integer → Integer → Integer
+subInteger n m = addInteger n (negateInteger m)
+
+mulInteger : Integer → Integer → Integer
+mulInteger (pos    n) (pos    m) = pos (n * m)
+mulInteger (pos    n) (negsuc m) = negNat (n * suc m)
+mulInteger (negsuc n) (pos    m) = negNat (suc n * m)
+mulInteger (negsuc n) (negsuc m) = pos (suc n * suc m)
+
+absInteger : Integer → Integer
+absInteger (pos    n) = pos n
+absInteger (negsuc n) = pos (suc n)
+
+signInteger : Integer → Integer
+signInteger (pos 0)       = 0
+signInteger (pos (suc _)) = 1
+signInteger (negsuc _)    = -1
+
+
+--------------------------------------------------
+-- Comparisons
+
+eqInteger : Integer → Integer → Bool
+eqInteger (pos n)    (pos m)    = n == m
+eqInteger (negsuc n) (negsuc m) = n == m
+eqInteger _          _          = false
+
+ltInteger : Integer → Integer → Bool
+ltInteger (pos    n) (pos    m) = n < m
+ltInteger (pos    n) (negsuc _) = false
+ltInteger (negsuc n) (pos    _) = true
+ltInteger (negsuc n) (negsuc m) = m < n
+
+
+--------------------------------------------------
+-- Show
+
+showInteger : Integer → List Char
+showInteger n = primStringToList (primShowInteger n)

--- a/lib/Haskell/Prim/Word.agda
+++ b/lib/Haskell/Prim/Word.agda
@@ -1,0 +1,54 @@
+
+module Haskell.Prim.Word where
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Bool
+open import Agda.Builtin.List
+open import Agda.Builtin.Char
+open import Agda.Builtin.String
+open import Agda.Builtin.FromNat
+open import Agda.Builtin.Unit
+
+import Agda.Builtin.Word renaming (primWord64ToNat to w2n; primWord64FromNat to n2w)
+open Agda.Builtin.Word
+open Agda.Builtin.Word public using (Word64)
+
+open import Haskell.Prim
+
+
+--------------------------------------------------
+-- Literals
+
+private
+  2⁶⁴ : Nat
+  2⁶⁴ = 18446744073709551616
+
+instance
+  iNumberWord : Number Word64
+  iNumberWord .Number.Constraint n = IsTrue (n < 2⁶⁴)
+  iNumberWord .fromNat n = n2w n
+
+
+--------------------------------------------------
+-- Arithmetic
+
+negateWord : Word64 → Word64
+negateWord a = n2w (2⁶⁴ - w2n a)
+
+addWord : Word64 → Word64 → Word64
+addWord a b = n2w (w2n a + w2n b)
+
+subWord : Word64 → Word64 → Word64
+subWord a b = addWord a (negateWord b)
+
+mulWord : Word64 → Word64 → Word64
+mulWord a b = n2w (w2n a * w2n b)
+
+eqWord : Word64 → Word64 → Bool
+eqWord a b = w2n a == w2n b
+
+ltWord : Word64 → Word64 → Bool
+ltWord a b = w2n a < w2n b
+
+showWord : Word64 → List Char
+showWord a = primStringToList (primShowNat (w2n a))

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -2,6 +2,7 @@
 module AllTests where
 
 import Issue14
+import Numbers
 import Pragmas
 import Sections
 import Test
@@ -10,6 +11,7 @@ import Where
 
 {-# FOREIGN AGDA2HS
 import Issue14
+import Numbers
 import Pragmas
 import Sections
 import Test

--- a/test/Fail/BadBuiltinImport.agda
+++ b/test/Fail/BadBuiltinImport.agda
@@ -1,0 +1,9 @@
+module Fail.BadBuiltinImport where
+
+import Agda.Builtin.Word
+
+{-# FOREIGN AGDA2HS
+import RandomModule (Word64)
+import AlsoNotRight (foo, Word64(..))
+import AsConstructor (D(Word64))
+#-}

--- a/test/Fail/BadBuiltinImport.agda
+++ b/test/Fail/BadBuiltinImport.agda
@@ -1,9 +1,9 @@
 module Fail.BadBuiltinImport where
 
-import Agda.Builtin.Word
+import Agda.Builtin.Nat
 
 {-# FOREIGN AGDA2HS
-import RandomModule (Word64)
-import AlsoNotRight (foo, Word64(..))
-import AsConstructor (D(Word64))
+import RandomModule (Natural)
+import AlsoNotRight (foo, Natural(..))
+import AsConstructor (D(Natural))
 #-}

--- a/test/Numbers.agda
+++ b/test/Numbers.agda
@@ -1,0 +1,25 @@
+
+module Numbers where
+
+open import Haskell.Prelude
+
+posNatural : Nat
+posNatural = 14
+
+posInteger : Integer
+posInteger = 52
+
+negInteger : Integer
+negInteger = -1001
+
+natToPos : Nat → Integer
+natToPos n = fromNat n
+
+natToNeg : Nat → Integer
+natToNeg n = fromNeg n
+
+{-# COMPILE AGDA2HS posNatural #-}
+{-# COMPILE AGDA2HS posInteger #-}
+{-# COMPILE AGDA2HS negInteger #-}
+{-# COMPILE AGDA2HS natToPos   #-}
+{-# COMPILE AGDA2HS natToNeg   #-}

--- a/test/Test.agda
+++ b/test/Test.agda
@@ -2,6 +2,7 @@ module _ where
 
 open import Haskell.Prelude
 open import Agda.Builtin.Word
+open import Agda.Builtin.Nat
 open import Agda.Builtin.Equality
 
 -- ** Foreign HS code
@@ -15,10 +16,6 @@ open import Agda.Builtin.Equality
 {-# FOREIGN AGDA2HS
 import Prelude hiding (sum)
 import Data.Monoid
--- import Data.Word
-
--- import Data.Word (Word64)
-import qualified Data.Word as Word64
 #-}
 
 -- ** Datatypes & functions
@@ -61,10 +58,10 @@ ex_float = 0.0
 {-# COMPILE AGDA2HS ex_float #-}
 
 postulate
-  toInteger : Word64 → Integer
-  fromInteger : Integer → Word64
+  toInteger : Word → Integer
+  fromInteger : Integer → Word
 
-ex_word : Word64
+ex_word : Word
 ex_word = fromInteger 0
 {-# COMPILE AGDA2HS ex_word #-}
 

--- a/test/Test.agda
+++ b/test/Test.agda
@@ -61,8 +61,8 @@ ex_float = 0.0
 {-# COMPILE AGDA2HS ex_float #-}
 
 postulate
-  toInteger : Word64 → Nat
-  fromInteger : Nat → Word64
+  toInteger : Word64 → Integer
+  fromInteger : Integer → Word64
 
 ex_word : Word64
 ex_word = fromInteger 0

--- a/test/Test.agda
+++ b/test/Test.agda
@@ -25,13 +25,13 @@ import qualified Data.Word as Word64
 
 data Exp (v : Set) : Set where
   Plus : Exp v → Exp v → Exp v
-  Int : Nat → Exp v
+  Lit : Nat → Exp v
   Var : v → Exp v
 {-# COMPILE AGDA2HS Exp #-}
 
 eval : (a → Nat) → Exp a → Nat
 eval env (Plus a b) = eval env a + eval env b
-eval env (Int n) = n
+eval env (Lit n) = n
 eval env (Var x) = env x
 {-# COMPILE AGDA2HS eval #-}
 

--- a/test/Where.agda
+++ b/test/Where.agda
@@ -10,6 +10,7 @@ postulate
 ex1 : Nat
 ex1 = mult num + bool2nat true
   where
+    num : Nat
     num = 42
 
     mult : Nat → Nat
@@ -19,6 +20,7 @@ ex1 = mult num + bool2nat true
 ex2 : Nat
 ex2 = mult num + bool2nat true
   where
+    num : Nat
     num = 42
 
     mult : Nat → Nat
@@ -61,6 +63,7 @@ ex4' b = mult (bool2nat b)
 ex5 : List Nat → Nat
 ex5 [] = zro
   where
+    zro : Nat
     zro = 0
 ex5 (n ∷ ns) = mult num + 1
   where
@@ -73,6 +76,7 @@ ex5 (n ∷ ns) = mult num + 1
 ex6 : List Nat → Bool → Nat
 ex6 [] b = zro
   where
+    zro : Nat
     zro = 0
 ex6 (n ∷ ns) b = mult (num ∷ 1 ∷ [])
   where
@@ -112,6 +116,7 @@ ex7' n₀ = go₁ n₀
 ex8 : Nat
 ex8 = n₂
   where
+    n₁ : Nat
     n₁ = 1
     n₂ = n₁ + 1
 

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -1,6 +1,7 @@
 module AllTests where
 
 import Issue14
+import Numbers
 import Pragmas
 import Sections
 import Test

--- a/test/golden/BadBuiltinImport.err
+++ b/test/golden/BadBuiltinImport.err
@@ -1,0 +1,6 @@
+test/Fail/BadBuiltinImport.agda:5,22-28
+Bad import of builtin type
+  Word64 from module RandomModule (expected Data.Word)
+  Word64 from module AlsoNotRight (expected Data.Word)
+  Word64 from module AsConstructor (expected Data.Word)
+Note: imports of builtin types are inserted automatically if omitted.

--- a/test/golden/BadBuiltinImport.err
+++ b/test/golden/BadBuiltinImport.err
@@ -1,6 +1,6 @@
-test/Fail/BadBuiltinImport.agda:5,22-28
+test/Fail/BadBuiltinImport.agda:5,22-29
 Bad import of builtin type
-  Word64 from module RandomModule (expected Data.Word)
-  Word64 from module AlsoNotRight (expected Data.Word)
-  Word64 from module AsConstructor (expected Data.Word)
+  Natural from module RandomModule (expected Numeric.Natural)
+  Natural from module AlsoNotRight (expected Numeric.Natural)
+  Natural from module AsConstructor (expected Numeric.Natural)
 Note: imports of builtin types are inserted automatically if omitted.

--- a/test/golden/Issue14.hs
+++ b/test/golden/Issue14.hs
@@ -1,11 +1,13 @@
 module Issue14 where
 
+import Numeric.Natural (Natural)
+
 constid :: a -> b -> b
 constid x = \ x -> x
 
-sectionTest₁ :: Integer -> Integer -> Integer
+sectionTest₁ :: Natural -> Natural -> Natural
 sectionTest₁ n = (+ n)
 
-sectionTest₂ :: Integer -> Integer -> Integer
+sectionTest₂ :: Natural -> Natural -> Natural
 sectionTest₂ section = (+ section)
 

--- a/test/golden/Numbers.hs
+++ b/test/golden/Numbers.hs
@@ -1,0 +1,19 @@
+module Numbers where
+
+import Numeric.Natural (Natural)
+
+posNatural :: Natural
+posNatural = 14
+
+posInteger :: Integer
+posInteger = 52
+
+negInteger :: Integer
+negInteger = -1001
+
+natToPos :: Natural -> Integer
+natToPos n = fromIntegral n
+
+natToNeg :: Natural -> Integer
+natToNeg n = (negate . fromIntegral) n
+

--- a/test/golden/Sections.hs
+++ b/test/golden/Sections.hs
@@ -1,17 +1,19 @@
 module Sections where
 
-test₁ :: Integer -> Integer
+import Numeric.Natural (Natural)
+
+test₁ :: Natural -> Natural
 test₁ = (5 +)
 
-test₂ :: Integer -> Integer
+test₂ :: Natural -> Natural
 test₂ = (+ 5)
 
-test₃ :: Integer -> Integer
+test₃ :: Natural -> Natural
 test₃ = (5 +)
 
-test₄ :: Integer -> Integer
+test₄ :: Natural -> Natural
 test₄ = \ x -> x + 5
 
-test₅ :: Integer -> Integer
+test₅ :: Natural -> Natural
 test₅ = (5 +)
 

--- a/test/golden/Test.hs
+++ b/test/golden/Test.hs
@@ -13,12 +13,12 @@ import Data.Monoid
 import qualified Data.Word as Word64
 
 data Exp v = Plus (Exp v) (Exp v)
-           | Int Natural
+           | Lit Natural
            | Var v
 
 eval :: (a -> Natural) -> Exp a -> Natural
 eval env (Plus a b) = eval env a + eval env b
-eval env (Int n) = n
+eval env (Lit n) = n
 eval env (Var x) = env x
 
 sum :: [Natural] -> Natural

--- a/test/golden/Test.hs
+++ b/test/golden/Test.hs
@@ -3,6 +3,8 @@
 module Test where
 
 import Data.Word (Word64)
+import Numeric.Natural (Natural)
+
 import Prelude hiding (sum)
 import Data.Monoid
 -- import Data.Word
@@ -11,15 +13,15 @@ import Data.Monoid
 import qualified Data.Word as Word64
 
 data Exp v = Plus (Exp v) (Exp v)
-           | Int Integer
+           | Int Natural
            | Var v
 
-eval :: (a -> Integer) -> Exp a -> Integer
+eval :: (a -> Natural) -> Exp a -> Natural
 eval env (Plus a b) = eval env a + eval env b
 eval env (Int n) = n
 eval env (Var x) = env x
 
-sum :: [Integer] -> Integer
+sum :: [Natural] -> Natural
 sum [] = 0
 sum (x : xs) = x + sum xs
 
@@ -53,13 +55,13 @@ listMap :: (a -> b) -> [a] -> [b]
 listMap f [] = []
 listMap f (x : xs) = f x : listMap f xs
 
-mapTest :: [Integer] -> [Integer]
+mapTest :: [Natural] -> [Natural]
 mapTest = map (id . (5 +))
 
-plus3 :: [Integer] -> [Integer]
+plus3 :: [Natural] -> [Natural]
 plus3 = map (\ n -> n + 3)
 
-doubleLambda :: Integer -> Integer -> Integer
+doubleLambda :: Natural -> Natural -> Natural
 doubleLambda = \ a b -> a + 2 * b
 
 class MonoidX a where
@@ -77,24 +79,24 @@ sumMon (x : xs) = x <> sumMon xs
 ex_bool :: Bool
 ex_bool = True
 
-ex_if :: Integer
+ex_if :: Natural
 ex_if = if True then 1 else 0
 
-if_over :: Integer
+if_over :: Natural
 if_over = (if True then \ x -> x else \ x -> x + 1) 0
 
-if_partial₁ :: [Integer] -> [Integer]
+if_partial₁ :: [Natural] -> [Natural]
 if_partial₁ = map (\ f -> if True then 1 else f)
 
-if_partial₂ :: [Integer] -> [Integer -> Integer]
+if_partial₂ :: [Natural] -> [Natural -> Natural]
 if_partial₂ = map (\ t f -> if True then t else f)
 
-if_partial₃ :: [Bool] -> [Integer -> Integer -> Integer]
+if_partial₃ :: [Bool] -> [Natural -> Natural -> Natural]
 if_partial₃ = map (\ b t f -> if b then t else f)
 
-if_partial₄ :: [Bool] -> [Integer -> Integer]
+if_partial₄ :: [Bool] -> [Natural -> Natural]
 if_partial₄ = map (\ section f -> if section then 1 else f)
 
-if_partial₅ :: Bool -> Integer -> [Integer] -> [Integer]
+if_partial₅ :: Bool -> Natural -> [Natural] -> [Natural]
 if_partial₅ b f = map (\ f₁ -> if b then f else f₁)
 

--- a/test/golden/Test.hs
+++ b/test/golden/Test.hs
@@ -2,15 +2,10 @@
 
 module Test where
 
-import Data.Word (Word64)
 import Numeric.Natural (Natural)
 
 import Prelude hiding (sum)
 import Data.Monoid
--- import Data.Word
-
--- import Data.Word (Word64)
-import qualified Data.Word as Word64
 
 data Exp v = Plus (Exp v) (Exp v)
            | Lit Natural
@@ -38,7 +33,7 @@ bla n = n * 4
 ex_float :: Double
 ex_float = 0.0
 
-ex_word :: Word64
+ex_word :: Word
 ex_word = fromInteger 0
 
 ex_char :: Char

--- a/test/golden/Where.hs
+++ b/test/golden/Where.hs
@@ -1,92 +1,94 @@
 module Where where
 
-bool2nat :: Bool -> Integer
-bool2nat = error "postulate: Bool -> Integer"
+import Numeric.Natural (Natural)
 
-ex1 :: Integer
+bool2nat :: Bool -> Natural
+bool2nat = error "postulate: Bool -> Natural"
+
+ex1 :: Natural
 ex1 = mult num + bool2nat True
-  where num :: Integer
+  where num :: Natural
         num = 42
-        mult :: Integer -> Integer
+        mult :: Natural -> Natural
         mult = (* 100)
 
-ex2 :: Integer
+ex2 :: Natural
 ex2 = mult num + bool2nat True
-  where num :: Integer
+  where num :: Natural
         num = 42
-        mult :: Integer -> Integer
+        mult :: Natural -> Natural
         mult = (⊗ 100)
-          where (⊗) :: Integer -> Integer -> Integer
+          where (⊗) :: Natural -> Natural -> Natural
                 (⊗) = (*)
 
-ex3 :: Integer -> Bool -> Integer
+ex3 :: Natural -> Bool -> Natural
 ex3 n b = mult num + bool2nat b
-  where num :: Integer
+  where num :: Natural
         num = 42 + bool2nat b
-        mult :: Integer -> Integer
+        mult :: Natural -> Natural
         mult = (* n)
 
-ex4 :: Bool -> Integer
+ex4 :: Bool -> Natural
 ex4 b = mult 42
-  where mult :: Integer -> Integer
+  where mult :: Natural -> Natural
         mult n = bump n (bool2nat b)
-          where bump :: Integer -> Integer -> Integer
+          where bump :: Natural -> Natural -> Natural
                 bump x y = x * y + n - bool2nat b
 
-ex4' :: Bool -> Integer
+ex4' :: Bool -> Natural
 ex4' b = mult (bool2nat b)
-  where mult :: Integer -> Integer
+  where mult :: Natural -> Natural
         mult n = bump n (bool2nat b)
-          where bump :: Integer -> Integer -> Integer
+          where bump :: Natural -> Natural -> Natural
                 bump x y = go (x * y) (n - bool2nat b)
-                  where go :: Integer -> Integer -> Integer
+                  where go :: Natural -> Natural -> Natural
                         go z w = z + x + w + y + n + bool2nat b
 
-ex5 :: [Integer] -> Integer
+ex5 :: [Natural] -> Natural
 ex5 [] = zro
-  where zro :: Integer
+  where zro :: Natural
         zro = 0
 ex5 (n : ns) = mult num + 1
-  where num :: Integer
+  where num :: Natural
         num = 42 + ex5 ns
-        mult :: Integer -> Integer
+        mult :: Natural -> Natural
         mult = (* n)
 
-ex6 :: [Integer] -> Bool -> Integer
+ex6 :: [Natural] -> Bool -> Natural
 ex6 [] b = zro
-  where zro :: Integer
+  where zro :: Natural
         zro = 0
 ex6 (n : ns) b = mult (num : 1 : [])
-  where mult :: [Integer] -> Integer
+  where mult :: [Natural] -> Natural
         mult [] = bump 5 (bool2nat b)
-          where bump :: Integer -> Integer -> Integer
+          where bump :: Natural -> Natural -> Natural
                 bump x y = x * y + n
         mult (m : ms) = bump n m
-          where bump :: Integer -> Integer -> Integer
+          where bump :: Natural -> Natural -> Natural
                 bump x y = x * y + m - n
-        num :: Integer
+        num :: Natural
         num = 42 + ex6 ns True
 
-ex7 :: Integer -> Integer
+ex7 :: Natural -> Natural
 ex7 n₀ = go₁ n₀
-  where go₁ :: Integer -> Integer
+  where go₁ :: Natural -> Natural
         go₁ n₁ = go₂ (n₀ + n₁)
-          where go₂ :: Integer -> Integer
+          where go₂ :: Natural -> Natural
                 go₂ n₂ = n₀ + n₁ + n₂
 
-ex7' :: Integer -> Integer
+ex7' :: Natural -> Natural
 ex7' n₀ = go₁ n₀
-  where go₁ :: Integer -> Integer
+  where go₁ :: Natural -> Natural
         go₁ n₁ = go₂ (n₀ + n₁)
-          where go₂ :: Integer -> Integer
+          where go₂ :: Natural -> Natural
                 go₂ n₂ = go₃ (n₀ + n₁ + n₂)
-                  where go₃ :: Integer -> Integer
+                  where go₃ :: Natural -> Natural
                         go₃ n₃ = n₀ + n₁ + n₂ + n₃
 
-ex8 :: Integer
+ex8 :: Natural
 ex8 = n₂
-  where n₁ :: Integer
+  where n₁ :: Natural
         n₁ = 1
-        n₂ :: Integer
+        n₂ :: Natural
         n₂ = n₁ + 1
 


### PR DESCRIPTION
Now maps
- `Agda.Builtin.Nat -> Numeric.Natural`
- `Agda.Builtin.Int -> Integer`
- `Agda.Builtin.Word64 -> Word` (instead of `Data.Word.Word64`)
- `Haskell.Prim.Int -> Int`

Also: special handling of `fromNat` and `fromNeg`.

Note: this means we are incompatible with 32-bit platforms (see #30)