### PR TITLE
[ new ] Add support for transparent function that are inlined in Haskell code

### DIFF
--- a/src/Agda2Hs/Compile.hs
+++ b/src/Agda2Hs/Compile.hs
@@ -7,7 +7,7 @@ import Agda.TypeChecking.Pretty
 
 import Agda2Hs.Compile.ClassInstance ( compileInstance )
 import Agda2Hs.Compile.Data ( compileData )
-import Agda2Hs.Compile.Function ( compileFun )
+import Agda2Hs.Compile.Function ( compileFun, checkTransparentPragma )
 import Agda2Hs.Compile.Postulate ( compilePostulate )
 import Agda2Hs.Compile.Record ( compileRecord, checkUnboxPragma )
 import Agda2Hs.Compile.Types
@@ -33,6 +33,7 @@ compile _ m _ def = withCurrentModule m $ runC $ processPragma (defName def) >>=
     (NoPragma           , _      , _         ) -> return []
     (ExistingClassPragma, _      , _         ) -> return [] -- No code generation, but affects how projections are compiled
     (UnboxPragma        , _      , defn      ) -> checkUnboxPragma defn >> return [] -- also no code generation
+    (TransparentPragma  , _      , Function{}) -> checkTransparentPragma def >> return [] -- also no code generation
     (ClassPragma ms     , _      , Record{}  ) -> tag . single <$> compileRecord (ToClass ms) def
     (DefaultPragma ds   , _      , Datatype{}) -> tag <$> compileData ds def
     (DefaultPragma _    , Just _ , _         ) -> tag . single <$> compileInstance def

--- a/src/Agda2Hs/Compile.hs
+++ b/src/Agda2Hs/Compile.hs
@@ -40,6 +40,7 @@ compile _ m _ def = withCurrentModule m $ runC $ processPragma (defName def) >>=
     (DefaultPragma _    , _      , Axiom{}   ) -> tag <$> compilePostulate def
     (DefaultPragma _    , _      , Function{}) -> tag <$> compileFun def
     (DefaultPragma ds   , _      , Record{}  ) -> tag . single <$> compileRecord (ToRecord ds) def
-    _                                          -> return []
+    _                                          -> genericDocError =<< do
+      text "Don't know how to compile" <+> prettyTCM (defName def)
   where tag code = [(nameBindingSite $ qnameName $ defName def, code)]
         single x = [x]

--- a/src/Agda2Hs/Compile.hs
+++ b/src/Agda2Hs/Compile.hs
@@ -29,6 +29,8 @@ runC m = runReaderT m initCompileEnv
 compile :: Options -> ModuleEnv -> IsMain -> Definition -> TCM CompiledDef
 compile _ m _ def = withCurrentModule m $ runC $ processPragma (defName def) >>= \ p -> do
   reportSDoc "agda2hs.compile" 5 $ text "Compiling definition: " <+> prettyTCM (defName def)
+  reportSDoc "agda2hs.compile" 45 $ text "Pragma: " <+> text (show p)
+  reportSDoc "agda2hs.compile" 45 $ text "Compiling definition: " <+> pretty (theDef def)
   case (p , defInstance def , theDef def) of
     (NoPragma           , _      , _         ) -> return []
     (ExistingClassPragma, _      , _         ) -> return [] -- No code generation, but affects how projections are compiled

--- a/src/Agda2Hs/Compile/Function.hs
+++ b/src/Agda2Hs/Compile/Function.hs
@@ -252,7 +252,7 @@ checkTransparentPragma def = compileFun def >>= \case
 
     checkTransparentClause :: Hs.Match () -> C ()
     checkTransparentClause = \case
-      Hs.Match _ _ [Hs.PVar _ x] (Hs.UnGuardedRhs _ (Hs.Var _ (Hs.UnQual _ y))) _ | x == y -> return ()
+      Hs.Match _ _ [p] (Hs.UnGuardedRhs _ e) _ | patToExp p == Just e -> return ()
       _ -> errNotTransparent
 
     checkTransparentTypeDef :: Hs.DeclHead () -> Hs.Type () -> C ()

--- a/src/Agda2Hs/Compile/Term.hs
+++ b/src/Agda2Hs/Compile/Term.hs
@@ -181,7 +181,7 @@ compileTerm v = do
       | Just semantics <- isSpecialTerm f -> semantics f es
       | otherwise -> isClassFunction f >>= \ case
         True  -> compileClassFunApp f es
-        False -> isUnboxProjection f >>= \ case
+        False -> isUnboxProjection f `or2M` isTransparentFunction f >>= \ case
           True  -> compileErasedApp es
           False -> do
             -- Drop module parameters (unless projection-like)

--- a/src/Agda2Hs/Compile/Utils.hs
+++ b/src/Agda2Hs/Compile/Utils.hs
@@ -153,6 +153,15 @@ isUnboxProjection :: QName -> C Bool
 isUnboxProjection q =
   caseMaybeM (liftTCM $ getRecordOfField q) (return False) isUnboxRecord
 
+isTransparentFunction :: QName -> C Bool
+isTransparentFunction q = do
+  getConstInfo q >>= \case
+    Defn{defName = r, theDef = Function{}} ->
+      processPragma r <&> \case
+        TransparentPragma -> True
+        _                 -> False
+    _ -> return False
+
 checkInstance :: Term -> C ()
 checkInstance u | varOrDef u = liftTCM $ noConstraints $ do
   reportSDoc "agda2hs.checkInstance" 5 $ text "checkInstance" <+> prettyTCM u

--- a/src/Agda2Hs/Pragma.hs
+++ b/src/Agda2Hs/Pragma.hs
@@ -52,6 +52,7 @@ data ParsedPragma
   | ClassPragma [String]
   | ExistingClassPragma
   | UnboxPragma
