### PR TITLE
Drop non-visible lambdas

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -768,6 +768,9 @@ compileTerm v =
           Hs.InfixApp _ a op b
             | a == hsx -> Hs.RightSection () op b -- System-inserted visible lambdas can only come from sections
           _            -> hsLambda x body         -- so we know x is not free in b.
+    Lam v b ->
+      -- Drop non-visible lambdas (#65)
+      underAbstraction_ b $ \ body -> compileTerm body
     t -> genericDocError =<< text "bad term:" <?> prettyTCM t
   where
     app :: Hs.Exp () -> Elims -> TCM (Hs.Exp ())

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -2,6 +2,7 @@
 module AllTests where
 
 import Issue14
+import Issue65
 import Fixities
 import LanguageConstructs
 import Numbers
@@ -16,6 +17,7 @@ import Records
 
 {-# FOREIGN AGDA2HS
 import Issue14
+import Issue65
 import Fixities
 import LanguageConstructs
 import Numbers

--- a/test/Issue65.agda
+++ b/test/Issue65.agda
@@ -1,0 +1,14 @@
+
+module Issue65 where
+
+open import Haskell.Prelude
+
+yeet : (c : Bool) → ({{c ≡ true}} → a) → ({{c ≡ false}} → a) → a
+yeet false x y = y {{refl}}
+yeet true  x y = x {{refl}}
+{-# COMPILE AGDA2HS yeet #-}
+
+-- The branches start with instance lambdas that should be dropped.
+xx : Int
+xx = yeet true 1 2
+{-# COMPILE AGDA2HS xx #-}

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -1,6 +1,7 @@
 module AllTests where
 
 import Issue14
+import Issue65
 import Fixities
 import LanguageConstructs
 import Numbers

--- a/test/golden/Issue65.hs
+++ b/test/golden/Issue65.hs
@@ -1,0 +1,9 @@
+module Issue65 where
+
+yeet :: Bool -> a -> a -> a
+yeet False x y = y
+yeet True x y = x
+
+xx :: Int
+xx = yeet True 1 2
+


### PR DESCRIPTION
Fixes #65

Note that the test case in the OP doesn't work since `{{Bool}} -> a` gets compiled to `Bool => a`. Making it a proper predicate on `c` makes the compiler drop it though.