### PR TITLE
Add Enum and Bounded to Prelude

### DIFF
--- a/lib/Haskell/Prelude.agda
+++ b/lib/Haskell/Prelude.agda
@@ -23,8 +23,10 @@ open Haskell.Prim public using ( TypeError; ⊥; iNumberNat; IsTrue; IsFalse;
 open import Haskell.Prim.Absurd      public
 open import Haskell.Prim.Applicative public
 open import Haskell.Prim.Bool        public
+open import Haskell.Prim.Bounded     public
 open import Haskell.Prim.Double      public
 open import Haskell.Prim.Either      public
+open import Haskell.Prim.Enum        public
 open import Haskell.Prim.Eq          public
 open import Haskell.Prim.Foldable    public
 open import Haskell.Prim.Functor     public
@@ -48,10 +50,6 @@ open import Haskell.Prim.Word        public
 --  - [Infinite]: Define colists and map to Haskell lists?
 
 -- Missing from the Haskell Prelude:
---
---     Enum(succ, pred, toEnum, fromEnum, enumFrom, enumFromThen,
---          enumFromTo, enumFromThenTo),      [Partial]
---     Bounded(minBound, maxBound),
 --
 --     Float        [Float]
 --     Rational

--- a/lib/Haskell/Prim.agda
+++ b/lib/Haskell/Prim.agda
@@ -101,3 +101,6 @@ data NonEmpty {a : Set} : List a → Set where
   instance itsNonEmpty : ∀ {x xs} → NonEmpty (x ∷ xs)
 
 data TypeError (err : String) : Set where
+
+it : ∀ {ℓ} {a : Set ℓ} → ⦃ a ⦄ → a
+it ⦃ x ⦄ = x

--- a/lib/Haskell/Prim/Bounded.agda
+++ b/lib/Haskell/Prim/Bounded.agda
@@ -1,0 +1,63 @@
+
+module Haskell.Prim.Bounded where
+
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Char
+open import Agda.Builtin.Equality
+open import Agda.Builtin.List
+
+open import Haskell.Prim
+open import Haskell.Prim.Eq
+open import Haskell.Prim.Int
+open import Haskell.Prim.Maybe
+open import Haskell.Prim.Ord
+open import Haskell.Prim.Tuple
+open import Haskell.Prim.Word
+
+--------------------------------------------------
+-- Bounded
+
+record Bounded (a : Set) : Set where
+  field
+    minBound : a
+    maxBound : a
+
+open Bounded ⦃ ... ⦄ public
+
+instance
+  iBoundedWord : Bounded Word
+  iBoundedWord .minBound = 0
+  iBoundedWord .maxBound = 18446744073709551615
+
+  iBoundedInt : Bounded Int
+  iBoundedInt .minBound = -9223372036854775808
+  iBoundedInt .maxBound = 9223372036854775807
+
+  iBoundedBool : Bounded Bool
+  iBoundedBool .minBound = false
+  iBoundedBool .maxBound = true
+
+  iBoundedChar : Bounded Char
+  iBoundedChar .minBound = '\0'
+  iBoundedChar .maxBound = '\1114111'
+
+  iBoundedTuple₀ : Bounded (Tuple [])
+  iBoundedTuple₀ .minBound = []
+  iBoundedTuple₀ .maxBound = []
+
+  iBoundedTuple : ∀ {as} → ⦃ Bounded a ⦄ → ⦃ Bounded (Tuple as) ⦄ → Bounded (Tuple (a ∷ as))
+  iBoundedTuple .minBound = minBound ∷ minBound
+  iBoundedTuple .maxBound = maxBound ∷ maxBound
+
+  iBoundedOrdering : Bounded Ordering
+  iBoundedOrdering .minBound = LT
+  iBoundedOrdering .maxBound = GT
+
+-- Sanity checks
+
+private
+  _ : addWord maxBound 1 ≡ minBound
+  _ = refl
+
+  _ : addInt maxBound 1 ≡ minBound
+  _ = refl

--- a/lib/Haskell/Prim/Bounded.agda
+++ b/lib/Haskell/Prim/Bounded.agda
@@ -1,6 +1,7 @@
 
 module Haskell.Prim.Bounded where
 
+open import Agda.Builtin.Nat
 open import Agda.Builtin.Bool
 open import Agda.Builtin.Char
 open import Agda.Builtin.Equality
@@ -17,41 +18,85 @@ open import Haskell.Prim.Word
 --------------------------------------------------
 -- Bounded
 
-record Bounded (a : Set) : Set where
+record BoundedBelow (a : Set) : Set where
   field
     minBound : a
+
+record BoundedAbove (a : Set) : Set where
+  field
     maxBound : a
 
-open Bounded ⦃ ... ⦄ public
+record Bounded (a : Set) : Set where
+  field
+    overlap ⦃ below ⦄ : BoundedBelow a
+    overlap ⦃ above ⦄ : BoundedAbove a
+
+open BoundedBelow ⦃ ... ⦄ public
+open BoundedAbove ⦃ ... ⦄ public
+
+mkBounded : ⦃ BoundedBelow a ⦄ → ⦃ BoundedAbove a ⦄ → Bounded a
+mkBounded .Bounded.below = it
+mkBounded .Bounded.above = it
 
 instance
+  iBoundedBelowNatural : BoundedBelow Nat
+  iBoundedBelowNatural .minBound = 0
+
+  iBoundedBelowWord : BoundedBelow Word
+  iBoundedBelowWord .minBound = 0
+  iBoundedAboveWord : BoundedAbove Word
+  iBoundedAboveWord .maxBound = 18446744073709551615
+
   iBoundedWord : Bounded Word
-  iBoundedWord .minBound = 0
-  iBoundedWord .maxBound = 18446744073709551615
+  iBoundedWord = mkBounded
+
+  iBoundedBelowInt : BoundedBelow Int
+  iBoundedBelowInt .minBound = -9223372036854775808
+  iBoundedAboveInt : BoundedAbove Int
+  iBoundedAboveInt .maxBound = 9223372036854775807
 
   iBoundedInt : Bounded Int
-  iBoundedInt .minBound = -9223372036854775808
-  iBoundedInt .maxBound = 9223372036854775807
+  iBoundedInt = mkBounded
+
+  iBoundedBelowBool : BoundedBelow Bool
+  iBoundedBelowBool .minBound = false
+  iBoundedAboveBool : BoundedAbove Bool
+  iBoundedAboveBool .maxBound = true
 
   iBoundedBool : Bounded Bool
-  iBoundedBool .minBound = false
-  iBoundedBool .maxBound = true
+  iBoundedBool = mkBounded
+
+  iBoundedBelowChar : BoundedBelow Char
+  iBoundedBelowChar .minBound = '\0'
+  iBoundedAboveChar : BoundedAbove Char
+  iBoundedAboveChar .maxBound = '\1114111'
 
   iBoundedChar : Bounded Char
-  iBoundedChar .minBound = '\0'
-  iBoundedChar .maxBound = '\1114111'
+  iBoundedChar = mkBounded
+
+  iBoundedBelowTuple₀ : BoundedBelow (Tuple [])
+  iBoundedBelowTuple₀ .minBound = []
+  iBoundedAboveTuple₀ : BoundedAbove (Tuple [])
+  iBoundedAboveTuple₀ .maxBound = []
 
   iBoundedTuple₀ : Bounded (Tuple [])
-  iBoundedTuple₀ .minBound = []
-  iBoundedTuple₀ .maxBound = []
+  iBoundedTuple₀ = mkBounded
+
+  iBoundedBelowTuple : ∀ {as} → ⦃ BoundedBelow a ⦄ → ⦃ BoundedBelow (Tuple as) ⦄ → BoundedBelow (Tuple (a ∷ as))
+  iBoundedBelowTuple .minBound = minBound ∷ minBound
+  iBoundedAboveTuple : ∀ {as} → ⦃ BoundedAbove a ⦄ → ⦃ BoundedAbove (Tuple as) ⦄ → BoundedAbove (Tuple (a ∷ as))
+  iBoundedAboveTuple .maxBound = maxBound ∷ maxBound
 
   iBoundedTuple : ∀ {as} → ⦃ Bounded a ⦄ → ⦃ Bounded (Tuple as) ⦄ → Bounded (Tuple (a ∷ as))
-  iBoundedTuple .minBound = minBound ∷ minBound
-  iBoundedTuple .maxBound = maxBound ∷ maxBound
+  iBoundedTuple = mkBounded
+
+  iBoundedBelowOrdering : BoundedBelow Ordering
+  iBoundedBelowOrdering .minBound = LT
+  iBoundedAboveOrdering : BoundedAbove Ordering
+  iBoundedAboveOrdering .maxBound = GT
 
   iBoundedOrdering : Bounded Ordering
-  iBoundedOrdering .minBound = LT
-  iBoundedOrdering .maxBound = GT
+  iBoundedOrdering = mkBounded
 
 -- Sanity checks
 

--- a/lib/Haskell/Prim/Bounded.agda
+++ b/lib/Haskell/Prim/Bounded.agda
@@ -34,9 +34,10 @@ record Bounded (a : Set) : Set where
 open BoundedBelow ⦃ ... ⦄ public
 open BoundedAbove ⦃ ... ⦄ public
 
-mkBounded : ⦃ BoundedBelow a ⦄ → ⦃ BoundedAbove a ⦄ → Bounded a
-mkBounded .Bounded.below = it
-mkBounded .Bounded.above = it
+instance
+  iBounded : ⦃ BoundedBelow a ⦄ → ⦃ BoundedAbove a ⦄ → Bounded a
+  iBounded .Bounded.below = it
+  iBounded .Bounded.above = it
 
 instance
   iBoundedBelowNatural : BoundedBelow Nat
@@ -47,56 +48,35 @@ instance
   iBoundedAboveWord : BoundedAbove Word
   iBoundedAboveWord .maxBound = 18446744073709551615
 
-  iBoundedWord : Bounded Word
-  iBoundedWord = mkBounded
-
   iBoundedBelowInt : BoundedBelow Int
   iBoundedBelowInt .minBound = -9223372036854775808
   iBoundedAboveInt : BoundedAbove Int
   iBoundedAboveInt .maxBound = 9223372036854775807
-
-  iBoundedInt : Bounded Int
-  iBoundedInt = mkBounded
 
   iBoundedBelowBool : BoundedBelow Bool
   iBoundedBelowBool .minBound = false
   iBoundedAboveBool : BoundedAbove Bool
   iBoundedAboveBool .maxBound = true
 
-  iBoundedBool : Bounded Bool
-  iBoundedBool = mkBounded
-
   iBoundedBelowChar : BoundedBelow Char
   iBoundedBelowChar .minBound = '\0'
   iBoundedAboveChar : BoundedAbove Char
   iBoundedAboveChar .maxBound = '\1114111'
-
-  iBoundedChar : Bounded Char
-  iBoundedChar = mkBounded
 
   iBoundedBelowTuple₀ : BoundedBelow (Tuple [])
   iBoundedBelowTuple₀ .minBound = []
   iBoundedAboveTuple₀ : BoundedAbove (Tuple [])
   iBoundedAboveTuple₀ .maxBound = []
 
-  iBoundedTuple₀ : Bounded (Tuple [])
-  iBoundedTuple₀ = mkBounded
-
   iBoundedBelowTuple : ∀ {as} → ⦃ BoundedBelow a ⦄ → ⦃ BoundedBelow (Tuple as) ⦄ → BoundedBelow (Tuple (a ∷ as))
   iBoundedBelowTuple .minBound = minBound ∷ minBound
   iBoundedAboveTuple : ∀ {as} → ⦃ BoundedAbove a ⦄ → ⦃ BoundedAbove (Tuple as) ⦄ → BoundedAbove (Tuple (a ∷ as))
   iBoundedAboveTuple .maxBound = maxBound ∷ maxBound
 
-  iBoundedTuple : ∀ {as} → ⦃ Bounded a ⦄ → ⦃ Bounded (Tuple as) ⦄ → Bounded (Tuple (a ∷ as))
-  iBoundedTuple = mkBounded
-
   iBoundedBelowOrdering : BoundedBelow Ordering
   iBoundedBelowOrdering .minBound = LT
   iBoundedAboveOrdering : BoundedAbove Ordering
   iBoundedAboveOrdering .maxBound = GT
-
-  iBoundedOrdering : Bounded Ordering
-  iBoundedOrdering = mkBounded
 
 -- Sanity checks
 

--- a/lib/Haskell/Prim/Either.agda
+++ b/lib/Haskell/Prim/Either.agda
@@ -2,6 +2,7 @@
 module Haskell.Prim.Either where
 
 open import Haskell.Prim
+open import Haskell.Prim.Bool
 
 --------------------------------------------------
 -- Either
@@ -13,3 +14,7 @@ data Either (a b : Set) : Set where
 either : (a → c) → (b → c) → Either a b → c
 either f g (Left  x) = f x
 either f g (Right y) = g y
+
+testBool : (b : Bool) → Either (IsFalse b) (IsTrue b)
+testBool false = Left  itsFalse
+testBool true  = Right itsTrue

--- a/lib/Haskell/Prim/Enum.agda
+++ b/lib/Haskell/Prim/Enum.agda
@@ -182,7 +182,7 @@ module _ (from : a → Integer) (to : Integer → a) where
 
 instance
   iEnumNatural : Enum Nat
-  iEnumNatural = boundedBelowEnumViaInteger pos λ where (pos n) → n; _ → 0
+  iEnumNatural = boundedBelowEnumViaInteger pos unsafeIntegerToNat
 
   iEnumInt : Enum Int
   iEnumInt = boundedEnumViaInteger intToInteger integerToInt

--- a/lib/Haskell/Prim/Enum.agda
+++ b/lib/Haskell/Prim/Enum.agda
@@ -1,0 +1,168 @@
+
+module Haskell.Prim.Enum where
+
+open import Agda.Builtin.Nat as Nat hiding (_==_; _<_; _+_; _*_; _-_)
+open import Agda.Builtin.Char
+open import Agda.Builtin.Equality
+open import Agda.Builtin.List
+open import Agda.Builtin.Unit
+open import Agda.Builtin.Int using (pos; negsuc)
+
+open import Haskell.Prim
+open import Haskell.Prim.Bool
+open import Haskell.Prim.Bounded
+open import Haskell.Prim.Either
+open import Haskell.Prim.Eq
+open import Haskell.Prim.Functor
+open import Haskell.Prim.Int
+open import Haskell.Prim.Integer
+open import Haskell.Prim.List
+open import Haskell.Prim.Maybe
+open import Haskell.Prim.Num
+open import Haskell.Prim.Ord
+open import Haskell.Prim.Tuple
+open import Haskell.Prim.Word
+
+
+--------------------------------------------------
+-- Enum
+--    Assumptions: unbounded enums have no constraints on their
+--    operations and bounded enums should work on all values between
+--    minBound and maxBound. Unbounded enums do not support enumFrom
+--    and enumFromThen (since they return infinite lists).
+
+IfBounded : Maybe (Bounded a) → (⦃ Bounded a ⦄ → Set) → Set
+IfBounded Nothing  k = ⊤
+IfBounded (Just i) k = k ⦃ i ⦄
+
+record Enum (a : Set) : Set₁ where
+  field
+    BoundedEnum : Maybe (Bounded a)
+    fromEnum    : a → Int
+
+  private
+    IsBounded : Set
+    IsBounded = maybe ⊥ (λ _ → ⊤) BoundedEnum
+
+    True : (⦃ Bounded a ⦄ → Bool) → Set
+    True C = IfBounded BoundedEnum (IsTrue C)
+
+    False : (⦃ Bounded a ⦄ → Bool) → Set
+    False C = IfBounded BoundedEnum (IsFalse C)
+
+    minInt : ⦃ Bounded a ⦄ → Int
+    minInt ⦃ _ ⦄ = fromEnum minBound
+
+    maxInt : ⦃ Bounded a ⦄ → Int
+    maxInt ⦃ _ ⦄ = fromEnum maxBound
+
+  field
+    toEnum : (n : Int) → ⦃ True (minInt <= n && n <= maxInt) ⦄ → a
+    succ   : (x : a) → ⦃ False (fromEnum x == maxInt) ⦄ → a
+    pred   : (x : a) → ⦃ False (fromEnum x == minInt) ⦄ → a
+
+    enumFrom       : ⦃ IsBounded ⦄ → a → List a
+    enumFromTo     : a → a → List a
+    -- In the Prelude Enum instances `enumFromThenTo x x y` gives the
+    -- infinite list of `x`s. The constraint is a little bit stronger than it needs to be,
+    -- since it rules out different x and x₁ that maps to the same Int, but this saves us
+    -- requiring an Eq instance for `a`, and it's not a terrible limitation to not be able to
+    -- write [0, 2^64 .. 2^66].
+    enumFromThenTo : (x x₁ : a) → ⦃ IsFalse (fromEnum x == fromEnum x₁) ⦄ → a → List a
+    enumFromThen   : ⦃ IsBounded ⦄ → (x x₁ : a) → ⦃ IsFalse (fromEnum x == fromEnum x₁) ⦄ → List a
+
+open Enum ⦃ ... ⦄ public
+
+private
+  divNat : Nat → Nat → Nat
+  divNat a 0       = 0
+  divNat a (suc b) = div-helper 0 b a b
+
+  diff : Integer → Integer → Maybe Nat
+  diff a b =
+    case a - b of λ where
+      (pos n)    → Just n
+      (negsuc _) → Nothing
+
+  unsafeIntegerToNat : Integer → Nat
+  unsafeIntegerToNat (pos n) = n
+  unsafeIntegerToNat (negsuc _) = 0
+
+  integerFromCount : Integer → Integer → Nat → List Integer
+  integerFromCount a step 0       = []
+  integerFromCount a step (suc n) = a ∷ integerFromCount (a + step) step n
+
+  integerFromTo : Integer → Integer → List Integer
+  integerFromTo a b = maybe [] (integerFromCount a 1 ∘ suc) (diff b a)
+
+  integerFromThenTo : (a a₁ : Integer) → ⦃ IsFalse (integerToInt a == integerToInt a₁) ⦄ → Integer → List Integer
+  integerFromThenTo a a₁ b =
+    case compare a a₁ of λ where
+      LT → maybe [] (λ d → integerFromCount a (a₁ - a) (suc (divNat d (unsafeIntegerToNat (a₁ - a))))) (diff b a)
+      EQ → [] -- impossible
+      GT → maybe [] (λ d → integerFromCount a (a₁ - a) (suc (divNat d (unsafeIntegerToNat (a - a₁))))) (diff a b)
+
+instance
+  iEnumInteger : Enum Integer
+  iEnumInteger .Enum.BoundedEnum       = Nothing
+  iEnumInteger .Enum.fromEnum          = integerToInt
+  iEnumInteger .Enum.toEnum          n = intToInteger n
+  iEnumInteger .Enum.succ              = _+ 1
+  iEnumInteger .Enum.pred              = _- 1
+  iEnumInteger .Enum.enumFromTo        = integerFromTo
+  iEnumInteger .Enum.enumFromThenTo    = integerFromThenTo
+
+module _ (from : a → Integer) (to : Integer → a) where
+  private
+    fromTo : a → a → List a
+    fromTo a b = map to (enumFromTo (from a) (from b))
+
+    fromThenTo : (x x₁ : a) → ⦃ IsFalse (fromEnum (from x) == fromEnum (from x₁)) ⦄ → a → List a
+    fromThenTo a a₁ b = map to (enumFromThenTo (from a) (from a₁) (from b))
+
+  unboundedEnumViaInteger : Enum a
+  unboundedEnumViaInteger .BoundedEnum           = Nothing
+  unboundedEnumViaInteger .fromEnum              = integerToInt ∘ from
+  unboundedEnumViaInteger .toEnum         n      = to (intToInteger n)
+  unboundedEnumViaInteger .succ           x      = to (from x + 1)
+  unboundedEnumViaInteger .pred           x      = to (from x - 1)
+  unboundedEnumViaInteger .enumFromTo     a b    = fromTo a b
+  unboundedEnumViaInteger .enumFromThenTo a a₁ b = fromThenTo a a₁ b
+
+  boundedEnumViaInteger : ⦃ Ord a ⦄ → ⦃ Bounded a ⦄ → Enum a
+  boundedEnumViaInteger .BoundedEnum           = Just it
+  boundedEnumViaInteger .fromEnum              = integerToInt ∘ from
+  boundedEnumViaInteger .toEnum         n      = to (intToInteger n)
+  boundedEnumViaInteger .succ           x      = to (from x + 1)
+  boundedEnumViaInteger .pred           x      = to (from x - 1)
+  boundedEnumViaInteger .enumFromTo     a b    = fromTo a b
+  boundedEnumViaInteger .enumFromThenTo a a₁ b = fromThenTo a a₁ b
+  boundedEnumViaInteger .enumFrom       a      = fromTo a maxBound
+  boundedEnumViaInteger .enumFromThen   a a₁   =
+    if a < a₁ then fromThenTo a a₁ maxBound
+              else fromThenTo a a₁ minBound
+
+instance
+  iEnumInt : Enum Int
+  iEnumInt = boundedEnumViaInteger intToInteger integerToInt
+
+  iEnumWord : Enum Word
+  iEnumWord = boundedEnumViaInteger wordToInteger integerToWord
+
+  iEnumBool : Enum Bool
+  iEnumBool = boundedEnumViaInteger (if_then 1 else 0) (_/= 0)
+
+  iEnumOrdering : Enum Ordering
+  iEnumOrdering = boundedEnumViaInteger (λ where LT → 0; EQ → 1; GT → 2)
+                                        (λ where (pos 0) → LT; (pos 1) → EQ; _ → GT)
+
+  iEnumUnit : Enum (Tuple [])
+  iEnumUnit = boundedEnumViaInteger (λ _ → 0) (λ _ → [])
+
+  iEnumChar : Enum Char
+  iEnumChar = boundedEnumViaInteger (pos ∘ primCharToNat)
+                                    λ where (pos n) → primNatToChar n; _ → '_'
+
+  -- Missing:
+  --  Enum Double  (can't go via Integer)
+  --  Enum Natural (bounded only below)

--- a/lib/Haskell/Prim/Int.agda
+++ b/lib/Haskell/Prim/Int.agda
@@ -26,12 +26,11 @@ open import Haskell.Prim.Bool
 data Int : Set where
   int64 : Word64 → Int
 
-private
-  intToWord : Int → Word64
-  intToWord (int64 a) = a
+intToWord : Int → Word64
+intToWord (int64 a) = a
 
-  unsafeIntToNat : Int → Nat
-  unsafeIntToNat a = w2n (intToWord a)
+unsafeIntToNat : Int → Nat
+unsafeIntToNat a = w2n (intToWord a)
 
 
 --------------------------------------------------

--- a/lib/Haskell/Prim/Integer.agda
+++ b/lib/Haskell/Prim/Integer.agda
@@ -92,6 +92,7 @@ ltInteger (negsuc n) (negsuc m) = m < n
 showInteger : Integer → List Char
 showInteger n = primStringToList (primShowInteger n)
 
+
 --------------------------------------------------
 -- Constraints
 

--- a/lib/Haskell/Prim/Maybe.agda
+++ b/lib/Haskell/Prim/Maybe.agda
@@ -1,9 +1,6 @@
 
 module Haskell.Prim.Maybe where
 
-private
-  variable a b : Set
-
 --------------------------------------------------
 -- Maybe
 

--- a/lib/Haskell/Prim/Maybe.agda
+++ b/lib/Haskell/Prim/Maybe.agda
@@ -11,6 +11,6 @@ data Maybe {ℓ} (a : Set ℓ) : Set ℓ where
   Nothing : Maybe a
   Just    : a -> Maybe a
 
-maybe : b → (a → b) → Maybe a → b
+maybe : ∀ {ℓ₁ ℓ₂} {a : Set ℓ₁} {b : Set ℓ₂} → b → (a → b) → Maybe a → b
 maybe n j Nothing  = n
 maybe n j (Just x) = j x

--- a/lib/Haskell/Prim/Ord.agda
+++ b/lib/Haskell/Prim/Ord.agda
@@ -2,6 +2,7 @@
 module Haskell.Prim.Ord where
 
 open import Agda.Builtin.Nat as Nat hiding (_==_; _<_)
+open import Agda.Builtin.Char
 
 open import Haskell.Prim
 open import Haskell.Prim.Eq
@@ -101,6 +102,9 @@ instance
 
   iOrdDouble : Ord Double
   iOrdDouble = ordFromLessThan primFloatNumericalLess
+
+  iOrdChar : Ord Char
+  iOrdChar = ordFromLessThan λ x y → primCharToNat x < primCharToNat y
 
   iOrdBool : Ord Bool
   iOrdBool = ordFromCompare λ where

--- a/lib/Haskell/Prim/Word.agda
+++ b/lib/Haskell/Prim/Word.agda
@@ -57,3 +57,6 @@ showWord a = primStringToList (primShowNat (w2n a))
 integerToWord : Integer → Word
 integerToWord (pos n)    = n2w n
 integerToWord (negsuc n) = negateWord (n2w (suc n))
+
+wordToInteger : Word → Integer
+wordToInteger n = pos (w2n n)

--- a/test/LanguageConstructs.agda
+++ b/test/LanguageConstructs.agda
@@ -58,3 +58,28 @@ applyToFalse = case false of_
 caseOf : a → (a → b) → b
 caseOf = case_of_
 {-# COMPILE AGDA2HS caseOf #-}
+
+
+--------------------------------------------------
+-- Enums
+
+
+enum₁ : List Int
+enum₁ = enumFromTo 5 10
+{-# COMPILE AGDA2HS enum₁ #-}
+
+enum₂ : List Integer
+enum₂ = enumFromThenTo 10 20 100
+{-# COMPILE AGDA2HS enum₂ #-}
+
+enum₃ : List Bool
+enum₃ = enumFrom false
+{-# COMPILE AGDA2HS enum₃ #-}
+
+enum₄ : List Ordering
+enum₄ = enumFromThen LT EQ
+{-# COMPILE AGDA2HS enum₄ #-}
+
+underappliedEnum : List Int → List (List Int)
+underappliedEnum = map (enumFromTo 1)
+{-# COMPILE AGDA2HS underappliedEnum #-}

--- a/test/Test.agda
+++ b/test/Test.agda
@@ -74,9 +74,6 @@ ex_char : Char
 ex_char = 'a'
 {-# COMPILE AGDA2HS ex_char #-}
 
-postulate
-  toEnum : Int → Char
-
 char_d : Char
 char_d = toEnum 100
 {-# COMPILE AGDA2HS char_d #-}
@@ -156,14 +153,14 @@ instance
 instance
   MonoidFunNat : {a : Set} → MonoidX (a → Nat)
   memptyX  {{MonoidFunNat}}     _ = memptyX
-  mappendX {{MonoidFunNat}} f g x = mappendX (f x) (g x) 
+  mappendX {{MonoidFunNat}} f g x = mappendX (f x) (g x)
 
 {-# COMPILE AGDA2HS MonoidFunNat #-}
 
 instance
   MonoidFun : {a b : Set} → {{MonoidX b}} → MonoidX (a → b)
   memptyX  {{MonoidFun}}     _ = memptyX
-  mappendX {{MonoidFun}} f g x = mappendX (f x) (g x) 
+  mappendX {{MonoidFun}} f g x = mappendX (f x) (g x)
 {-# COMPILE AGDA2HS MonoidFun #-}
 
 sumMonX : ∀{a} → {{MonoidX a}} → List a → a

--- a/test/golden/LanguageConstructs.hs
+++ b/test/golden/LanguageConstructs.hs
@@ -38,3 +38,18 @@ applyToFalse = ($ False)
 caseOf :: a -> (a -> b) -> b
 caseOf = flip ($)
 
+enum₁ :: [Int]
+enum₁ = [5 .. 10]
+
+enum₂ :: [Integer]
+enum₂ = [10, 20 .. 100]
+
+enum₃ :: [Bool]
+enum₃ = [False ..]
+
+enum₄ :: [Ordering]
+enum₄ = [LT, EQ ..]
+
+underappliedEnum :: [Int] -> [[Int]]
+underappliedEnum = map (enumFromTo 1)
+


### PR DESCRIPTION
... and compile to enumFromTo sugar.

Not quite perfect: with the current representation an `Enum` is either `Bounded` or unbounded, which works for most types, but notably not for `Natural` which is only bounded below.

Possible solution would be to split `Bounded` into `BoundedAbove` and `BoundedBelow` and base the `Enum` constraints on these.