+  | TransparentPragma
   deriving Show
 
 processPragma :: QName -> C ParsedPragma
@@ -61,6 +62,7 @@ processPragma qn = liftTCM (getUniqueCompilerPragma pragmaName qn) >>= \case
     | "class" `isPrefixOf` s    -> return $ ClassPragma (words $ drop 5 s)
     | s == "existing-class"     -> return ExistingClassPragma
     | s == "unboxed"            -> return UnboxPragma
+    | s == "transparent"        -> return TransparentPragma
     | "deriving" `isPrefixOf` s ->
       -- parse a deriving clause for a datatype by tacking it onto a
       -- dummy datatype and then only keeping the deriving part

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -32,6 +32,7 @@ import ScopedTypeVariables
 import LiteralPatterns
 import Issue92
 import HeightMirror
+import TransparentFun
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -65,4 +66,5 @@ import ScopedTypeVariables
 import LiteralPatterns
 import Issue92
 import HeightMirror
+import TransparentFun
 #-}

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -31,6 +31,7 @@ import UnboxPragma
 import ScopedTypeVariables
 import LiteralPatterns
 import Issue92
+import HeightMirror
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -63,4 +64,5 @@ import UnboxPragma
 import ScopedTypeVariables
 import LiteralPatterns
 import Issue92
+import HeightMirror
 #-}

--- a/test/HeightMirror.agda
+++ b/test/HeightMirror.agda
@@ -1,0 +1,34 @@
+
+open import Haskell.Prelude hiding (max)
+
+subst : (@0 p : @0 a → Set) {@0 m n : a} → @0 m ≡ n → p m → p n
+subst p refl t = t
+
+{-# COMPILE AGDA2HS subst transparent #-}
+
+max : Nat → Nat → Nat
+max zero    n       = n
+max (suc m) zero    = suc m
+max (suc m) (suc n) = suc (max m n)
+
+data Tree (a : Set) : (@0 height : Nat) → Set where
+  Tip : Tree a 0
+  Bin : ∀ {@0 l r} (x : a) → Tree a l → Tree a r → Tree a (suc (max l r))
+
+{-# COMPILE AGDA2HS Tree #-}
+
+@0 cong : (f : a → b) → {@0 x y : a} → @0 x ≡ y → f x ≡ f y
+cong f refl = refl
+
+@0 max-comm : (@0 l r : Nat) → max l r ≡ max r l
+max-comm zero zero = refl
+max-comm zero (suc r) = refl
+max-comm (suc l) zero = refl
+max-comm (suc l) (suc r) = cong suc (max-comm l r)
+
+mirror : ∀ {@0 h} → Tree a h → Tree a h
+mirror Tip = Tip
+mirror {a = a} (Bin {l} {r} x lt rt) =
+  subst (Tree a) (cong suc (max-comm r l)) (Bin x (mirror rt) (mirror lt))
+
+{-# COMPILE AGDA2HS mirror #-}

--- a/test/TransparentFun.agda
+++ b/test/TransparentFun.agda
@@ -1,0 +1,43 @@
+{-# OPTIONS -v agda2hs:50 #-}
+
+open import Haskell.Prelude
+
+data Unit : Set where
+  unit : Unit
+
+myId : @0 Unit → a → a
+myId unit x = x
+
+{-# COMPILE AGDA2HS myId transparent #-}
+
+testMyId : @0 Unit → Nat
+testMyId u = myId u 42
+
+{-# COMPILE AGDA2HS testMyId #-}
+
+tyId : @0 Unit → Set → Set
+tyId unit a = a
+
+{-# COMPILE AGDA2HS tyId transparent #-}
+
+testTyId : ∀ {@0 u : Unit} → tyId u (tyId u Int → tyId u Int)
+testTyId {unit} n = n
+
+{-# COMPILE AGDA2HS testTyId #-}
+
+data Tree : Set where
+  Tip : Tree
+  Bin : Tree → Tree → Tree
+
+{-# COMPILE AGDA2HS Tree #-}
+
+treeId : Tree → Tree
+treeId Tip = Tip
+treeId (Bin x y) = Bin (treeId x) (treeId y)
+
+{-# COMPILE AGDA2HS treeId transparent #-}
+
+testTreeId : Tree → Tree
+testTreeId = treeId
+
+{-# COMPILE AGDA2HS testTreeId #-}

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -31,4 +31,5 @@ import ScopedTypeVariables
 import LiteralPatterns
 import Issue92
 import HeightMirror
+import TransparentFun
 

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -30,4 +30,5 @@ import UnboxPragma
 import ScopedTypeVariables
 import LiteralPatterns
 import Issue92
+import HeightMirror
 

--- a/test/golden/HeightMirror.hs
+++ b/test/golden/HeightMirror.hs
@@ -1,0 +1,9 @@
+module HeightMirror where
+
+data Tree a = Tip
+            | Bin a (Tree a) (Tree a)
+
+mirror :: Tree a -> Tree a
+mirror Tip = Tip
+mirror (Bin x lt rt) = Bin x (mirror rt) (mirror lt)
+

--- a/test/golden/TransparentFun.hs
+++ b/test/golden/TransparentFun.hs
@@ -1,0 +1,16 @@
+module TransparentFun where
+
+import Numeric.Natural (Natural)
+
+testMyId :: Natural
+testMyId = 42
+
+testTyId :: Int -> Int
+testTyId n = n
+
+data Tree = Tip
+          | Bin Tree Tree
+
+testTreeId :: Tree -> Tree
+testTreeId = id
+


### PR DESCRIPTION
This allows us to get rid of function calls that are simply the identity after erasure, e.g. `subst`.