### PR TITLE
[ fix #59 ] Add translation to Haskell records

### DIFF
--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -11,6 +11,7 @@ import Tuples
 import Where
 import TypeSynonyms
 import Datatypes
+import Records
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -23,4 +24,5 @@ import Tuples
 import Where
 import TypeSynonyms
 import Datatypes
+import Records
 #-}

--- a/test/Fail/RecordWithoutConstructor.agda
+++ b/test/Fail/RecordWithoutConstructor.agda
@@ -1,0 +1,7 @@
+module Fail.RecordWithoutConstructor where
+
+record Test (a : Set) : Set where
+  field
+    one : a
+
+{-# COMPILE AGDA2HS Test #-}

--- a/test/Records.agda
+++ b/test/Records.agda
@@ -1,0 +1,18 @@
+module Records where
+
+-- parametrized record type exported as an Haskell record
+record Pair (a b : Set) : Set where
+  constructor MkPair
+  field
+    fst : a
+    snd : b
+
+{-# COMPILE AGDA2HS Pair #-}
+
+-- record type exported as an Haskell class definition
+record MyMonoid (a : Set) : Set where
+  field
+    mempty  : a
+    mappend : a → a → a
+
+{-# COMPILE AGDA2HS MyMonoid class #-}

--- a/test/Test.agda
+++ b/test/Test.agda
@@ -140,7 +140,7 @@ record MonoidX (a : Set) : Set where
 
 open MonoidX {{...}} public
 
-{-# COMPILE AGDA2HS MonoidX #-}
+{-# COMPILE AGDA2HS MonoidX class #-}
 
 instance
   MonoidNat : MonoidX Nat

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -10,4 +10,5 @@ import Tuples
 import Where
 import TypeSynonyms
 import Datatypes
+import Records
 

--- a/test/golden/RecordWithoutConstructor.err
+++ b/test/golden/RecordWithoutConstructor.err
@@ -1,0 +1,1 @@
+Not supported: Test is missing a named constructor.

--- a/test/golden/Records.hs
+++ b/test/golden/Records.hs
@@ -1,0 +1,8 @@
+module Records where
+
+data Pair a b = MkPair{fst :: a, snd :: b}
+
+class MyMonoid a where
+    mempty :: a
+    mappend :: a -> a -> a
+


### PR DESCRIPTION
Given `Rec` an agda record type, `{-# COMPILE AGDA2HS Rec #-}` will now produce an Haskell record type, and `{-# COMPILE AGDA2HS Rec class #-}` will produce a class definition.
Support for `deriving` could most likely be added later.