### PR TITLE
Insert parens when required in infix applications

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -784,7 +784,7 @@ renderBlocks :: [Block] -> String
 renderBlocks = unlines . map unlines . sortRanges . filter (not . null . snd)
 
 defBlock :: CompiledDef -> [Block]
-defBlock def = [ (r, map pp ds) | (r, ds) <- def ]
+defBlock def = [ (r, map (pp . insertParens) ds) | (r, ds) <- def ]
 
 codePragmas :: [Ranged Code] -> [Block]
 codePragmas code = [ (r, map pp ps) | (r, (Hs.Module _ _ ps _ _, _)) <- code ]

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -2,6 +2,7 @@
 module AllTests where
 
 import Issue14
+import Fixities
 import LanguageConstructs
 import Numbers
 import Pragmas
@@ -12,6 +13,7 @@ import Where
 
 {-# FOREIGN AGDA2HS
 import Issue14
+import Fixities
 import LanguageConstructs
 import Numbers
 import Pragmas

--- a/test/Fixities.agda
+++ b/test/Fixities.agda
@@ -1,0 +1,27 @@
+
+module Fixities where
+
+open import Haskell.Prelude
+
+leftAssoc : Int → List Int
+leftAssoc n = 2 * n + 1
+            ∷ 2 * (n + 1)
+            ∷ 1 + n * 2
+            ∷ (1 + n) * 2
+            ∷ (n + n) + n
+            ∷ n + (n + n)
+            ∷ []
+
+rightAssoc : List Int → List Int
+rightAssoc xs = xs ++ xs ++ ((xs ++ xs) ++ xs) ++ xs
+
+nonAssoc : Bool → Bool
+nonAssoc b = (b == b) == (b == b)
+
+mixedAssoc : Maybe Int → (Int → Maybe Int) → Maybe Int
+mixedAssoc m f = f =<< (((f =<< m) >>= f) >>= f)
+
+{-# COMPILE AGDA2HS leftAssoc  #-}
+{-# COMPILE AGDA2HS rightAssoc #-}
+{-# COMPILE AGDA2HS nonAssoc   #-}
+{-# COMPILE AGDA2HS mixedAssoc #-}

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -1,6 +1,7 @@
 module AllTests where
 
 import Issue14
+import Fixities
 import LanguageConstructs
 import Numbers
 import Pragmas

--- a/test/golden/Fixities.hs
+++ b/test/golden/Fixities.hs
@@ -1,0 +1,16 @@
+module Fixities where
+
+leftAssoc :: Int -> [Int]
+leftAssoc n
+  = [2 * n + 1, 2 * (n + 1), 1 + n * 2, (1 + n) * 2, n + n + n,
+     n + (n + n)]
+
+rightAssoc :: [Int] -> [Int]
+rightAssoc xs = xs ++ xs ++ ((xs ++ xs) ++ xs) ++ xs
+
+nonAssoc :: Bool -> Bool
+nonAssoc b = (b == b) == (b == b)
+
+mixedAssoc :: Maybe Int -> (Int -> Maybe Int) -> Maybe Int
+mixedAssoc m f = f =<< ((f =<< m) >>= f >>= f)
+

--- a/test/golden/Test.hs
+++ b/test/golden/Test.hs
@@ -51,7 +51,7 @@ char_d = toEnum 100
 
 (+++) :: [a] -> [a] -> [a]
 [] +++ ys = ys
-(x : xs) +++ ys = x : xs +++ ys
+(x : xs) +++ ys = x : (xs +++ ys)
 
 listMap :: (a -> b) -> [a] -> [b]
 listMap f [] = []

--- a/test/golden/Where.hs
+++ b/test/golden/Where.hs
@@ -39,7 +39,7 @@ ex4 b = mult 42
     mult n = bump n (bool2nat b)
       where
         bump :: Natural -> Natural -> Natural
-        bump x y = x * y + n - bool2nat b
+        bump x y = x * y + (n - bool2nat b)
 
 ex4' :: Bool -> Natural
 ex4' b = mult (bool2nat b)
@@ -80,7 +80,7 @@ ex6 (n : ns) b = mult [num, 1]
     mult (m : ms) = bump n m
       where
         bump :: Natural -> Natural -> Natural
-        bump x y = x * y + m - n
+        bump x y = x * y + (m - n)
     num :: Natural
     num = 42 + ex6 ns True
 


### PR DESCRIPTION
Does not know about user-defined fixities, so might insert unnecessary parens in those cases.

Fixes #54