### PR TITLE
[ fix #52 ] Add support for type synonyms

### DIFF
--- a/agda2hs.cabal
+++ b/agda2hs.cabal
@@ -30,7 +30,8 @@ executable agda2hs
                        syb >= 0.7
   default-language:    Haskell2010
   default-extensions:  LambdaCase,
-                       RecordWildCards
+                       RecordWildCards,
+                       FlexibleContexts
 
   -- Agda-2.6.1.2 does not work with ghc-8.10.3 (see https://github.com/agda/agda/issues/5136)
   if impl(ghc == 8.10.3)

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -9,6 +9,7 @@ import Sections
 import Test
 import Tuples
 import Where
+import TypeSynonyms
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -19,4 +20,5 @@ import Sections
 import Test
 import Tuples
 import Where
+import TypeSynonyms
 #-}

--- a/test/TypeSynonyms.agda
+++ b/test/TypeSynonyms.agda
@@ -7,6 +7,10 @@ data Nat : Set where
 Nat' = Nat
 {-# COMPILE AGDA2HS Nat' #-}
 
+myNat : Nat'
+myNat = Suc (Suc Zero)
+{-# COMPILE AGDA2HS myNat #-}
+
 data List (a : Set) : Set where
   Nil : List a
   Cons : a → List a → List a
@@ -19,6 +23,17 @@ List' a = List a
 NatList = List Nat
 {-# COMPILE AGDA2HS NatList #-}
 
+myListFun : List' Nat' → NatList
+myListFun Nil = Nil
+myListFun (Cons x xs) = Cons x (myListFun xs)
+{-# COMPILE AGDA2HS myListFun #-}
+
 ListList : Set → Set
 ListList a = List (List a)
 {-# COMPILE AGDA2HS ListList #-}
+
+flatten : ∀ {a} → ListList a → List a
+flatten Nil = Nil
+flatten (Cons Nil xss) = flatten xss
+flatten (Cons (Cons x xs) xss) = Cons x (flatten (Cons xs xss))
+{-# COMPILE AGDA2HS flatten #-}

--- a/test/TypeSynonyms.agda
+++ b/test/TypeSynonyms.agda
@@ -1,0 +1,24 @@
+
+data Nat : Set where
+  Zero : Nat
+  Suc  : Nat → Nat
+{-# COMPILE AGDA2HS Nat #-}
+
+Nat' = Nat
+{-# COMPILE AGDA2HS Nat' #-}
+
+data List (a : Set) : Set where
+  Nil : List a
+  Cons : a → List a → List a
+{-# COMPILE AGDA2HS List #-}
+
+List' : Set → Set
+List' a = List a
+{-# COMPILE AGDA2HS List' #-}
+
+NatList = List Nat
+{-# COMPILE AGDA2HS NatList #-}
+
+ListList : Set → Set
+ListList a = List (List a)
+{-# COMPILE AGDA2HS ListList #-}

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -8,4 +8,5 @@ import Sections
 import Test
 import Tuples
 import Where
+import TypeSynonyms
 

--- a/test/golden/TypeSynonyms.hs
+++ b/test/golden/TypeSynonyms.hs
@@ -1,0 +1,16 @@
+module TypeSynonyms where
+
+data Nat = Zero
+         | Suc Nat
+
+type Nat' = Nat
+
+data List a = Nil
+            | Cons a (List a)
+
+type List' a = List a
+
+type NatList = List Nat
+
+type ListList a = List (List a)
+

--- a/test/golden/TypeSynonyms.hs
+++ b/test/golden/TypeSynonyms.hs
@@ -5,6 +5,9 @@ data Nat = Zero
 
 type Nat' = Nat
 
+myNat :: Nat'
+myNat = Suc (Suc Zero)
+
 data List a = Nil
             | Cons a (List a)
 
@@ -12,5 +15,14 @@ type List' a = List a
 
 type NatList = List Nat
 
+myListFun :: List' Nat' -> NatList
+myListFun Nil = Nil
+myListFun (Cons x xs) = Cons x (myListFun xs)
+
 type ListList a = List (List a)
+
+flatten :: ListList a -> List a
+flatten Nil = Nil
+flatten (Cons Nil xss) = flatten xss
+flatten (Cons (Cons x xs) xss) = Cons x (flatten (Cons xs xss))
 


### PR DESCRIPTION
This adds basic support for type synonyms. We could consider extending this further with support for (closed) type families, but for now this should get us far enough.