### PR TITLE
Record projections

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ See `test/Test.agda` for an example.
 - [x] Compile if/then/else [#13](https://github.com/agda/agda2hs/pull/13)
 - [ ] Literals in patterns
 - [x] Use some Haskell syntax ADT and a proper pretty printing library [#4](https://github.com/agda/agda2hs/pull/4)
-- [ ] Map instance arguments to Haskell type classes (definitions and use) [#3](https://github.com/agda/agda2hs/pull/3)
+- [x] Map instance arguments to Haskell type classes (definitions and use) [#3](https://github.com/agda/agda2hs/pull/3)
 - [x] `where` clauses [#23](https://github.com/agda/agda2hs/pull/23)
 - [ ] Higher-rank polymorphism
 - [x] More builtin types (Double, Word64) [#12](https://github.com/agda/agda2hs/pull/12)

--- a/lib/Haskell/Prim/Applicative.agda
+++ b/lib/Haskell/Prim/Applicative.agda
@@ -29,6 +29,8 @@ record Applicative (f : Set → Set) : Set₁ where
 
 open Applicative ⦃ ... ⦄ public
 
+{-# COMPILE AGDA2HS Applicative existing-class #-}
+
 instance
   iApplicativeList : Applicative List
   iApplicativeList .pure x      = x ∷ []

--- a/lib/Haskell/Prim/Bounded.agda
+++ b/lib/Haskell/Prim/Bounded.agda
@@ -31,6 +31,8 @@ record Bounded (a : Set) : Set where
     overlap ⦃ below ⦄ : BoundedBelow a
     overlap ⦃ above ⦄ : BoundedAbove a
 
+{-# COMPILE AGDA2HS Bounded existing-class #-}
+
 open BoundedBelow ⦃ ... ⦄ public
 open BoundedAbove ⦃ ... ⦄ public
 

--- a/lib/Haskell/Prim/Enum.agda
+++ b/lib/Haskell/Prim/Enum.agda
@@ -87,6 +87,8 @@ record Enum (a : Set) : Set₁ where
 
 open Enum ⦃ ... ⦄ public
 
+{-# COMPILE AGDA2HS Enum existing-class #-}
+
 private
   divNat : Nat → Nat → Nat
   divNat a 0       = 0

--- a/lib/Haskell/Prim/Eq.agda
+++ b/lib/Haskell/Prim/Eq.agda
@@ -29,6 +29,8 @@ record Eq (a : Set) : Set where
 
 open Eq ⦃ ... ⦄ public
 
+{-# COMPILE AGDA2HS Eq existing-class #-}
+
 instance
   iEqNat : Eq Nat
   iEqNat ._==_ = Nat._==_

--- a/lib/Haskell/Prim/Foldable.agda
+++ b/lib/Haskell/Prim/Foldable.agda
@@ -66,6 +66,8 @@ record Foldable (t : Set → Set) : Set₁ where
 
 open Foldable ⦃ ... ⦄ public
 
+{-# COMPILE AGDA2HS Foldable existing-class #-}
+
 instance
   iFoldableList : Foldable List
   iFoldableList .foldMap f []       = mempty

--- a/lib/Haskell/Prim/Functor.agda
+++ b/lib/Haskell/Prim/Functor.agda
@@ -34,6 +34,8 @@ record Functor (f : Set → Set) : Set₁ where
 
 open Functor ⦃ ... ⦄ public
 
+{-# COMPILE AGDA2HS Functor existing-class #-}
+
 instance
   iFunctorList : Functor List
   iFunctorList .fmap = map

--- a/lib/Haskell/Prim/Monad.agda
+++ b/lib/Haskell/Prim/Monad.agda
@@ -31,6 +31,8 @@ record Monad (m : Set → Set) : Set₁ where
 
 open Monad ⦃ ... ⦄ public
 
+{-# COMPILE AGDA2HS Monad existing-class #-}
+
 mapM₋ : ⦃ Monad m ⦄ → ⦃ Foldable t ⦄ → (a → m b) → t a → m ⊤
 mapM₋ f = foldr (λ x k → f x >> k) (pure tt)
 
@@ -70,6 +72,8 @@ record MonadFail (m : Set → Set) : Set₁ where
     overlap ⦃ super ⦄ : Monad m
 
 open MonadFail ⦃ ... ⦄ public
+
+{-# COMPILE AGDA2HS MonadFail existing-class #-}
 
 instance
   MonadFailList : MonadFail List

--- a/lib/Haskell/Prim/Monoid.agda
+++ b/lib/Haskell/Prim/Monoid.agda
@@ -20,6 +20,8 @@ record Semigroup (a : Set) : Set where
 
 open Semigroup ⦃ ... ⦄ public
 
+{-# COMPILE AGDA2HS Semigroup existing-class #-}
+
 instance
   iSemigroupList : Semigroup (List a)
   iSemigroupList ._<>_ = _++_
@@ -62,6 +64,8 @@ record Monoid (a : Set) : Set where
   mconcat (x ∷ xs) = x <> mconcat xs
 
 open Monoid ⦃ ... ⦄ public
+
+{-# COMPILE AGDA2HS Monoid existing-class #-}
 
 instance
   iMonoidList : Monoid (List a)

--- a/lib/Haskell/Prim/Num.agda
+++ b/lib/Haskell/Prim/Num.agda
@@ -40,6 +40,8 @@ record Num (a : Set) : Set₁ where
 
 open Num ⦃ ... ⦄ public hiding (FromIntegerOK; number)
 
+{-# COMPILE AGDA2HS Num existing-class #-}
+
 instance
   iNumNat : Num Nat
   iNumNat .MinusOK n m      = IsFalse (n Nat.< m)

--- a/lib/Haskell/Prim/Ord.agda
+++ b/lib/Haskell/Prim/Ord.agda
@@ -56,6 +56,8 @@ record Ord (a : Set) : Set where
 
 open Ord ⦃ ... ⦄ public
 
+{-# COMPILE AGDA2HS Ord existing-class #-}
+
 ordFromCompare : ⦃ Eq a ⦄ → (a → a → Ordering) → Ord a
 ordFromCompare cmp .compare = cmp
 ordFromCompare cmp ._<_  x y = cmp x y == LT

--- a/lib/Haskell/Prim/Show.agda
+++ b/lib/Haskell/Prim/Show.agda
@@ -54,6 +54,8 @@ defaultShowList shows (x ∷ xs) = showString "[" ∘ foldl (λ s x → s ∘ sh
 
 open Show ⦃ ... ⦄ public
 
+{-# COMPILE AGDA2HS Show existing-class #-}
+
 private
   makeShow : (a → String) → Show a
   makeShow sh .showsPrec _ = showString ∘ sh

--- a/lib/Haskell/Prim/Traversable.agda
+++ b/lib/Haskell/Prim/Traversable.agda
@@ -31,6 +31,8 @@ record Traversable (t : Set → Set) : Set₁ where
 
 open Traversable ⦃ ... ⦄ public
 
+{-# COMPILE AGDA2HS Traversable existing-class #-}
+
 instance
   iTraversableList : Traversable List
   iTraversableList .traverse f []       = pure []

--- a/test/Fail/QualifiedRecordProjections.agda
+++ b/test/Fail/QualifiedRecordProjections.agda
@@ -1,4 +1,4 @@
-module Fail.RecordWithoutConstructor where
+module Fail.QualifiedRecordProjections where
 
 record Test (a : Set) : Set where
   field

--- a/test/Records.agda
+++ b/test/Records.agda
@@ -1,13 +1,28 @@
 module Records where
 
+variable
+  a b : Set
+
 -- parametrized record type exported as an Haskell record
 record Pair (a b : Set) : Set where
   constructor MkPair
   field
-    fst : a
-    snd : b
+    proj₁ : a
+    proj₂ : b
+
+open Pair public
 
 {-# COMPILE AGDA2HS Pair #-}
+
+-- no named constructor means we reuse the record name
+
+record Wrap (a : Set) : Set where
+  field
+    unwrap : a
+
+open Wrap public
+
+{-# COMPILE AGDA2HS Wrap #-}
 
 -- record type exported as an Haskell class definition
 record MyMonoid (a : Set) : Set where
@@ -16,3 +31,12 @@ record MyMonoid (a : Set) : Set where
     mappend : a → a → a
 
 {-# COMPILE AGDA2HS MyMonoid class #-}
+
+swap : Pair a b → Pair b a
+swap (MkPair x y) = MkPair y x
+
+swap₂ : Wrap (Pair a b) → Wrap (Pair b a)
+swap₂ (record {unwrap = p}) = record {unwrap = record { proj₁ = proj₂ p; proj₂ = p .proj₁ } }
+
+{-# COMPILE AGDA2HS swap #-}
+{-# COMPILE AGDA2HS swap₂ #-}

--- a/test/golden/QualifiedRecordProjections.err
+++ b/test/golden/QualifiedRecordProjections.err
@@ -1,0 +1,4 @@
+test/Fail/QualifiedRecordProjections.agda:5,5-8
+Record projections (`one` in this case) must be brought into scope
+when compiling to Haskell record types. Add `open Test public`
+after the record declaration to fix this.

--- a/test/golden/RecordWithoutConstructor.err
+++ b/test/golden/RecordWithoutConstructor.err
@@ -1,1 +1,0 @@
-Not supported: Test is missing a named constructor.

--- a/test/golden/Records.hs
+++ b/test/golden/Records.hs
@@ -1,8 +1,16 @@
 module Records where
 
-data Pair a b = MkPair{fst :: a, snd :: b}
+data Pair a b = MkPair{proj₁ :: a, proj₂ :: b}
+
+data Wrap a = Wrap{unwrap :: a}
 
 class MyMonoid a where
     mempty :: a
     mappend :: a -> a -> a
+
+swap :: Pair a b -> Pair b a
+swap (MkPair x y) = MkPair y x
+
+swap₂ :: Wrap (Pair a b) -> Wrap (Pair b a)
+swap₂ (Wrap p) = Wrap (MkPair (proj₂ p) (proj₁ p))
 


### PR DESCRIPTION
For this we need to know about records that map to existing Haskell classes, like the ones in the Prelude. For this purpose there is a new pragma

```
{-# COMPILE AGDA2HS Name existing-class #-}
```

which marks `Name` as a class, but doesn't generate any Haskell code.

Fixes #59