### PR TITLE
Compatibility with --erased-cubical

### DIFF
--- a/agda2hs.agda-lib
+++ b/agda2hs.agda-lib
@@ -1,3 +1,4 @@
 name: agda2hs
 depend:
 include: lib
+flags: --without-K

--- a/agda2hs.agda-lib
+++ b/agda2hs.agda-lib
@@ -1,4 +1,3 @@
 name: agda2hs
 depend:
 include: lib
-flags: --erase-record-parameters

--- a/lib/Haskell/Prim.agda
+++ b/lib/Haskell/Prim.agda
@@ -23,9 +23,9 @@ open import Agda.Builtin.Strict     public
 open import Agda.Builtin.List       public
 
 variable
-  @0 ℓ : Level
-  @0 a b c d e : Set
-  @0 f m s t : Set → Set
+  ℓ : Level
+  a b c d e : Set
+  f m s t : Set → Set
 
 
 --------------------------------------------------
@@ -93,7 +93,7 @@ lengthNat (_ ∷ xs) = addNat 1 (lengthNat xs)
 data ⊥ : Set where
 
 -- Use to bundle up constraints
-data All {@0 a b} {@0 A : Set a} (@0 B : A → Set b) : List A → Set (a ⊔ b) where
+data All {a b} {A : Set a} (B : A → Set b) : List A → Set (a ⊔ b) where
   instance
     allNil  : All B []
     allCons : ∀ {x xs} ⦃ i : B x ⦄ ⦃ is : All B xs ⦄ → All B (x ∷ xs)
@@ -104,7 +104,7 @@ data IsTrue : Bool → Set where
 data IsFalse : Bool → Set where
   instance itsFalse : IsFalse False
 
-data NonEmpty {@0 a : Set} : List a → Set where
+data NonEmpty {a : Set} : List a → Set where
   instance itsNonEmpty : ∀ {x xs} → NonEmpty (x ∷ xs)
 
 data TypeError (err : AgdaString) : Set where

--- a/lib/Haskell/Prim/Eq.agda
+++ b/lib/Haskell/Prim/Eq.agda
@@ -60,9 +60,13 @@ instance
   iEqTuple ._==_ (x ; xs) (y ; ys) = x == y && xs == ys
 
   iEqList : ⦃ Eq a ⦄ → Eq (List a)
-  iEqList ._==_ []       []       = True
-  iEqList ._==_ (x ∷ xs) (y ∷ ys) = x == y && xs == ys
-  iEqList ._==_ _        _        = False
+  iEqList {a} ._==_ = eqList
+    where
+      eqList : List a → List a → Bool
+      eqList [] [] = True
+      eqList (x ∷ xs) (y ∷ ys) = x == y && eqList xs ys
+      eqList _ _ = False
+
 
   iEqMaybe : ⦃ Eq a ⦄ → Eq (Maybe a)
   iEqMaybe ._==_ Nothing  Nothing  = True

--- a/lib/Haskell/Prim/Foldable.agda
+++ b/lib/Haskell/Prim/Foldable.agda
@@ -70,8 +70,11 @@ open Foldable ⦃ ... ⦄ public
 
 instance
   iFoldableList : Foldable List
-  iFoldableList .foldMap f []       = mempty
-  iFoldableList .foldMap f (x ∷ xs) = f x <> foldMap f xs
+  iFoldableList .foldMap = foldMapList
+    where
+      foldMapList : ⦃ Monoid b ⦄ → (a → b) → List a → b
+      foldMapList f []       = mempty
+      foldMapList f (x ∷ xs) = f x <> foldMapList f xs
 
   iFoldableMaybe : Foldable Maybe
   iFoldableMaybe .foldMap _ Nothing  = mempty

--- a/lib/Haskell/Prim/Thunk.agda
+++ b/lib/Haskell/Prim/Thunk.agda
@@ -6,7 +6,7 @@ open import Agda.Builtin.Size public
 
 open import Haskell.Prim
 
-record Thunk {ℓ} (a : @0 Size → Set ℓ) (@0 i : Size) : Set ℓ where
+record Thunk {ℓ} (a : Size → Set ℓ) (i : Size) : Set ℓ where
   constructor delay
   coinductive
   field force : {j : Size< i} → a j

--- a/lib/Haskell/Prim/Thunk.agda
+++ b/lib/Haskell/Prim/Thunk.agda
@@ -6,10 +6,10 @@ open import Agda.Builtin.Size public
 
 open import Haskell.Prim
 
-record Thunk {ℓ} (a : Size → Set ℓ) (i : Size) : Set ℓ where
+record Thunk {ℓ} (a : {j : Size} → Set ℓ) (i : Size) : Set ℓ where
   constructor delay
   coinductive
