### PR TITLE
Fix bug in Eq instance for List

### DIFF
--- a/lib/Haskell/Prim/Eq.agda
+++ b/lib/Haskell/Prim/Eq.agda
@@ -65,7 +65,7 @@ instance
   iEqTuple ._==_ (x ∷ xs) (y ∷ ys) = x == y && xs == ys
 
   iEqList : ⦃ Eq a ⦄ → Eq (List a)
-  iEqList ._==_ []       []       = false
+  iEqList ._==_ []       []       = true
   iEqList ._==_ (x ∷ xs) (y ∷ ys) = x == y && xs == ys
   iEqList ._==_ _        _        = false
 


### PR DESCRIPTION
https://github.com/agda/agda2hs/blob/1b350f85ed02f44dd24c07bf7f147055cac6da2e/lib/Haskell/Prim/Eq.agda#L67-L70

Pretty sure it should be
```
iEqList ._==_  []  [] = true
```