### PR TITLE
Add support for do-notation

### DIFF
--- a/lib/Haskell/Prim/Monad.agda
+++ b/lib/Haskell/Prim/Monad.agda
@@ -29,6 +29,15 @@ record Monad (m : Set → Set) : Set₁ where
   _=<<_ : (a → m b) → m a → m b
   _=<<_ = flip _>>=_
 
+-- Use `Dont._>>=_` and `Dont._>>_` if you do not want agda2hs to use
+-- do-notation.
+module Dont where
+  _>>=_ : ⦃ Monad m ⦄ → m a → (a → m b) → m b
+  _>>=_ = Monad._>>=_ it
+
+  _>>_ : ⦃ Monad m ⦄ → m a → m b → m b
+  _>>_ = Monad._>>_ it
+
 open Monad ⦃ ... ⦄ public
 
 {-# COMPILE AGDA2HS Monad existing-class #-}

--- a/src/Agda2Hs/Compile/Term.hs
+++ b/src/Agda2Hs/Compile/Term.hs
@@ -44,6 +44,8 @@ isSpecialTerm q = case prettyShow q of
   "Haskell.Prim.Enum.Enum.enumFromThen"         -> Just mkEnumFromThen
   "Haskell.Prim.Enum.Enum.enumFromThenTo"       -> Just mkEnumFromThenTo
   "Haskell.Prim.case_of_"                       -> Just caseOf
+  "Haskell.Prim.Monad.Monad._>>=_"              -> Just bind
+  "Haskell.Prim.Monad.Monad._>>_"               -> Just sequ
   "Agda.Builtin.FromNat.Number.fromNat"         -> Just fromNat
   "Agda.Builtin.FromNeg.Negative.fromNeg"       -> Just fromNeg
   "Agda.Builtin.FromString.IsString.fromString" -> Just fromString
@@ -116,6 +118,24 @@ delay _ = compileErasedApp
 
 force :: QName -> Elims -> C (Hs.Exp ())
 force _ = compileErasedApp
+
+bind :: QName -> Elims -> C (Hs.Exp ())
+bind q es = compileElims (drop 1 es) >>= \case
+  (u : Hs.Lambda _ [p] v : vs) -> do
+    let stmt1 = Hs.Generator () p u
+    case v of
+      Hs.Do _ stmts -> return $ Hs.Do () (stmt1 : stmts)
+      _             -> return $ Hs.Do () [stmt1, Hs.Qualifier () v]
+  vs     -> return $ hsVar "_>>=_" `eApp` vs
+
+sequ :: QName -> Elims -> C (Hs.Exp ())
+sequ q es = compileElims es >>= \case
+  (u : v : vs) -> do
+    let stmt1 = Hs.Qualifier () u
+    case v of
+      Hs.Do _ stmts -> return $ Hs.Do () (stmt1 : stmts)
+      _             -> return $ Hs.Do () [stmt1, Hs.Qualifier () v]
+  vs -> return $ hsVar "_>>_" `eApp` vs
 
 caseOf :: QName -> Elims -> C (Hs.Exp ())
 caseOf _ es = compileElims es >>= \ case

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -38,6 +38,7 @@ import BangPatterns
 import Issue94
 import Issue107
 import Importer
+import DoNotation
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -76,4 +77,5 @@ import Issue115
 import BangPatterns
 import Issue94
 import Importer
+import DoNotation
 #-}

--- a/test/DoNotation.agda
+++ b/test/DoNotation.agda
@@ -34,3 +34,12 @@ routine = do
     landLeft 1 second
 
 {-# COMPILE AGDA2HS routine #-}
+
+routineWithoutDo : Maybe Pole
+routineWithoutDo =
+    return (0 , 0) Dont.>>= λ start →
+    landLeft 2 start Dont.>>= λ first →
+    landRight 2 first Dont.>>= λ second →
+    landLeft 1 second
+
+{-# COMPILE AGDA2HS routineWithoutDo #-}

--- a/test/DoNotation.agda
+++ b/test/DoNotation.agda
@@ -1,0 +1,36 @@
+
+open import Haskell.Prelude
+
+-- Example from http://learnyouahaskell.com/a-fistful-of-monads#getting-our-feet-wet-with-maybe
+
+Birds = Int
+Pole = Birds × Birds
+
+{-# COMPILE AGDA2HS Birds #-}
+{-# COMPILE AGDA2HS Pole #-}
+
+
+landLeft : Birds → Pole → Maybe Pole
+landLeft n (left , right) =
+  if abs ((left + n) - right) < 4
+  then Just (left + n , right)
+  else Nothing
+
+{-# COMPILE AGDA2HS landLeft #-}
+
+landRight : Birds → Pole → Maybe Pole
+landRight n (left , right) =
+  if abs (left - (right + n)) < 4
+  then Just (left , right + n)
+  else Nothing
+
+{-# COMPILE AGDA2HS landRight #-}
+
+routine : Maybe Pole
+routine = do
+    start ← return (0 , 0)
+    first ← landLeft 2 start
+    second ← landRight 2 first
+    landLeft 1 second
+
+{-# COMPILE AGDA2HS routine #-}

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -36,4 +36,4 @@ import Issue115
 import BangPatterns
 import Issue94
 import Importer
-
+import DoNotation

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -37,3 +37,4 @@ import BangPatterns
 import Issue94
 import Importer
 import DoNotation
+

--- a/test/golden/DoNotation.hs
+++ b/test/golden/DoNotation.hs
@@ -20,3 +20,9 @@ routine
        first <- landLeft 2 start
        landRight 2 first >>= landLeft 1
 
+routineWithoutDo :: Maybe Pole
+routineWithoutDo
+  = return (0, 0) >>=
+      \ start ->
+        landLeft 2 start >>= \ first -> landRight 2 first >>= landLeft 1
+

--- a/test/golden/DoNotation.hs
+++ b/test/golden/DoNotation.hs
@@ -1,0 +1,22 @@
+module DoNotation where
+
+type Birds = Int
+
+type Pole = (Birds, Birds)
+
+landLeft :: Birds -> Pole -> Maybe Pole
+landLeft n (left, right)
+  = if abs (left + n - right) < 4 then Just (left + n, right) else
+      Nothing
+
+landRight :: Birds -> Pole -> Maybe Pole
+landRight n (left, right)
+  = if abs (left - (right + n)) < 4 then Just (left, right + n) else
+      Nothing
+
+routine :: Maybe Pole
+routine
+  = do start <- return (0, 0)
+       first <- landLeft 2 start
+       landRight 2 first >>= landLeft 1
+


### PR DESCRIPTION
This is a first attempt at adding support for do-notation to Agda2Hs. There are still two problems with this implementation:

- It does not detect all uses of do-notation in Agda, see the test case. The reason is that Agda tries to eta-contract the second argument of `>>=`, but I currently rely on the presence of a lambda to turn `>>=` back into do-notation.
- Conversely, the current implementation will turn *all* occurrences of `>>=` where the second argument is a lambda into `do`-notation, even when the user didn't use do-notation in the Agda source.

Both problems could be prevented if only Agda would keep track of a bit more information, in particular about the origin of each `QName`: whether it was written by the user, generated by desugaring (such as for `do`-notation) or system-generated. Without this change to Agda, it seems very difficult to build better support for do-notation.