### PR TITLE
[ fix #95 ] Define tuples by large elimination

### DIFF
--- a/lib/Haskell/Prim/Applicative.agda
+++ b/lib/Haskell/Prim/Applicative.agda
@@ -61,6 +61,6 @@ instance
 
   iApplicativeTuple₄ : ⦃ Monoid a ⦄ → ⦃ Monoid b ⦄ → ⦃ Monoid c ⦄ →
                        Applicative (λ d → Tuple (a ∷ b ∷ c ∷ d ∷ []))
-  iApplicativeTuple₄ .pure x                          = mempty ∷ mempty ∷ mempty ∷ x ∷ []
-  iApplicativeTuple₄ ._<*>_ (a ∷ b ∷ c ∷ f ∷ []) (a₁ ∷ b₁ ∷ c₁ ∷ x ∷ []) =
-    a <> a₁ ∷ b <> b₁ ∷ c <> c₁ ∷ f x ∷ []
+  iApplicativeTuple₄ .pure x                          = mempty ; mempty ; mempty ; x ; tt
+  iApplicativeTuple₄ ._<*>_ (a ; b ; c ; f ; tt) (a₁ ; b₁ ; c₁ ; x ; tt) =
+    a <> a₁ ; b <> b₁ ; c <> c₁ ; f x ; tt

--- a/lib/Haskell/Prim/Bounded.agda
+++ b/lib/Haskell/Prim/Bounded.agda
@@ -60,14 +60,14 @@ instance
   iBoundedAboveChar .maxBound = '\1114111'
 
   iBoundedBelowTuple₀ : BoundedBelow (Tuple [])
-  iBoundedBelowTuple₀ .minBound = []
+  iBoundedBelowTuple₀ .minBound = tt
   iBoundedAboveTuple₀ : BoundedAbove (Tuple [])
-  iBoundedAboveTuple₀ .maxBound = []
+  iBoundedAboveTuple₀ .maxBound = tt
 
   iBoundedBelowTuple : ⦃ BoundedBelow a ⦄ → ⦃ BoundedBelow (Tuple as) ⦄ → BoundedBelow (Tuple (a ∷ as))
-  iBoundedBelowTuple .minBound = minBound ∷ minBound
+  iBoundedBelowTuple .minBound = minBound ; minBound
   iBoundedAboveTuple : ⦃ BoundedAbove a ⦄ → ⦃ BoundedAbove (Tuple as) ⦄ → BoundedAbove (Tuple (a ∷ as))
-  iBoundedAboveTuple .maxBound = maxBound ∷ maxBound
+  iBoundedAboveTuple .maxBound = maxBound ; maxBound
 
   iBoundedBelowOrdering : BoundedBelow Ordering
   iBoundedBelowOrdering .minBound = LT

--- a/lib/Haskell/Prim/Enum.agda
+++ b/lib/Haskell/Prim/Enum.agda
@@ -192,8 +192,8 @@ instance
   iEnumOrdering = boundedEnumViaInteger (λ where LT → 0; EQ → 1; GT → 2)
                                         (λ where (pos 0) → LT; (pos 1) → EQ; _ → GT)
 
-  iEnumUnit : Enum (Tuple [])
-  iEnumUnit = boundedEnumViaInteger (λ _ → 0) (λ _ → [])
+  iEnumUnit : Enum ⊤ 
+  iEnumUnit = boundedEnumViaInteger (λ _ → 0) λ _ → tt
 
   iEnumChar : Enum Char
   iEnumChar = boundedEnumViaInteger (pos ∘ primCharToNat)

--- a/lib/Haskell/Prim/Eq.agda
+++ b/lib/Haskell/Prim/Eq.agda
@@ -57,7 +57,7 @@ instance
   iEqTuple₀ ._==_ _ _ = True
 
   iEqTuple : ⦃ Eq a ⦄ → ⦃ Eq (Tuple as) ⦄ → Eq (Tuple (a ∷ as))
-  iEqTuple ._==_ (x ∷ xs) (y ∷ ys) = x == y && xs == ys
+  iEqTuple ._==_ (x ; xs) (y ; ys) = x == y && xs == ys
 
   iEqList : ⦃ Eq a ⦄ → Eq (List a)
   iEqList ._==_ []       []       = True

--- a/lib/Haskell/Prim/Functor.agda
+++ b/lib/Haskell/Prim/Functor.agda
@@ -30,7 +30,7 @@ record Functor (f : Set → Set) : Set₁ where
   m $> x = x <$ m
 
   void : f a → f (Tuple [])
-  void = [] <$_
+  void = tt <$_
 
 open Functor ⦃ ... ⦄ public
 
@@ -58,4 +58,4 @@ instance
   iFunctorTuple₃ .fmap f (x , y , z) = x , y , f z
 
   iFunctorTuple₄ : Functor (λ d → Tuple (a ∷ b ∷ c ∷ d ∷ []))
-  iFunctorTuple₄ .fmap f (x ∷ y ∷ z ∷ w ∷ []) = x ∷ y ∷ z ∷ f w ∷ []
+  iFunctorTuple₄ .fmap f (x ; y ; z ; w ; tt) = x ; y ; z ; f w ; tt

--- a/lib/Haskell/Prim/Monad.agda
+++ b/lib/Haskell/Prim/Monad.agda
@@ -62,9 +62,9 @@ instance
 
   iMonadTuple₄ : ⦃ Monoid a ⦄ → ⦃ Monoid b ⦄ → ⦃ Monoid c ⦄ →
                  Monad (λ d → Tuple (a ∷ b ∷ c ∷ d ∷ []))
-  iMonadTuple₄ ._>>=_ (a ∷ b ∷ c ∷ x ∷ []) k =
+  iMonadTuple₄ ._>>=_ (a ; b ; c ; x ; tt) k =
     case k x of λ where
-      (a₁ ∷ b₁ ∷ c₁ ∷ y ∷ []) → a <> a₁ ∷ b <> b₁ ∷ c <> c₁ ∷ y ∷ []
+      (a₁ ; b₁ ; c₁ ; y ; tt) → a <> a₁ ; b <> b₁ ; c <> c₁ ; y ; tt
 
 record MonadFail (m : Set → Set) : Set₁ where
   field

--- a/lib/Haskell/Prim/Monoid.agda
+++ b/lib/Haskell/Prim/Monoid.agda
@@ -40,10 +40,10 @@ instance
   iSemigroupUnit ._<>_ _ _ = tt
 
   iSemigroupTuple₀ : Semigroup (Tuple [])
-  iSemigroupTuple₀ ._<>_ _ _ = []
+  iSemigroupTuple₀ ._<>_ _ _ = tt
 
   iSemigroupTuple : ⦃ Semigroup a ⦄ → ⦃ Semigroup (Tuple as) ⦄ → Semigroup (Tuple (a ∷ as))
-  iSemigroupTuple ._<>_ (x ∷ xs) (y ∷ ys) = x <> y ∷ xs <> ys
+  iSemigroupTuple ._<>_ (x ; xs) (y ; ys) = x <> y ; xs <> ys
 
 
 --------------------------------------------------
@@ -79,10 +79,10 @@ instance
   iMonoidUnit .mempty = tt
 
   iMonoidTuple₀ : Monoid (Tuple [])
-  iMonoidTuple₀ .mempty = []
+  iMonoidTuple₀ .mempty = tt 
 
   iMonoidTuple : ⦃ Monoid a ⦄ → ⦃ Monoid (Tuple as) ⦄ → Monoid (Tuple (a ∷ as))
-  iMonoidTuple .mempty = mempty ∷ mempty
+  iMonoidTuple .mempty = mempty ; mempty
 
 MonoidEndo : Monoid (a → a)
 MonoidEndo .mempty      = id

--- a/lib/Haskell/Prim/Ord.agda
+++ b/lib/Haskell/Prim/Ord.agda
@@ -115,7 +115,7 @@ instance
   iOrdTuple₀ = ordFromCompare λ _ _ → EQ
 
   iOrdTuple : ⦃ Ord a ⦄ → ⦃ Ord (Tuple as) ⦄ → Ord (Tuple (a ∷ as))
-  iOrdTuple = ordFromCompare λ where (x ∷ xs) (y ∷ ys) → compare x y <> compare xs ys
+  iOrdTuple = ordFromCompare λ where (x ; xs) (y ; ys) → compare x y <> compare xs ys
 
 compareList : ⦃ Ord a ⦄ → List a → List a → Ordering
 compareList []       []       = EQ

--- a/lib/Haskell/Prim/Show.agda
+++ b/lib/Haskell/Prim/Show.agda
@@ -104,9 +104,9 @@ instance
 private
   -- Minus the parens
   showTuple : ⦃ All Show as ⦄ → Tuple as → ShowS
-  showTuple             []       = showString ""
-  showTuple ⦃ allCons ⦄ (x ∷ []) = shows x
-  showTuple ⦃ allCons ⦄ (x ∷ xs) = shows x ∘ showString "," ∘ showTuple xs
+  showTuple {_} ⦃ allNil  ⦄                   _        = showString ""
+  showTuple {_} ⦃ allCons ⦃ _ ⦄ ⦃ allNil ⦄ ⦄ (x ; tt) = shows x
+  showTuple {_} ⦃ allCons ⦄                   (x ; xs) = shows x ∘ showString ", " ∘ showTuple xs
 
 instance
   iShowTuple : ⦃ All Show as ⦄ → Show (Tuple as)

--- a/lib/Haskell/Prim/Tuple.agda
+++ b/lib/Haskell/Prim/Tuple.agda
@@ -9,10 +9,14 @@ variable
 --------------------------------------------------
 -- Tuples
 
-infixr 5 _∷_
-data Tuple : List Set → Set where
-  []  : Tuple []
-  _∷_ : a → Tuple as → Tuple (a ∷ as)
+infixr 5 _;_
+record Pair (A B : Set) : Set where
+  constructor _;_
+  field fst : A ; snd : B
+
+Tuple : List Set → Set
+Tuple [] = ⊤
+Tuple (A ∷ AS) = Pair A (Tuple AS)
 
 infix 3 _×_ _×_×_
 
@@ -24,8 +28,8 @@ a × b × c = Tuple (a ∷ b ∷ c ∷ [])
 
 infix -1 _,_ _,_,_
 
-pattern _,_     x y     = x Tuple.∷ y Tuple.∷ []
-pattern _,_,_   x y z   = x Tuple.∷ y Tuple.∷ z Tuple.∷ []
+pattern _,_     x y     = x ; y ; tt
+pattern _,_,_   x y z   = x ; y ; z ; tt
 
 uncurry : (a → b → c) → a × b → c
 uncurry f (x , y) = f x y

--- a/test/Fail/TuplePat.agda
+++ b/test/Fail/TuplePat.agda
@@ -4,6 +4,6 @@ module Fail.TuplePat where
 open import Haskell.Prelude
 
 fst₃ : a × b × c → a
-fst₃ (x ∷ xs) = x
+fst₃ (x ; xs) = x
 
 {-# COMPILE AGDA2HS fst₃ #-}

--- a/test/Fail/TupleTerm.agda
+++ b/test/Fail/TupleTerm.agda
@@ -4,6 +4,6 @@ module Fail.TupleTerm where
 open import Haskell.Prelude
 
 pair2trip : a → b × c → a × b × c
-pair2trip x xs = x ∷ xs
+pair2trip x xs = x ; xs
 
 {-# COMPILE AGDA2HS pair2trip #-}

--- a/test/Tuples.agda
+++ b/test/Tuples.agda
@@ -9,6 +9,27 @@ swap (a , b) = b , a
 {-# COMPILE AGDA2HS swap #-}
 
 unit2unit : ⊤ → Tuple []
-unit2unit tt = []
+unit2unit tt = tt
 
 {-# COMPILE AGDA2HS unit2unit #-}
+
+data TuplePos : Set where
+  Test : TuplePos × Bool → TuplePos
+
+{-# COMPILE AGDA2HS TuplePos #-}
+
+
+t1 : Bool × Bool × Bool
+t1 = True , False , True
+
+{-# COMPILE AGDA2HS t1 #-}
+
+t2 : (Bool × Bool) × Bool
+t2 = (True , False) , True
+
+{-# COMPILE AGDA2HS t2 #-}
+
+t3 : Bool × (Bool × Bool)
+t3 = True , (False , True)
+
+{-# COMPILE AGDA2HS t3 #-}

--- a/test/golden/TuplePat.err
+++ b/test/golden/TuplePat.err
@@ -1,4 +1,2 @@
 test/Fail/TuplePat.agda:6,1-5
-Tuple pattern
-  (_∷_ .(a) .(b ∷ c ∷ []) x xs)
-does not have a known size.
+Tuple pattern (_;_ x xs) does not have a known size.

--- a/test/golden/TupleTerm.err
+++ b/test/golden/TupleTerm.err
@@ -1,2 +1,2 @@
 test/Fail/TupleTerm.agda:6,1-10
-Tuple value x ∷ xs does not have a known size.
+Tuple value x ; xs does not have a known size.

--- a/test/golden/TupleType.err
+++ b/test/golden/TupleType.err
@@ -1,2 +1,2 @@
 test/Fail/TupleType.agda:6,1-4
-Argument as to Tuple is not a concrete list
+Tuple as is not a concrete sequence of types.

--- a/test/golden/Tuples.hs
+++ b/test/golden/Tuples.hs
@@ -6,3 +6,14 @@ swap (a, b) = (b, a)
 unit2unit :: () -> ()
 unit2unit () = ()
 
+data TuplePos = Test (TuplePos, Bool)
+
+t1 :: (Bool, Bool, Bool)
+t1 = (True, False, True)
+
+t2 :: ((Bool, Bool), Bool)
+t2 = ((True, False), True)
+
+t3 :: (Bool, (Bool, Bool))
+t3 = (True, (False, True))
+


### PR DESCRIPTION
Might have to make `Pair` *private* (in `Prim/Tuple.agda`) to avoid things going wrong.
Other than that this fixes the original issue.

A nice byproduct is that now `Tuple []` and `⊤` are the same.