### PR TITLE
Fix errors in setup documentation

### DIFF
--- a/docs/source/introduction.md
+++ b/docs/source/introduction.md
@@ -25,20 +25,20 @@ cd agda2hs
 cabal install
 
 # register the agda2hs Agda library
-echo $DIR/agda2hs/agda2hs.agda-lib >> ~/.agda/libraries
+echo $(pwd)/agda2hs.agda-lib >> ~/.agda/libraries
 # register the agda2hs Agda library as a default
-echo $DIR/agda2hs/agda2hs.agda-lib >> ~/.agda/defaults
+echo agda2hs >> ~/.agda/defaults
 ```
 
 ### Running `agda2hs`
 
 To run agda2hs, run
 ```
-agda2hs <path>/<name>.agda
+agda2hs <path>/<name>.agda [-o <outputDir>]
 ```
-which compiles and writes
+which, for all dependencies of that Agda file, compiles and writes
 ```
-<path>/<name>.hs
+[<outputDir>/]<modulePath>.hs
 ```
 
 ### Using agda2hs with Stack


### PR DESCRIPTION
* fix paths and output when registering Agda2HS as a library
* fix information about where Agda2HS will output the Haskell file(s)