### PR TITLE
Agda-2.6.2 compatibility

### DIFF
--- a/agda2hs.cabal
+++ b/agda2hs.cabal
@@ -21,15 +21,17 @@ source-repository head
 executable agda2hs
   main-is:             Main.hs
   other-modules:       HsUtils
-  build-depends:       base >= 4.10 && < 4.15,
-                       Agda >= 2.6 && < 2.6.2,
+  build-depends:       base >= 4.10 && < 4.16,
+                       Agda >= 2.6.2 && < 2.6.3,
                        containers >= 0.6 && < 0.7,
                        unordered-containers >= 0.2,
                        mtl >= 2.2,
                        directory >= 1.2.6.2 && < 1.4,
                        filepath >= 1.4.1.0 && < 1.5,
                        haskell-src-exts >= 1.23 && < 1.25,
-                       syb >= 0.7
+                       syb >= 0.7,
+                       text >= 1.2.3.0,
+                       deepseq >= 1.4.1.1
   default-language:    Haskell2010
   default-extensions:  LambdaCase,
                        RecordWildCards,
@@ -37,5 +39,5 @@ executable agda2hs
 
   -- Agda-2.6.1.2 does not work with ghc-8.10.3 (see https://github.com/agda/agda/issues/5136)
   if impl(ghc == 8.10.3)
-    build-depends: Agda == 2.6.1.1
+    build-depends: Agda < 2.6.1.2 || > 2.6.1.2
 

--- a/lib/Haskell/Prim/Absurd.agda
+++ b/lib/Haskell/Prim/Absurd.agda
@@ -11,10 +11,11 @@ open import Haskell.Prim
 
 private
 
-  pattern vArg x = arg (arg-info visible relevant) x
+  pattern vArg x = arg (arg-info visible (modality relevant quantity-ω)) x
 
   refute : Nat → Term
-  refute i = def (quote _$_) (vArg (pat-lam (absurd-clause (vArg absurdP ∷ []) ∷ []) []) ∷ vArg (var i []) ∷ [])
+  refute i = def (quote _$_) ( vArg (pat-lam (absurd-clause [] (vArg (absurdP 0) ∷ []) ∷ []) [])
+                             ∷ vArg (var i []) ∷ [])
 
   tryRefute : Nat → Term → TC ⊤
   tryRefute 0       _    = typeError (strErr "No variable of empty type found in the context" ∷ [])

--- a/lib/Haskell/Prim/Eq.agda
+++ b/lib/Haskell/Prim/Eq.agda
@@ -45,7 +45,7 @@ instance
   iEqWord ._==_ = eqWord
 
   iEqDouble : Eq Double
-  iEqDouble ._==_ = primFloatNumericalEquality
+  iEqDouble ._==_ = primFloatEquality
 
   iEqBool : Eq Bool
   iEqBool ._==_ false false = true

--- a/lib/Haskell/Prim/Ord.agda
+++ b/lib/Haskell/Prim/Ord.agda
@@ -103,7 +103,7 @@ instance
   iOrdWord = ordFromLessThan ltWord
 
   iOrdDouble : Ord Double
-  iOrdDouble = ordFromLessThan primFloatNumericalLess
+  iOrdDouble = ordFromLessThan primFloatLess
 
   iOrdChar : Ord Char
   iOrdChar = ordFromLessThan λ x y → primCharToNat x < primCharToNat y


### PR DESCRIPTION
Only for the implementation, not for the agda lib.

Fixes #79

- ~~[ ] CI for both 2.6.1 and 2.6.2~~
- ~~[ ] Figure out how to handle the Agda library~~

Edit: as discussed in #79, we're dropping support for 2.6.1.

If anyone desperately needs it in the future, it should be easy enough to make a separate branch for it.