### PR TITLE
Instance tweaks

### DIFF
--- a/lib/Haskell/Prelude.agda
+++ b/lib/Haskell/Prelude.agda
@@ -15,7 +15,7 @@ open import Agda.Builtin.FromNeg      public using (fromNeg)
 open import Agda.Builtin.Word         public renaming (Word64 to Word)
 
 open import Haskell.Prim
-open Haskell.Prim public using (if_then_else_; iNumberNat)
+open Haskell.Prim public using (if_then_else_; iNumberNat; IsTrue; itsTrue)
 
 open import Haskell.Prim.Integer
 open Haskell.Prim.Integer public using (Integer; iNumberInteger; iNegativeInteger)

--- a/test/Makefile
+++ b/test/Makefile
@@ -6,7 +6,7 @@ ROOT=$(shell cd ..; pwd)/
 default : clean alltests fail compare
 
 clean :
-	@rm -f build/*
+	@rm -rf build/*
 
 alltests :
 	@echo == Compiling tests ==

--- a/test/Test.agda
+++ b/test/Test.agda
@@ -141,6 +141,19 @@ sumMon []       = mempty
 sumMon (x ∷ xs) = x <> sumMon xs
 {-# COMPILE AGDA2HS sumMon #-}
 
+data NonEmpty {a : Set} : List a → Set where
+  instance
+    itsNonEmpty : ∀ {x xs} → NonEmpty (x ∷ xs)
+
+-- Instance argument proof obligation that should not turn into a class constraint
+hd : (xs : List a) → ⦃ NonEmpty xs ⦄ → a
+hd [] ⦃ () ⦄
+hd (x ∷ _) = x
+{-# COMPILE AGDA2HS hd #-}
+
+five : Int
+five = hd (5 ∷ 3 ∷ [])
+{-# COMPILE AGDA2HS five #-}
 
 -- ** Booleans
 

--- a/test/golden/Test.hs
+++ b/test/golden/Test.hs
@@ -75,6 +75,13 @@ sumMon :: Monoid a => [a] -> a
 sumMon [] = mempty
 sumMon (x : xs) = x <> sumMon xs
 
+hd :: [a] -> a
+hd [] = undefined
+hd (x₁ : xs) = x₁
+
+five :: Int
+five = hd (5 : 3 : [])
+
 ex_bool :: Bool
 ex_bool = True
 


### PR DESCRIPTION
Two things:
- Drop record argument also from functions defined in record modules (not just for projections). Useful for builtin classes which aren't going to be translated to Haskell. Functions that should be translated to Haskell cannot go in the record module at the moment, but possibly something could be done to allow this.
- Drop instance arguments that depend on visible arguments. This lets you have proof objects as instance arguments on the Agda side.