-  field force : {j : Size< i} → a j
+  field force : {j : Size< i} → a {j}
 open Thunk public
 
 {-# COMPILE AGDA2HS Thunk unboxed #-}

--- a/lib/Haskell/Prim/Traversable.agda
+++ b/lib/Haskell/Prim/Traversable.agda
@@ -35,8 +35,11 @@ open Traversable ⦃ ... ⦄ public
 
 instance
   iTraversableList : Traversable List
-  iTraversableList .traverse f []       = pure []
-  iTraversableList .traverse f (x ∷ xs) = ⦇ f x ∷ traverse f xs ⦈
+  iTraversableList .traverse = traverseList
+    where
+      traverseList : ⦃ Applicative f ⦄ → (a → f b) → List a → f (List b)
+      traverseList f []       = pure []
+      traverseList f (x ∷ xs) = ⦇ f x ∷ traverseList f xs ⦈
 
   iTraversableMaybe : Traversable Maybe
   iTraversableMaybe .traverse f Nothing  = pure Nothing

--- a/lib/Haskell/Prim/Tuple.agda
+++ b/lib/Haskell/Prim/Tuple.agda
@@ -4,7 +4,7 @@ module Haskell.Prim.Tuple where
 open import Haskell.Prim
 
 variable
-  @0 as : List Set
+  as : List Set
 
 --------------------------------------------------
 -- Tuples

--- a/src/Agda2Hs/Compile/Term.hs
+++ b/src/Agda2Hs/Compile/Term.hs
@@ -195,11 +195,9 @@ compileTerm v = do
       True  -> compileErasedApp es
       False -> (`app` es) . Hs.Con () =<< hsQName (conName h)
     Lit l -> compileLiteral l
-    Lam v b | usableModality v, getOrigin v == UserWritten -> do
-      unless (visible v) $ genericDocError =<< do
-        text "Implicit lambda not supported: " <+> prettyTCM (absName b)
+    Lam v b | keepArg v, getOrigin v == UserWritten -> do
       hsLambda (absName b) <$> underAbstr_ b compileTerm
-    Lam v b | usableModality v ->
+    Lam v b | keepArg v ->
       -- System-inserted lambda, no need to preserve the name.
       underAbstraction_ b $ \ body -> do
         unless (visible v) $ genericDocError =<< do

--- a/src/Agda2Hs/Compile/Term.hs
+++ b/src/Agda2Hs/Compile/Term.hs
@@ -200,8 +200,6 @@ compileTerm v = do
     Lam v b | keepArg v ->
       -- System-inserted lambda, no need to preserve the name.
       underAbstraction_ b $ \ body -> do
-        unless (visible v) $ genericDocError =<< do
-          text "Implicit lambda not supported: " <+> prettyTCM (absName b)
         x <- showTCM (Var 0 [])
         let hsx = hsVar x
         body <- compileTerm body

--- a/src/Agda2Hs/Compile/Utils.hs
+++ b/src/Agda2Hs/Compile/Utils.hs
@@ -102,7 +102,7 @@ underAbstr_ = underAbstr __DUMMY_DOM__
 -- Determine whether an argument should be kept or dropped.
 -- We drop all arguments that have quantity 0 (= run-time erased).
 -- We also drop hidden non-erased arguments (which should all be of
--- type Level or Set l).
+-- type Level, Set l, or Size).
 keepArg :: (LensHiding a, LensModality a) => a -> Bool
 keepArg x = usableModality x && visible x
 

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -33,7 +33,6 @@ import LiteralPatterns
 import Issue92
 import HeightMirror
 import TransparentFun
