### PR TITLE
Skip compilation of runtime-erased arguments and lambdas

### DIFF
--- a/test/Vector.agda
+++ b/test/Vector.agda
@@ -14,3 +14,18 @@ mapV f (Cons x xs) = Cons (f x) (mapV f xs)
 tailV : {a : Set} {n : Nat} → Vec a {suc n} → Vec a {n}
 tailV (Cons x xs) = xs
 {-# COMPILE AGDA2HS tailV #-}
+
+-- Using erasure instead of implicit arguments
+data Vec' (a : Set) : (@0 n : Nat) → Set where
+  Nil' : Vec' a 0
+  Cons' : {@0 n : Nat} → a → Vec' a n → Vec' a (suc n)
+{-# COMPILE AGDA2HS Vec' #-}
+
+mapV' : {a b : Set} {@0 n : Nat} (f : a → b) → Vec' a n → Vec' b n
+mapV' f Nil' = Nil'
+mapV' f (Cons' x xs) = Cons' (f x) (mapV' f xs)
+{-# COMPILE AGDA2HS mapV' #-}
+
+tailV' : {a : Set} {@0 n : Nat} → Vec' a (suc n) → Vec' a n
+tailV' (Cons' x xs) = xs
+{-# COMPILE AGDA2HS tailV' #-}

--- a/test/golden/Vector.hs
+++ b/test/golden/Vector.hs
@@ -10,3 +10,13 @@ mapV f (Cons x xs) = Cons (f x) (mapV f xs)
 tailV :: Vec a -> Vec a
 tailV (Cons x xs) = xs
 
+data Vec' a = Nil'
+            | Cons' a (Vec' a)
+
+mapV' :: (a -> b) -> Vec' a -> Vec' b
+mapV' f Nil' = Nil'
+mapV' f (Cons' x xs) = Cons' (f x) (mapV' f xs)
+
+tailV' :: Vec' a -> Vec' a
+tailV' (Cons' x xs) = xs
+


### PR DESCRIPTION
Sometimes we want an argument to be explicit but still not be compiled to Haskell. In that case it's natural to use Agda's `@0` modality to mark those arguments that should be erased by the backend.