### PR TITLE
added support for deriving in a pragma

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -344,7 +344,7 @@ processPragma qn = getUniqueCompilerPragma pragmaName qn >>= \case
     case Hs.parseDecl ("data X = X " ++ s) of
       Hs.ParseFailed loc msg ->
         setCurrentRange (srcLocToRange loc) $ genericError msg
-      Hs.ParseOk m | Hs.DataDecl _ _ _ _ _ ds <- m ->
+      Hs.ParseOk (Hs.DataDecl _ _ _ _ _ ds) ->
         return $ DerivingPragma ds
       Hs.ParseOk _ -> __IMPOSSIBLE__
   _ -> return DefaultPragma

--- a/test/Test.agda
+++ b/test/Test.agda
@@ -22,7 +22,7 @@ data Exp (v : Set) : Set where
   Plus : Exp v → Exp v → Exp v
   Lit : Nat → Exp v
   Var : v → Exp v
-{-# COMPILE AGDA2HS Exp #-}
+{-# COMPILE AGDA2HS Exp deriving (Show,Eq) #-}
 
 eval : (a → Nat) → Exp a → Nat
 eval env (Plus a b) = eval env a + eval env b

--- a/test/golden/Test.hs
+++ b/test/golden/Test.hs
@@ -10,6 +10,7 @@ import Data.Monoid
 data Exp v = Plus (Exp v) (Exp v)
            | Lit Natural
            | Var v
+               deriving (Show, Eq)
 
 eval :: (a -> Natural) -> Exp a -> Natural
 eval env (Plus a b) = eval env a + eval env b


### PR DESCRIPTION
I followed @UlfNorell's suggestion https://github.com/agda/agda2hs/issues/42#issuecomment-742502084

Eg.,
```
data Exp (v : Set) : Set where
  Plus : Exp v → Exp v → Exp v
  Lit : Nat → Exp v
  Var : v → Exp v
{-# COMPILE AGDA2HS Exp deriving (Show,Eq) #-}
```
->
```
data Exp v = Plus (Exp v) (Exp v)
           | Lit Natural
           | Var v
               deriving (Show, Eq)
```

Fixes https://github.com/agda/agda2hs/issues/42