--- import StreamFusion TODO: cannot import b/c of --erased-cubical flag
 
 {-# FOREIGN AGDA2HS
 import Issue14

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -33,6 +33,7 @@ import LiteralPatterns
 import Issue92
 import HeightMirror
 import TransparentFun
+-- import StreamFusion TODO: cannot import b/c of --erased-cubical flag
 
 {-# FOREIGN AGDA2HS
 import Issue14

--- a/test/Coinduction.agda
+++ b/test/Coinduction.agda
@@ -5,13 +5,13 @@ module Coinduction where
 open import Haskell.Prelude
 open import Haskell.Prim.Thunk
 
-data Colist (a : Set) (@0 i : Size) : Set where
-  Nil  : Colist a i
-  Cons : a -> Thunk (Colist a) i -> Colist a i
+data Colist (a : Set) {i : Size} : Set where
+  Nil  : Colist a
+  Cons : a -> Thunk (λ {j} → Colist a {j}) i -> Colist a {i}
 
 {-# COMPILE AGDA2HS Colist #-}
 
-repeater : ∀ {a i} → a → Colist a i
+repeater : ∀ {a i} → a → Colist a {i}
 repeater x = Cons x λ where .force → repeater x
 
 {-# COMPILE AGDA2HS repeater #-}

--- a/test/CubicalTests.agda
+++ b/test/CubicalTests.agda
@@ -1,0 +1,9 @@
+{-# OPTIONS --erased-cubical #-}
+
+module CubicalTests where
+
+import StreamFusion
+
+{-# FOREIGN AGDA2HS
+import StreamFusion
+#-}

--- a/test/DefaultMethods.agda
+++ b/test/DefaultMethods.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --no-auto-inline --erase-record-parameters #-}
+{-# OPTIONS --no-auto-inline #-}
 module DefaultMethods where
 
 open import Haskell.Prim

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,9 +1,9 @@
 
-.PHONY : default clean golden alltests fail print-fail compare force-recompile
+.PHONY : default clean golden alltests cubicaltests fail print-fail compare force-recompile
 
 ROOT=$(shell cd ..; pwd)/
 
-default : clean alltests fail compare
+default : clean alltests cubicaltests fail compare
 
 clean :
 	@rm -rf build/*
@@ -13,6 +13,12 @@ alltests :
 	./agda2hs AllTests.agda -o build
 	@echo == Running ghc ==
 	@(cd build; ghc -fno-code -XScopedTypeVariables AllTests.hs)
+
+cubicaltests :
+	@echo == Compiling tests using cubical ==
+	./agda2hs CubicalTests.agda -o build
+	@echo == Running ghc ==
+	@(cd build; ghc -fno-code -XScopedTypeVariables CubicalTests.hs)
 
 compare :
 	@echo == Comparing output ==

--- a/test/ScopedTypeVariables.agda
+++ b/test/ScopedTypeVariables.agda
@@ -3,7 +3,7 @@ module ScopedTypeVariables where
 open import Haskell.Prelude
 
 -- We can encode explicit `forall` quantification by module parameters in Agda.
-module _ {@0 a : Set} {{_ : Eq a}} where
+module _ {a : Set} {{_ : Eq a}} where
   foo : a → Bool
   foo x = it x == x
     where
@@ -12,7 +12,7 @@ module _ {@0 a : Set} {{_ : Eq a}} where
 {-# COMPILE AGDA2HS foo #-}
 
 -- Type arguments should be compiled in the right order.
-module _ {@0 a b : Set} where
+module _ {a b : Set} where
   bar : a → b → (b → b) → b
   bar x y f = baz y
     where

--- a/test/StreamFusion.agda
+++ b/test/StreamFusion.agda
@@ -1,0 +1,29 @@
+{-# OPTIONS --erased-cubical #-}
+
+open import Haskell.Prelude
+
+open import Agda.Primitive
+open import Agda.Primitive.Cubical
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Size
+
+variable
+  i : Size
+
+record Stream (a : Set) {i : Size} : Set where
+  pattern; inductive; constructor _:>_
+  field
+    shead : a
+    stail : ∀ {j} → Stream a {j}
+open Stream public
+
+{-# COMPILE AGDA2HS Stream #-}
+
+smap  : (a → b) → Stream a {i} → Stream b {i}
+smap  f (x :> xs) = (f x) :> smap f xs
+
+{-# COMPILE AGDA2HS smap #-}
+
+smap-fusion  : (f : a → b) (g : b → c) (s : Stream a {i})
+             → PathP (λ _ → Stream c {i}) (smap {i = i} g (smap {i = i} f s)) (smap {i = i} (λ x → g (f x)) s)
+smap-fusion  f g (hd :> tl) i = (g (f hd)) :> smap-fusion f g tl i

--- a/test/TransparentFun.agda
+++ b/test/TransparentFun.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS -v agda2hs:50 #-}
 
 open import Haskell.Prelude
 

--- a/test/golden/CubicalTests.hs
+++ b/test/golden/CubicalTests.hs
@@ -1,0 +1,4 @@
+module CubicalTests where
+
+import StreamFusion
+

--- a/test/golden/StreamFusion.hs
+++ b/test/golden/StreamFusion.hs
@@ -1,0 +1,7 @@
+module StreamFusion where
+
+data Stream a = (:>){shead :: a, stail :: Stream a}
+
+smap :: (a -> b) -> Stream a -> Stream b
+smap f (x :> xs) = f x :> smap f xs
+

--- a/test/golden/StreamFusion.hs
+++ b/test/golden/StreamFusion.hs
@@ -1,7 +1,0 @@
-module StreamFusion where
-
-data Stream a = (:>){shead :: a, stail :: Stream a}
-
-smap :: (a -> b) -> Stream a -> Stream b
-smap f (x :> xs) = f x :> smap f xs
-


### PR DESCRIPTION
It would be cool if we could use `--erased-cubical` together with Agda2Hs so we can use cubical features to prove things such as functional extensionality and that bisimilarity implies equality for coinductive data structures. It would also enable the use of (erased) higher constructors to enforce that functions on a given datatype always respect certain semantic equivalences.

This PR makes three relatively small changes to enable this:
- Remove erasure annotations from levels and types (see https://github.com/agda/agda/issues/6114)
- Rewrite a few functions in the prelude to make them pass the stricter `--without-K` termination checker
- Make arguments of type `Size` implicit so they are erased even without a `@0` annotation (basically giving them the same treatment as levels)