### PR TITLE
Agda-2.6.1.2 doesn't work with ghc-8.10.3

### DIFF
--- a/agda2hs.cabal
+++ b/agda2hs.cabal
@@ -32,3 +32,7 @@ executable agda2hs
   default-extensions:  LambdaCase,
                        RecordWildCards
 
+  -- Agda-2.6.1.2 does not work with ghc-8.10.3 (see https://github.com/agda/agda/issues/5136)
+  if impl(ghc == 8.10.3)
+    build-depends: Agda == 2.6.1.1
+


### PR DESCRIPTION
See agda/agda#5136.