### PR TITLE
support for contexts in type class instances

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -360,15 +360,12 @@ compileInstanceClause ls c = do
   -- 1. drop any patterns before record projection to suppress the instance arg
   -- 2. use record proj. as function name
   -- 3. process remaing patterns as usual
-  let (p : ps) = dropWhile (not . isProjP . namedArg) (namedClausePats c)
+  let (p : ps) = dropWhile (isNothing . isProjP) (namedClausePats c)
       c' = c {namedClausePats = ps}
       ProjP _ q = namedArg p
       uf = hsName (show (nameConcrete (qnameName q)))
   (_ , x) <- compileClause ls uf c'
   return $ Hs.InsDecl () (Hs.FunBind () [x])
-    where isProjP :: DeBruijnPattern -> Bool
-          isProjP (ProjP _ _) = True
-          isProjP _           = False
 
 compileRecord :: Definition -> TCM [Hs.Decl ()]
 compileRecord def = do

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ See `test/Test.agda` for an example.
 - [x] Compile if/then/else [#13](https://github.com/agda/agda2hs/pull/13)
 - [ ] Literals in patterns
 - [x] Use some Haskell syntax ADT and a proper pretty printing library [#4](https://github.com/agda/agda2hs/pull/4)
-- [ ] Map instance arguments to Haskell type classes (definitions and use) [#3](https://github.com/agda/agda2hs/pull/3)
+- [ ] Map instance arguments to Haskell type classes (definitions and use) [#3](https://github.com/agda/agda2hs/pull/3),  [#31](https://github.com/agda/agda2hs/pull/31),  [#37](https://github.com/agda/agda2hs/pull/37)
 - [x] `where` clauses [#23](https://github.com/agda/agda2hs/pull/23)
 - [ ] Higher-rank polymorphism
 - [x] More builtin types (Double, Word64) [#12](https://github.com/agda/agda2hs/pull/12)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ See `test/Test.agda` for an example.
 - [x] Compile if/then/else [#13](https://github.com/agda/agda2hs/pull/13)
 - [ ] Literals in patterns
 - [x] Use some Haskell syntax ADT and a proper pretty printing library [#4](https://github.com/agda/agda2hs/pull/4)
-- [ ] Map instance arguments to Haskell type classes (definitions and use) [#3](https://github.com/agda/agda2hs/pull/3),  [#31](https://github.com/agda/agda2hs/pull/31),  [#37](https://github.com/agda/agda2hs/pull/37)
+- [ ] Map instance arguments to Haskell type classes (definitions and use) [#3](https://github.com/agda/agda2hs/pull/3)
 - [x] `where` clauses [#23](https://github.com/agda/agda2hs/pull/23)
 - [ ] Higher-rank polymorphism
 - [x] More builtin types (Double, Word64) [#12](https://github.com/agda/agda2hs/pull/12)

--- a/test/Test.agda
+++ b/test/Test.agda
@@ -8,6 +8,7 @@ open import Agda.Builtin.Equality
 -- language extensions
 {-# FOREIGN AGDA2HS
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE FlexibleInstances #-}
 #-}
 
 -- imports
@@ -151,7 +152,17 @@ instance
 
 {-# COMPILE AGDA2HS MonoidNat #-}
 
--- instances cannot be compiled yet
+
+instance
+  MonoidFunNat : {a : Set} → MonoidX (a → Nat)
+  memptyX  {{MonoidFunNat}}     _ = memptyX
+  mappendX {{MonoidFunNat}} f g x = mappendX (f x) (g x) 
+
+instance
+  MonoidFun : {a b : Set} → {{MonoidX b}} → MonoidX (a → b)
+  memptyX  {{MonoidFun}}     _ = memptyX
+  mappendX {{MonoidFun}} f g x = mappendX (f x) (g x) 
+{-# COMPILE AGDA2HS MonoidFun #-}
 
 sumMonX : ∀{a} → {{MonoidX a}} → List a → a
 sumMonX []       = memptyX

--- a/test/Test.agda
+++ b/test/Test.agda
@@ -158,6 +158,8 @@ instance
   memptyX  {{MonoidFunNat}}     _ = memptyX
   mappendX {{MonoidFunNat}} f g x = mappendX (f x) (g x) 
 
+{-# COMPILE AGDA2HS MonoidFunNat #-}
+
 instance
   MonoidFun : {a b : Set} → {{MonoidX b}} → MonoidX (a → b)
   memptyX  {{MonoidFun}}     _ = memptyX

--- a/test/golden/Test.hs
+++ b/test/golden/Test.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE FlexibleInstances #-}
 
 module Test where
 
@@ -83,6 +84,14 @@ class MonoidX a where
 instance MonoidX Natural where
         memptyX = 0
         mappendX i j = i + j
+
+instance MonoidX (a -> Natural) where
+        memptyX _ = memptyX
+        mappendX f g x = mappendX (f x) (g x)
+
+instance (MonoidX b) => MonoidX (a -> b) where
+        memptyX _ = memptyX
+        mappendX f g x = mappendX (f x) (g x)
 
 sumMonX :: MonoidX a => [a] -> a
 sumMonX [] = memptyX


### PR DESCRIPTION
Instance contexts and also more flexible instances.

E.g.,
```
instance (MonoidX b) => MonoidX (a -> b) where
        memptyX _ = memptyX
        mappendX f g x = mappendX (f x) (g x)
```