### PR TITLE
Pattern matching with Nat literals

### DIFF
--- a/src/Agda2Hs/Compile/Function.hs
+++ b/src/Agda2Hs/Compile/Function.hs
@@ -46,6 +46,8 @@ isSpecialPat = prettyShow >>> \ case
   "Haskell.Prim.Tuple._;_" -> Just tuplePat
   "Agda.Builtin.Int.Int.pos" -> Just posIntPat
   "Agda.Builtin.Int.Int.negsuc" -> Just negSucIntPat
+  "Agda.Builtin.Nat.Nat.zero" -> Just zeroNatPat
+  "Agda.Builtin.Nat.Nat.suc" -> Just sucNatPat
   _ -> Nothing
 
 isUnboxCopattern :: DeBruijnPattern -> C Bool
@@ -85,6 +87,15 @@ negSucIntPat c i [p] = do
   n <- (1+) <$> compileLitNatPat (namedArg p)
   return $ Hs.PLit () (Hs.Negative ()) (Hs.Int () n (show (negate n)))
 negSucIntPat _ _ _ = __IMPOSSIBLE__
+
+zeroNatPat :: ConHead -> ConPatternInfo -> [NamedArg DeBruijnPattern] -> C (Hs.Pat ())
+zeroNatPat _ _ _ = return $ Hs.PLit () (Hs.Signless ()) (Hs.Int () 0 "0")
+
+sucNatPat :: ConHead -> ConPatternInfo -> [NamedArg DeBruijnPattern] -> C (Hs.Pat ())
+sucNatPat _ _ [p] = do
+  n <- (1+) <$> compileLitNatPat (namedArg p)
+  return $ Hs.PLit () (Hs.Signless ()) (Hs.Int () n (show n))
+sucNatPat _ _ _ = __IMPOSSIBLE__
 
 -- The bool argument says whether we also want the type signature or just the body
 compileFun, compileFun' :: Bool -> Definition -> C [Hs.Decl ()]

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -39,6 +39,7 @@ import Issue94
 import Issue107
 import Importer
 import DoNotation
+import NatLitPat
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -78,4 +79,5 @@ import BangPatterns
 import Issue94
 import Importer
 import DoNotation
+import NatLitPat
 #-}

--- a/test/NatLitPat.agda
+++ b/test/NatLitPat.agda
@@ -1,0 +1,43 @@
+module NatLitPat where
+
+open import Agda.Builtin.Equality using (_≡_ ; refl)
+open import Haskell.Prelude
+
+data RecHelp₁ : Nat → Set where
+  ≡0 : RecHelp₁ 0
+  ≢0 : {n : Nat} → ⦃ _ : Num.MinusOK iNumNat n 1 ⦄ → RecHelp₁ (n - 1) → RecHelp₁ n
+
+data RecHelp₂ : Nat → Set where
+  ≡0 : RecHelp₂ 0
+  ≡1 : RecHelp₂ 1
+  >1 : {n : Nat} → ⦃ _ : Num.MinusOK iNumNat n 1 ⦄ → ⦃ _ : Num.MinusOK iNumNat n 2 ⦄ →
+       RecHelp₂ (n - 1) → RecHelp₂ (n - 2) → RecHelp₂ n
+
+instance
+  @0 recHelp₁ : {n : Nat} → RecHelp₁ n
+  recHelp₁ {zero}  = ≡0
+  recHelp₁ {suc n} = ≢0 (recHelp₁ {n})
+
+  @0 recHelp₂ : {n : Nat} → RecHelp₂ n
+  recHelp₂ {zero}        = ≡0
+  recHelp₂ {suc 0}       = ≡1
+  recHelp₂ {suc (suc n)} = >1 (recHelp₂ {suc n}) (recHelp₂ {n})
+
+fac : (n : Nat) → ⦃ @0 _ : RecHelp₁ n ⦄ → Nat
+fac 0          = 1
+fac n ⦃ ≢0 r ⦄ = n * fac (n - 1) ⦃ r ⦄
+
+{-# COMPILE AGDA2HS fac #-}
+
+fib : (n : Nat) → ⦃ @0 _ : RecHelp₂ n ⦄ → Nat
+fib 0              = 0
+fib 1              = 1
+fib n ⦃ >1 r₁ r₂ ⦄ = fib (n - 1) ⦃ r₁ ⦄ + fib (n - 2) ⦃ r₂ ⦄
+
+{-# COMPILE AGDA2HS fib #-}
+
+proof₁ : fac 5 ≡ 120
+proof₁ = refl
+
+proof₂ : fib 10 ≡ 55
+proof₂ = refl

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -37,4 +37,5 @@ import BangPatterns
 import Issue94
 import Importer
 import DoNotation
+import NatLitPat
 

--- a/test/golden/NatLitPat.hs
+++ b/test/golden/NatLitPat.hs
@@ -1,0 +1,13 @@
+module NatLitPat where
+
+import Numeric.Natural (Natural)
+
+fac :: Natural -> Natural
+fac 0 = 1
+fac n = n * fac (n - 1)
+
+fib :: Natural -> Natural
+fib 0 = 0
+fib 1 = 1
+fib n = fib (n - 1) + fib (n - 2)
+


### PR DESCRIPTION
A proposal to add pattern matching with Nat literals to `agda2hs`.

Includes the factorial and Fibonacci function over `Nat` as examples.

Just an idea. Feel free to close, if this is too specific to my use cases.

Coming up with the recursion schemes for the examples included quite a bit of trial and error. And I still don't fully understand, why Agda accepts, for example, the `>1` constructor in the last clause of `fib`. Agda seems to magically rule out `≡0` and `≡1`, so that `>1` is the only option and thus doesn't complain about a pattern match with an erased function argument. Same for the `≢0` in the last clause of `fac`.

In any case, this seems to address my need for basic "count down from n to 0" Nat recursion.