### PR TITLE
Issue 51

### DIFF
--- a/HsUtils.hs
+++ b/HsUtils.hs
@@ -40,7 +40,10 @@ isOp _                   = False
 -- Utilities for building Haskell constructs
 
 pp :: Pretty a => a -> String
-pp = prettyPrintWithMode defaultMode{ spacing = False }
+pp = prettyPrintWithMode defaultMode{ spacing = False
+                                    , classIndent = 4
+                                    , whereIndent = 2
+                                    }
 
 -- exactPrint really looks at the line numbers (and we're using the locations from the agda source
 -- to report Haskell parse errors at the right location), so shift everything to start at line 1.

--- a/test/Test.agda
+++ b/test/Test.agda
@@ -132,7 +132,7 @@ thm : (xs ys : List Nat) → sum (xs ++ ys) ≡ sum xs + sum ys
 thm []       ys = refl
 thm (x ∷ xs) ys rewrite thm xs ys | assoc x (sum xs) (sum ys) = refl
 
--- (custom) Monoid instance
+-- (custom) Monoid class
 
 record MonoidX (a : Set) : Set where
   field memptyX  : a
@@ -172,6 +172,31 @@ sumMon : ∀{a} → {{Monoid a}} → List a → a
 sumMon []       = mempty
 sumMon (x ∷ xs) = x <> sumMon xs
 {-# COMPILE AGDA2HS sumMon #-}
+
+-- Using the Monoid class from the Prelude
+
+data NatSum : Set where
+  MkSum : Nat → NatSum
+
+{-# COMPILE AGDA2HS NatSum #-}
+
+instance
+  SemigroupNatSum : Semigroup NatSum
+  SemigroupNatSum ._<>_ (MkSum a) (MkSum b) = MkSum (a + b)
+
+  MonoidNatSum : Monoid NatSum
+  MonoidNatSum .mempty = MkSum 0
+
+double : ⦃ Monoid a ⦄ → a → a
+double x = x <> x
+
+doubleSum : NatSum → NatSum
+doubleSum = double
+
+{-# COMPILE AGDA2HS SemigroupNatSum #-}
+{-# COMPILE AGDA2HS MonoidNatSum    #-}
+{-# COMPILE AGDA2HS double          #-}
+{-# COMPILE AGDA2HS doubleSum       #-}
 
 -- Instance argument proof obligation that should not turn into a class constraint
 hd : (xs : List a) → ⦃ NonEmpty xs ⦄ → a

--- a/test/golden/Test.hs
+++ b/test/golden/Test.hs
@@ -79,20 +79,20 @@ initLast :: [a] -> ([a], a)
 initLast xs = (init xs, last xs)
 
 class MonoidX a where
-        memptyX :: a
-        mappendX :: a -> a -> a
+    memptyX :: a
+    mappendX :: a -> a -> a
 
 instance MonoidX Natural where
-        memptyX = 0
-        mappendX i j = i + j
+    memptyX = 0
+    mappendX i j = i + j
 
 instance MonoidX (a -> Natural) where
-        memptyX _ = memptyX
-        mappendX f g x = mappendX (f x) (g x)
+    memptyX _ = memptyX
+    mappendX f g x = mappendX (f x) (g x)
 
 instance (MonoidX b) => MonoidX (a -> b) where
-        memptyX _ = memptyX
-        mappendX f g x = mappendX (f x) (g x)
+    memptyX _ = memptyX
+    mappendX f g x = mappendX (f x) (g x)
 
 sumMonX :: MonoidX a => [a] -> a
 sumMonX [] = memptyX

--- a/test/golden/Test.hs
+++ b/test/golden/Test.hs
@@ -102,6 +102,20 @@ sumMon :: Monoid a => [a] -> a
 sumMon [] = mempty
 sumMon (x : xs) = x <> sumMon xs
 
+data NatSum = MkSum Natural
+
+instance Semigroup NatSum where
+    MkSum a <> MkSum b = MkSum (a + b)
+
+instance Monoid NatSum where
+    mempty = MkSum 0
+
+double :: Monoid a => a -> a
+double x = x <> x
+
+doubleSum :: NatSum -> NatSum
+doubleSum = double
+
 hd :: [a] -> a
 hd [] = error "hd: empty list"
 hd (x : _) = x

--- a/test/golden/Where.hs
+++ b/test/golden/Where.hs
@@ -7,88 +7,109 @@ bool2nat = error "postulate: Bool -> Natural"
 
 ex1 :: Natural
 ex1 = mult num + bool2nat True
-  where num :: Natural
-        num = 42
-        mult :: Natural -> Natural
-        mult = (* 100)
+  where
+    num :: Natural
+    num = 42
+    mult :: Natural -> Natural
+    mult = (* 100)
 
 ex2 :: Natural
 ex2 = mult num + bool2nat True
-  where num :: Natural
-        num = 42
-        mult :: Natural -> Natural
-        mult = (⊗ 100)
-          where (⊗) :: Natural -> Natural -> Natural
-                (⊗) = (*)
+  where
+    num :: Natural
+    num = 42
+    mult :: Natural -> Natural
+    mult = (⊗ 100)
+      where
+        (⊗) :: Natural -> Natural -> Natural
+        (⊗) = (*)
 
 ex3 :: Natural -> Bool -> Natural
 ex3 n b = mult num + bool2nat b
-  where num :: Natural
-        num = 42 + bool2nat b
-        mult :: Natural -> Natural
-        mult = (* n)
+  where
+    num :: Natural
+    num = 42 + bool2nat b
+    mult :: Natural -> Natural
+    mult = (* n)
 
 ex4 :: Bool -> Natural
 ex4 b = mult 42
-  where mult :: Natural -> Natural
-        mult n = bump n (bool2nat b)
-          where bump :: Natural -> Natural -> Natural
-                bump x y = x * y + n - bool2nat b
+  where
+    mult :: Natural -> Natural
+    mult n = bump n (bool2nat b)
+      where
+        bump :: Natural -> Natural -> Natural
+        bump x y = x * y + n - bool2nat b
 
 ex4' :: Bool -> Natural
 ex4' b = mult (bool2nat b)
-  where mult :: Natural -> Natural
-        mult n = bump n (bool2nat b)
-          where bump :: Natural -> Natural -> Natural
-                bump x y = go (x * y) (n - bool2nat b)
-                  where go :: Natural -> Natural -> Natural
-                        go z w = z + x + w + y + n + bool2nat b
+  where
+    mult :: Natural -> Natural
+    mult n = bump n (bool2nat b)
+      where
+        bump :: Natural -> Natural -> Natural
+        bump x y = go (x * y) (n - bool2nat b)
+          where
+            go :: Natural -> Natural -> Natural
+            go z w = z + x + w + y + n + bool2nat b
 
 ex5 :: [Natural] -> Natural
 ex5 [] = zro
-  where zro :: Natural
-        zro = 0
+  where
+    zro :: Natural
+    zro = 0
 ex5 (n : ns) = mult num + 1
-  where num :: Natural
-        num = 42 + ex5 ns
-        mult :: Natural -> Natural
-        mult = (* n)
+  where
+    num :: Natural
+    num = 42 + ex5 ns
+    mult :: Natural -> Natural
+    mult = (* n)
 
 ex6 :: [Natural] -> Bool -> Natural
 ex6 [] b = zro
-  where zro :: Natural
-        zro = 0
+  where
+    zro :: Natural
+    zro = 0
 ex6 (n : ns) b = mult [num, 1]
-  where mult :: [Natural] -> Natural
-        mult [] = bump 5 (bool2nat b)
-          where bump :: Natural -> Natural -> Natural
-                bump x y = x * y + n
-        mult (m : ms) = bump n m
-          where bump :: Natural -> Natural -> Natural
-                bump x y = x * y + m - n
-        num :: Natural
-        num = 42 + ex6 ns True
+  where
+    mult :: [Natural] -> Natural
+    mult [] = bump 5 (bool2nat b)
+      where
+        bump :: Natural -> Natural -> Natural
+        bump x y = x * y + n
+    mult (m : ms) = bump n m
+      where
+        bump :: Natural -> Natural -> Natural
+        bump x y = x * y + m - n
+    num :: Natural
+    num = 42 + ex6 ns True
 
 ex7 :: Natural -> Natural
 ex7 n₀ = go₁ n₀
-  where go₁ :: Natural -> Natural
-        go₁ n₁ = go₂ (n₀ + n₁)
-          where go₂ :: Natural -> Natural
-                go₂ n₂ = n₀ + n₁ + n₂
+  where
+    go₁ :: Natural -> Natural
+    go₁ n₁ = go₂ (n₀ + n₁)
+      where
+        go₂ :: Natural -> Natural
+        go₂ n₂ = n₀ + n₁ + n₂
 
 ex7' :: Natural -> Natural
 ex7' n₀ = go₁ n₀
-  where go₁ :: Natural -> Natural
-        go₁ n₁ = go₂ (n₀ + n₁)
-          where go₂ :: Natural -> Natural
-                go₂ n₂ = go₃ (n₀ + n₁ + n₂)
-                  where go₃ :: Natural -> Natural
-                        go₃ n₃ = n₀ + n₁ + n₂ + n₃
+  where
+    go₁ :: Natural -> Natural
+    go₁ n₁ = go₂ (n₀ + n₁)
+      where
+        go₂ :: Natural -> Natural
+        go₂ n₂ = go₃ (n₀ + n₁ + n₂)
+          where
+            go₃ :: Natural -> Natural
+            go₃ n₃ = n₀ + n₁ + n₂ + n₃
 
 ex8 :: Natural
 ex8 = n₂
-  where n₁ :: Natural
-        n₁ = 1
-        n₂ :: Natural
-        n₂ = n₁ + 1
+  where
+    n₁ :: Natural
+    n₁ = 1
+    n₂ :: Natural
+    n₂ = n₁ + 1
 


### PR DESCRIPTION
When generating instance declarations, only explicit fields should be used as members. Implicit and instances fields are used for additional proofs, or super class constraints, so should be dropped from the Haskell code.

Fixes #51