### PR TITLE
Add support for qualified imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ test/agda2hs
 docs/build/
 test/*.hs
 test/Haskell
+*.hi
+*.o

--- a/agda2hs.cabal
+++ b/agda2hs.cabal
@@ -68,5 +68,6 @@ executable agda2hs
                        RecordWildCards,
                        FlexibleContexts,
                        MultiWayIf,
-                       TupleSections
+                       TupleSections,
+                       ScopedTypeVariables
   ghc-options:         -Werror

--- a/lib/Haskell/Prim/Bounded.agda
+++ b/lib/Haskell/Prim/Bounded.agda
@@ -27,8 +27,8 @@ record Bounded (a : Set) : Set where
 
 {-# COMPILE AGDA2HS Bounded existing-class #-}
 
-open BoundedBelow ⦃ ... ⦄ public
-open BoundedAbove ⦃ ... ⦄ public
+open BoundedBelow ⦃...⦄ public
+open BoundedAbove ⦃...⦄ public
 
 instance
   iBounded : ⦃ BoundedBelow a ⦄ → ⦃ BoundedAbove a ⦄ → Bounded a

--- a/lib/Haskell/Prim/Enum.agda
+++ b/lib/Haskell/Prim/Enum.agda
@@ -78,7 +78,7 @@ record Enum (a : Set) : Set₁ where
     enumFromThenTo : (x x₁ : a) → ⦃ IsFalse (fromEnum x == fromEnum x₁) ⦄ → a → List a
     enumFromThen   : ⦃ IsBoundedBelow ⦄ → ⦃ IsBoundedAbove ⦄ → (x x₁ : a) → ⦃ IsFalse (fromEnum x == fromEnum x₁) ⦄ → List a
 
-open Enum ⦃ ... ⦄ public
+open Enum ⦃...⦄ public
 
 {-# COMPILE AGDA2HS Enum existing-class #-}
 

--- a/lib/Haskell/Prim/Eq.agda
+++ b/lib/Haskell/Prim/Eq.agda
@@ -22,7 +22,7 @@ record Eq (a : Set) : Set where
   _/=_ : a → a → Bool
   x /= y = not (x == y)
 
-open Eq ⦃ ... ⦄ public
+open Eq ⦃...⦄ public
 
 {-# COMPILE AGDA2HS Eq existing-class #-}
 

--- a/lib/Haskell/Prim/Foldable.agda
+++ b/lib/Haskell/Prim/Foldable.agda
@@ -19,54 +19,54 @@ record Foldable (t : Set → Set) : Set₁ where
   field
     foldMap : ⦃ Monoid b ⦄ → (a → b) → t a → b
 
-  foldr : (a → b → b) → b → t a → b
-  foldr f z t = foldMap ⦃ MonoidEndo ⦄ f t z
-
-  foldl : (b → a → b) → b → t a → b
-  foldl f z t = foldMap ⦃ MonoidEndoᵒᵖ ⦄ (flip f) t z
-
-  any : (a → Bool) → t a → Bool
-  any = foldMap ⦃ MonoidDisj ⦄
-
-  all : (a → Bool) → t a → Bool
-  all = foldMap ⦃ MonoidConj ⦄
-
-  and : t Bool → Bool
-  and = all id
-
-  or : t Bool → Bool
-  or = any id
-
-  null : t a → Bool
-  null = all (const False)
-
-  concat : t (List a) → List a
-  concat = foldMap id
-
-  concatMap : (a → List b) → t a → List b
-  concatMap = foldMap
-
-  elem : ⦃ Eq a ⦄ → a → t a → Bool
-  elem x = foldMap ⦃ MonoidDisj ⦄ (x ==_)
-
-  notElem : ⦃ Eq a ⦄ → a → t a → Bool
-  notElem x t = not (elem x t)
-
-  toList : t a → List a
-  toList = foldr _∷_ []
-
-  sum : ⦃ iNum : Num a ⦄ → t a → a
-  sum = foldMap ⦃ MonoidSum ⦄ id
-
-  product : ⦃ iNum : Num a ⦄ → t a → a
-  product = foldMap ⦃ MonoidProduct ⦄ id
-
-  length : t a → Int
-  length = foldMap ⦃ MonoidSum ⦄ (const 1)
-
 open Foldable ⦃ ... ⦄ public
 
 {-# COMPILE AGDA2HS Foldable existing-class #-}
+
+foldr : ⦃ Foldable t ⦄ → (a → b → b) → b → t a → b
+foldr f z t = foldMap ⦃ it ⦄ ⦃ MonoidEndo ⦄ f t z
+
+foldl : ⦃ Foldable t ⦄ → (b → a → b) → b → t a → b
+foldl f z t = foldMap ⦃ it ⦄ ⦃ MonoidEndoᵒᵖ ⦄ (flip f) t z
+
+any : ⦃ Foldable t ⦄ → (a → Bool) → t a → Bool
+any = foldMap ⦃ it ⦄ ⦃ MonoidDisj ⦄
+
+all : ⦃ Foldable t ⦄ → (a → Bool) → t a → Bool
+all = foldMap ⦃ it ⦄ ⦃ MonoidConj ⦄
+
+and : ⦃ Foldable t ⦄ → t Bool → Bool
+and = all id
+
+or : ⦃ Foldable t ⦄ → t Bool → Bool
+or = any id
+
+null : ⦃ Foldable t ⦄ → t a → Bool
+null = all (const False)
+
+concat : ⦃ Foldable t ⦄ → t (List a) → List a
+concat = foldMap id
+
+concatMap : ⦃ Foldable t ⦄ → (a → List b) → t a → List b
+concatMap = foldMap
+
+elem : ⦃ Foldable t ⦄ → ⦃ Eq a ⦄ → a → t a → Bool
+elem x = foldMap ⦃ it ⦄ ⦃ MonoidDisj ⦄ (x ==_)
+
+notElem : ⦃ Foldable t ⦄ → ⦃ Eq a ⦄ → a → t a → Bool
+notElem x t = not (elem x t)
+
+toList : ⦃ Foldable t ⦄ → t a → List a
+toList = foldr _∷_ []
+
+sum : ⦃ Foldable t ⦄ → ⦃ iNum : Num a ⦄ → t a → a
+sum = foldMap ⦃ it ⦄ ⦃ MonoidSum ⦄ id
+
+product : ⦃ Foldable t ⦄ → ⦃ iNum : Num a ⦄ → t a → a
+product = foldMap ⦃ it ⦄ ⦃ MonoidProduct ⦄ id
+
+length : ⦃ Foldable t ⦄ → t a → Int
+length = foldMap ⦃ it ⦄ ⦃ MonoidSum ⦄ (const 1)
 
 instance
   iFoldableList : Foldable List

--- a/lib/Haskell/Prim/Foldable.agda
+++ b/lib/Haskell/Prim/Foldable.agda
@@ -2,7 +2,7 @@
 module Haskell.Prim.Foldable where
 
 open import Haskell.Prim
-open import Haskell.Prim.Num
+open import Haskell.Prim.Num hiding (abs)
 open import Haskell.Prim.Eq
 open import Haskell.Prim.List
 open import Haskell.Prim.Int
@@ -15,74 +15,101 @@ open import Haskell.Prim.Monoid
 --------------------------------------------------
 -- Foldable
 
+-- ** base
 record Foldable (t : Set → Set) : Set₁ where
   field
     foldMap : ⦃ Monoid b ⦄ → (a → b) → t a → b
+    foldr : (a → b → b) → b → t a → b
+    foldl : (b → a → b) → b → t a → b
+    any : (a → Bool) → t a → Bool
+    all : (a → Bool) → t a → Bool
+    and : t Bool → Bool
+    null : t a → Bool
+    or : t Bool → Bool
+    concat : t (List a) → List a
+    concatMap : (a → List b) → t a → List b
+    elem : ⦃ Eq a ⦄ → a → t a → Bool
+    notElem : ⦃ Eq a ⦄ → a → t a → Bool
+    toList : t a → List a
+    sum : ⦃ iNum : Num a ⦄ → t a → a
+    product : ⦃ iNum : Num a ⦄ → t a → a
+    length : t a → Int
+-- ** defaults
+record DefaultFoldable (t : Set → Set) : Set₁ where
+  module M = Foldable {t = t}
+  field foldMap : ⦃ Monoid b ⦄ → (a → b) → t a → b
 
-open Foldable ⦃ ... ⦄ public
+  foldr : (a → b → b) → b → t a → b
+  foldr f z t = foldMap ⦃ MonoidEndo ⦄ f t z
 
+  foldl : (b → a → b) → b → t a → b
+  foldl f z t = foldMap ⦃ MonoidEndoᵒᵖ ⦄ (flip f) t z
+
+  any : (a → Bool) → t a → Bool
+  any = foldMap ⦃ MonoidDisj ⦄
+
+  all : (a → Bool) → t a → Bool
+  all = foldMap ⦃ MonoidConj ⦄
+
+  and : t Bool → Bool
+  and = all id
+
+  or : t Bool → Bool
+  or = any id
+
+  null : t a → Bool
+  null = all (const False)
+
+  concat : t (List a) → List a
+  concat = foldMap id
+
+  concatMap : (a → List b) → t a → List b
+  concatMap = foldMap
+
+  elem : ⦃ Eq a ⦄ → a → t a → Bool
+  elem x = foldMap ⦃ MonoidDisj ⦄ (x ==_)
+
+  notElem : ⦃ Eq a ⦄ → a → t a → Bool
+  notElem x t = not (elem x t)
+
+  toList : t a → List a
+  toList = foldr _∷_ []
+
+  sum : ⦃ iNum : Num a ⦄ → t a → a
+  sum = foldMap ⦃ MonoidSum ⦄ id
+
+  product : ⦃ iNum : Num a ⦄ → t a → a
+  product = foldMap ⦃ MonoidProduct ⦄ id
+
+  length : t a → Int
+  length = foldMap ⦃ MonoidSum ⦄ (const 1)
+-- ** export
+open Foldable ⦃...⦄ public
 {-# COMPILE AGDA2HS Foldable existing-class #-}
+-- ** instances
+private
+  mkFoldable : DefaultFoldable t → Foldable t
+  mkFoldable x = record {DefaultFoldable x}
 
-foldr : ⦃ Foldable t ⦄ → (a → b → b) → b → t a → b
-foldr f z t = foldMap ⦃ it ⦄ ⦃ MonoidEndo ⦄ f t z
-
-foldl : ⦃ Foldable t ⦄ → (b → a → b) → b → t a → b
-foldl f z t = foldMap ⦃ it ⦄ ⦃ MonoidEndoᵒᵖ ⦄ (flip f) t z
-
-any : ⦃ Foldable t ⦄ → (a → Bool) → t a → Bool
-any = foldMap ⦃ it ⦄ ⦃ MonoidDisj ⦄
-
-all : ⦃ Foldable t ⦄ → (a → Bool) → t a → Bool
-all = foldMap ⦃ it ⦄ ⦃ MonoidConj ⦄
-
-and : ⦃ Foldable t ⦄ → t Bool → Bool
-and = all id
-
-or : ⦃ Foldable t ⦄ → t Bool → Bool
-or = any id
-
-null : ⦃ Foldable t ⦄ → t a → Bool
-null = all (const False)
-
-concat : ⦃ Foldable t ⦄ → t (List a) → List a
-concat = foldMap id
-
-concatMap : ⦃ Foldable t ⦄ → (a → List b) → t a → List b
-concatMap = foldMap
-
-elem : ⦃ Foldable t ⦄ → ⦃ Eq a ⦄ → a → t a → Bool
-elem x = foldMap ⦃ it ⦄ ⦃ MonoidDisj ⦄ (x ==_)
-
-notElem : ⦃ Foldable t ⦄ → ⦃ Eq a ⦄ → a → t a → Bool
-notElem x t = not (elem x t)
-
-toList : ⦃ Foldable t ⦄ → t a → List a
-toList = foldr _∷_ []
-
-sum : ⦃ Foldable t ⦄ → ⦃ iNum : Num a ⦄ → t a → a
-sum = foldMap ⦃ it ⦄ ⦃ MonoidSum ⦄ id
-
-product : ⦃ Foldable t ⦄ → ⦃ iNum : Num a ⦄ → t a → a
-product = foldMap ⦃ it ⦄ ⦃ MonoidProduct ⦄ id
-
-length : ⦃ Foldable t ⦄ → t a → Int
-length = foldMap ⦃ it ⦄ ⦃ MonoidSum ⦄ (const 1)
-
+  foldMap=_ : (∀ {b a} → ⦃ Monoid b ⦄ → (a → b) → t a → b) → Foldable t
+  foldMap= x = record {DefaultFoldable (record {foldMap = x})}
 instance
   iFoldableList : Foldable List
-  iFoldableList .foldMap = foldMapList
+  iFoldableList = foldMap= foldMapList
     where
       foldMapList : ⦃ Monoid b ⦄ → (a → b) → List a → b
       foldMapList f []       = mempty
       foldMapList f (x ∷ xs) = f x <> foldMapList f xs
 
   iFoldableMaybe : Foldable Maybe
-  iFoldableMaybe .foldMap _ Nothing  = mempty
-  iFoldableMaybe .foldMap f (Just x) = f x
+  iFoldableMaybe = foldMap= λ where
+    _ Nothing  → mempty
+    f (Just x) → f x
 
   iFoldableEither : Foldable (Either a)
-  iFoldableEither .foldMap _ (Left _) = mempty
-  iFoldableEither .foldMap f (Right x) = f x
+  iFoldableEither = foldMap= λ where
+    _ (Left _)  → mempty
+    f (Right x) → f x
 
   iFoldablePair : Foldable (a ×_)
-  iFoldablePair .foldMap f (_ , x) = f x
+  iFoldablePair = foldMap= λ f (_ , x) → f x

--- a/lib/Haskell/Prim/Functor.agda
+++ b/lib/Haskell/Prim/Functor.agda
@@ -10,9 +10,20 @@ open import Haskell.Prim.Tuple
 --------------------------------------------------
 -- Functor
 
+-- ** base
 record Functor (f : Set → Set) : Set₁ where
+  infixl 1 _<&>_
+  infixl 4 _<$>_ _<$_ _$>_
   field
     fmap : (a → b) → f a → f b
+    _<$>_ : (a → b) → f a → f b
+    _<&>_ : f a → (a → b) → f b
+    _<$_ : a → f b → f a
+    _$>_ : f a → b → f b
+    void : f a → f (Tuple [])
+-- ** defaults
+record DefaultFunctor (f : Set → Set) : Set₁ where
+  field fmap : (a → b) → f a → f b
 
   infixl 1 _<&>_
   infixl 4 _<$>_ _<$_ _$>_
@@ -31,31 +42,38 @@ record Functor (f : Set → Set) : Set₁ where
 
   void : f a → f (Tuple [])
   void = tt <$_
-
-open Functor ⦃ ... ⦄ public
-
+-- ** export
+open Functor ⦃...⦄ public
 {-# COMPILE AGDA2HS Functor existing-class #-}
+-- ** instances
+private
+  mkFunctor : DefaultFunctor t → Functor t
+  mkFunctor x = record {DefaultFunctor x}
 
+  fmap=_ : (∀ {a b} → (a → b) → f a → f b) → Functor f
+  fmap= x = record {DefaultFunctor (record {fmap = x})}
 instance
   iFunctorList : Functor List
-  iFunctorList .fmap = map
+  iFunctorList = fmap= map
 
   iFunctorMaybe : Functor Maybe
-  iFunctorMaybe .fmap f Nothing  = Nothing
-  iFunctorMaybe .fmap f (Just x) = Just (f x)
+  iFunctorMaybe = fmap= λ where
+    f Nothing  → Nothing
+    f (Just x) → Just (f x)
 
   iFunctorEither : Functor (Either a)
-  iFunctorEither .fmap f (Left  x) = Left x
-  iFunctorEither .fmap f (Right y) = Right (f y)
+  iFunctorEither = fmap= λ where
+    f (Left  x) → Left x
+    f (Right y) → Right (f y)
 
   iFunctorFun : Functor (λ b → a → b)
-  iFunctorFun .fmap = _∘_
+  iFunctorFun = fmap= _∘_
 
   iFunctorTuple₂ : Functor (a ×_)
-  iFunctorTuple₂ .fmap f (x , y) = x , f y
+  iFunctorTuple₂ = fmap= λ f (x , y) → x , f y
 
   iFunctorTuple₃ : Functor (a × b ×_)
-  iFunctorTuple₃ .fmap f (x , y , z) = x , y , f z
+  iFunctorTuple₃ = fmap= λ f (x , y , z) → x , y , f z
 
   iFunctorTuple₄ : Functor (λ d → Tuple (a ∷ b ∷ c ∷ d ∷ []))
-  iFunctorTuple₄ .fmap f (x ; y ; z ; w ; tt) = x ; y ; z ; f w ; tt
+  iFunctorTuple₄ = fmap= λ f (x ; y ; z ; w ; tt) → x ; y ; z ; f w ; tt

--- a/lib/Haskell/Prim/Monad.agda
+++ b/lib/Haskell/Prim/Monad.agda
@@ -15,32 +15,39 @@ open import Haskell.Prim.Tuple
 --------------------------------------------------
 -- Monad
 
-record Monad (m : Set → Set) : Set₁ where
-  field
-    _>>=_ : m a → (a → m b) → m b
-    overlap ⦃ super ⦄ : Applicative m
+module Do where
 
-  return : a → m a
+  record Monad (m : Set → Set) : Set₁ where
+    field
+      _>>=_ : m a → (a → m b) → m b
+      overlap ⦃ super ⦄ : Applicative m
+
+  open Monad ⦃ ... ⦄ public
+
+  {-# COMPILE AGDA2HS Monad existing-class #-}
+
+  return : ⦃ Monad m ⦄ → a → m a
   return = pure
 
-  _>>_ : m a → m b → m b
+  _>>_ : ⦃ Monad m ⦄ → m a → m b → m b
   m >> m₁ = m >>= λ _ → m₁
 
-  _=<<_ : (a → m b) → m a → m b
+  _=<<_ : ⦃ Monad m ⦄ → (a → m b) → m a → m b
   _=<<_ = flip _>>=_
 
 -- Use `Dont._>>=_` and `Dont._>>_` if you do not want agda2hs to use
 -- do-notation.
 module Dont where
+
+  open Do using (Monad)
+
   _>>=_ : ⦃ Monad m ⦄ → m a → (a → m b) → m b
-  _>>=_ = Monad._>>=_ it
+  _>>=_ = Do._>>=_
 
   _>>_ : ⦃ Monad m ⦄ → m a → m b → m b
-  _>>_ = Monad._>>_ it
+  _>>_ = Do._>>_
 
-open Monad ⦃ ... ⦄ public
-
-{-# COMPILE AGDA2HS Monad existing-class #-}
+open Do public
 
 mapM₋ : ⦃ Monad m ⦄ → ⦃ Foldable t ⦄ → (a → m b) → t a → m ⊤
 mapM₋ f = foldr (λ x k → f x >> k) (pure tt)

--- a/lib/Haskell/Prim/Monad.agda
+++ b/lib/Haskell/Prim/Monad.agda
@@ -17,23 +17,30 @@ open import Haskell.Prim.Tuple
 
 module Do where
 
+  -- ** base
   record Monad (m : Set → Set) : Set₁ where
     field
       _>>=_ : m a → (a → m b) → m b
       overlap ⦃ super ⦄ : Applicative m
+      return : a → m a
+      _>>_ : m a → m b → m b
+      _=<<_ : (a → m b) → m a → m b
+  -- ** defaults
+  record DefaultMonad (m : Set → Set) : Set₁ where
+    field
+      _>>=_ : m a → (a → m b) → m b
+      overlap ⦃ super ⦄ : Applicative m
+    return : a → m a
+    return = pure
 
-  open Monad ⦃ ... ⦄ public
+    _>>_ : m a → m b → m b
+    m >> m₁ = m >>= λ _ → m₁
 
+    _=<<_ : (a → m b) → m a → m b
+    _=<<_ = flip _>>=_
+  -- ** export
+  open Monad ⦃...⦄ public
   {-# COMPILE AGDA2HS Monad existing-class #-}
-
-  return : ⦃ Monad m ⦄ → a → m a
-  return = pure
-
-  _>>_ : ⦃ Monad m ⦄ → m a → m b → m b
-  m >> m₁ = m >>= λ _ → m₁
-
-  _=<<_ : ⦃ Monad m ⦄ → (a → m b) → m a → m b
-  _=<<_ = flip _>>=_
 
 -- Use `Dont._>>=_` and `Dont._>>_` if you do not want agda2hs to use
 -- do-notation.
@@ -55,30 +62,38 @@ mapM₋ f = foldr (λ x k → f x >> k) (pure tt)
 sequence₋ : ⦃ Monad m ⦄ → ⦃ Foldable t ⦄ → t (m a) → m ⊤
 sequence₋ = foldr _>>_ (pure tt)
 
+-- ** instances
+private
+  mkMonad : DefaultMonad t → Monad t
+  mkMonad x = record {DefaultMonad x}
+
+  infix 0 bind=_
+  bind=_ : ⦃ Applicative m ⦄ → (∀ {a b} → m a → (a → m b) → m b) → Monad m
+  bind= x = record {DefaultMonad (record {_>>=_ = x})}
 instance
   iMonadList : Monad List
-  iMonadList ._>>=_ = flip concatMap
+  iMonadList = bind= flip concatMap
 
   iMonadMaybe : Monad Maybe
-  iMonadMaybe ._>>=_ m k = maybe Nothing k m
+  iMonadMaybe = bind= flip (maybe Nothing)
 
   iMonadEither : Monad (Either a)
-  iMonadEither ._>>=_ m k = either Left k m
+  iMonadEither = bind= flip (either Left)
 
   iMonadFun : Monad (λ b → a → b)
-  iMonadFun ._>>=_ f k r = k (f r) r
+  iMonadFun = bind= λ f k r → k (f r) r
 
   iMonadTuple₂ : ⦃ Monoid a ⦄ → Monad (a ×_)
-  iMonadTuple₂ ._>>=_ (a , x) k = first (a <>_) (k x)
+  iMonadTuple₂ = bind= λ (a , x) k → first (a <>_) (k x)
 
   iMonadTuple₃ : ⦃ Monoid a ⦄ → ⦃ Monoid b ⦄ → Monad (a × b ×_)
-  iMonadTuple₃ ._>>=_ (a , b , x) k =
+  iMonadTuple₃ = bind= λ (a , b , x) k →
     case k x of λ where
       (a₁ , b₁ , y) → a <> a₁ , b <> b₁ , y
 
   iMonadTuple₄ : ⦃ Monoid a ⦄ → ⦃ Monoid b ⦄ → ⦃ Monoid c ⦄ →
                  Monad (λ d → Tuple (a ∷ b ∷ c ∷ d ∷ []))
-  iMonadTuple₄ ._>>=_ (a ; b ; c ; x ; tt) k =
+  iMonadTuple₄ = bind= λ (a ; b ; c ; x ; tt) k →
     case k x of λ where
       (a₁ ; b₁ ; c₁ ; y ; tt) → a <> a₁ ; b <> b₁ ; c <> c₁ ; y ; tt
 
@@ -87,7 +102,7 @@ record MonadFail (m : Set → Set) : Set₁ where
     fail : String → m a
     overlap ⦃ super ⦄ : Monad m
 
-open MonadFail ⦃ ... ⦄ public
+open MonadFail ⦃...⦄ public
 
 {-# COMPILE AGDA2HS MonadFail existing-class #-}
 

--- a/lib/Haskell/Prim/Num.agda
+++ b/lib/Haskell/Prim/Num.agda
@@ -32,7 +32,7 @@ record Num (a : Set) : Set₁ where
     overlap ⦃ numZero ⦄ : number .Number.Constraint 0
     overlap ⦃ numOne ⦄  : number .Number.Constraint 1
 
-open Num ⦃ ... ⦄ public hiding (FromIntegerOK; number)
+open Num ⦃...⦄ public hiding (FromIntegerOK; number)
 
 {-# COMPILE AGDA2HS Num existing-class #-}
 
@@ -105,10 +105,16 @@ instance
   iNumDouble .fromInteger (pos    n) = fromNat n
   iNumDouble .fromInteger (negsuc n) = fromNeg (suc n)
 
+open DefaultMonoid
+
 MonoidSum : ⦃ iNum : Num a ⦄ → Monoid a
-MonoidSum .mempty      = 0
-MonoidSum .super ._<>_ = _+_
+MonoidSum = record {DefaultMonoid (λ where
+  .mempty      → 0
+  .super ._<>_ → _+_
+ )}
 
 MonoidProduct : ⦃ iNum : Num a ⦄ → Monoid a
-MonoidProduct .mempty      = 1
-MonoidProduct .super ._<>_ = _*_
+MonoidProduct = record {DefaultMonoid (λ where
+  .mempty      → 1
+  .super ._<>_ → _*_
+ )}

--- a/lib/Haskell/Prim/Ord.agda
+++ b/lib/Haskell/Prim/Ord.agda
@@ -33,7 +33,7 @@ instance
   iSemigroupOrdering ._<>_ GT _ = GT
 
   iMonoidOrdering : Monoid Ordering
-  iMonoidOrdering .mempty = EQ
+  iMonoidOrdering = record {DefaultMonoid (record {mempty = EQ})}
 
 --------------------------------------------------
 -- Ord
@@ -51,7 +51,7 @@ record Ord (a : Set) : Set where
 
   infix 4 _<_ _>_ _<=_ _>=_
 
-open Ord ⦃ ... ⦄ public
+open Ord ⦃...⦄ public
 
 {-# COMPILE AGDA2HS Ord existing-class #-}
 

--- a/lib/Haskell/Prim/Show.agda
+++ b/lib/Haskell/Prim/Show.agda
@@ -33,81 +33,97 @@ showParen : Bool → ShowS → ShowS
 showParen False s = s
 showParen True  s = showString "(" ∘ s ∘ showString ")"
 
+defaultShowList : (a → ShowS) → List a → ShowS
+defaultShowList shows = λ where
+  []       → showString "[]"
+  (x ∷ xs) → showString "["
+           ∘ foldl (λ s x → s ∘ showString "," ∘ shows x) (shows x) xs
+           ∘ showString "]"
+
+-- ** base
 record Show (a : Set) : Set where
   field
     showsPrec : Int → a → ShowS
     showList  : List a → ShowS
-
-  shows : a → ShowS
-  shows = showsPrec 0
+    show      : a → String
+-- ** export
+record Show₁ (a : Set) : Set where
+  field showsPrec : Int → a → ShowS
 
   show : a → String
-  show x = shows x ""
+  show x = showsPrec 0 x ""
 
-defaultShowList : (a → ShowS) → List a → ShowS
-defaultShowList _     []       = showString "[]"
-defaultShowList shows (x ∷ xs) = showString "[" ∘ foldl (λ s x → s ∘ showString "," ∘ shows x) (shows x) xs ∘ showString "]"
+  showList : List a → ShowS
+  showList = defaultShowList (showsPrec 0)
+record Show₂ (a : Set) : Set where
+  field show : a → String
 
-open Show ⦃ ... ⦄ public
+  showsPrec : Int → a → ShowS
+  showsPrec _ x s = show x ++ s
+
+  showList : List a → ShowS
+  showList = defaultShowList (showsPrec 0)
+-- ** export
+open Show ⦃...⦄ public
+
+shows : ⦃ Show a ⦄ → a → ShowS
+shows = showsPrec 0
 
 {-# COMPILE AGDA2HS Show existing-class #-}
-
+-- ** instances
 private
-  makeShow : (a → String) → Show a
-  makeShow sh .showsPrec _ = showString ∘ sh
-  makeShow sh .showList    = defaultShowList (showString ∘ sh)
+  infix 0 showsPrec=_ show=_
 
-  makeShowsPrec : (Int → a → ShowS) → Show a
-  makeShowsPrec shp .showsPrec = shp
-  makeShowsPrec shp .showList = defaultShowList (shp 0)
+  showsPrec=_ : (Int → a → ShowS) → Show a
+  showsPrec=_ x = record {Show₁ (record {showsPrec = x})}
 
+  show=_ : (a → String) → Show a
+  show= x = record {Show₂ (record {show = x})}
 instance
   iShowNat : Show Nat
-  iShowNat = makeShow (primStringToList ∘ primShowNat)
+  iShowNat = show= (primStringToList ∘ primShowNat)
 
   iShowInteger : Show Integer
-  iShowInteger = makeShow showInteger
+  iShowInteger = show= showInteger
 
   iShowInt : Show Int
-  iShowInt = makeShow showInt
+  iShowInt = show= showInt
 
   iShowWord : Show Word
-  iShowWord = makeShow showWord
+  iShowWord = show= showWord
 
   iShowDouble : Show Double
-  iShowDouble = makeShow (primStringToList ∘ primShowFloat)
+  iShowDouble = show= (primStringToList ∘ primShowFloat)
 
   iShowBool : Show Bool
-  iShowBool = makeShow λ where False → "False"; True → "True"
+  iShowBool = show= λ where False → "False"; True → "True"
 
   iShowChar : Show Char
-  iShowChar .showsPrec _ = showString ∘ primStringToList ∘ primShowChar
-  iShowChar .showList    = showString ∘ primStringToList ∘ primShowString ∘ primStringFromList
+  iShowChar = showsPrec= λ _ → showString ∘ primStringToList ∘ primShowChar
 
   iShowList : ⦃ Show a ⦄ → Show (List a)
-  iShowList .showsPrec _ = showList
-  iShowList .showList    = defaultShowList showList
-
+  iShowList = showsPrec= λ _ → showList
 private
   showApp₁ : ⦃ Show a ⦄ → Int → String → a → ShowS
-  showApp₁ p tag x = showParen (p > 10) $ showString tag ∘ showString " " ∘ showsPrec 11 x
-
+  showApp₁ p tag x = showParen (p > 10) $
+    showString tag ∘ showString " " ∘ showsPrec 11 x
 instance
   iShowMaybe : ⦃ Show a ⦄ → Show (Maybe a)
-  iShowMaybe = makeShowsPrec λ where p Nothing  → showString "Nothing"
-                                     p (Just x) → showApp₁ p "Just" x
+  iShowMaybe = showsPrec= λ where
+    p Nothing  → showString "Nothing"
+    p (Just x) → showApp₁ p "Just" x
 
   iShowEither : ⦃ Show a ⦄ → ⦃ Show b ⦄ → Show (Either a b)
-  iShowEither = makeShowsPrec λ where p (Left  x) → showApp₁ p "Left"  x
-                                      p (Right y) → showApp₁ p "Right" y
-
+  iShowEither = showsPrec= λ where
+    p (Left  x) → showApp₁ p "Left"  x
+    p (Right y) → showApp₁ p "Right" y
 private
   -- Minus the parens
   showTuple : ⦃ All Show as ⦄ → Tuple as → ShowS
-  showTuple {_} ⦃ allNil  ⦄                   _        = showString ""
-  showTuple {_} ⦃ allCons ⦃ _ ⦄ ⦃ allNil ⦄ ⦄ (x ; tt) = shows x
-  showTuple {_} ⦃ allCons ⦄                   (x ; xs) = shows x ∘ showString ", " ∘ showTuple xs
-
+  showTuple ⦃ allNil  ⦄                 _        = showString ""
+  showTuple ⦃ allCons ⦃ is = allNil ⦄ ⦄ (x ; tt) = shows x
+  showTuple ⦃ allCons ⦄                 (x ; xs) = shows x
+                                                 ∘ showString ", " ∘ showTuple xs
 instance
   iShowTuple : ⦃ All Show as ⦄ → Show (Tuple as)
-  iShowTuple = makeShowsPrec λ _ → showParen True ∘ showTuple
+  iShowTuple = showsPrec= λ _ → showParen True ∘ showTuple

--- a/src/Agda2Hs/Compile.hs
+++ b/src/Agda2Hs/Compile.hs
@@ -17,22 +17,22 @@ import Agda2Hs.Compile.Types
 import Agda2Hs.Pragma
 
 initCompileEnv :: TopLevelModuleName -> CompileEnv
-initCompileEnv tlmn = CompileEnv
-  { currModule = tlmn
+initCompileEnv tlm = CompileEnv
+  { currModule = tlm
   , minRecordName = Nothing
   , locals = []
   , isCompilingInstance = False
   }
 
 runC :: TopLevelModuleName -> C a -> TCM (a, CompileOutput)
-runC tlmn m = runWriterT $ runReaderT m $ initCompileEnv tlmn
+runC tlm m = runWriterT $ runReaderT m $ initCompileEnv tlm
 
 -- Main compile function
 ------------------------
 
 compile :: Options -> ModuleEnv -> IsMain -> Definition ->
   TCM (CompiledDef, CompileOutput)
-compile _ tlmn _ def = withCurrentModule (qnameModule $ defName def) $ runC tlmn $
+compile _ tlm _ def = withCurrentModule (qnameModule $ defName def) $ runC tlm $
   processPragma (defName def) >>= \ p -> do
     reportSDoc "agda2hs.compile" 5 $
       text "Compiling definition: " <+> prettyTCM (defName def)

--- a/src/Agda2Hs/Compile/Function.hs
+++ b/src/Agda2Hs/Compile/Function.hs
@@ -42,7 +42,7 @@ import Agda2Hs.Compile.Utils
 import Agda2Hs.HsUtils
 
 isSpecialPat :: QName -> Maybe (ConHead -> ConPatternInfo -> [NamedArg DeBruijnPattern] -> C (Hs.Pat ()))
-isSpecialPat = prettyShow >>> \ case
+isSpecialPat = prettyShow >>> \case
   "Haskell.Prim.Tuple._;_" -> Just tuplePat
   "Agda.Builtin.Int.Int.pos" -> Just posIntPat
   "Agda.Builtin.Int.Int.negsuc" -> Just negSucIntPat
@@ -172,7 +172,7 @@ compilePat p@(VarP o x)
       return $ Hs.PVar () n
 compilePat (ConP h i ps)
   | Just semantics <- isSpecialPat (conName h) = setCurrentRange h $ semantics h i ps
-compilePat (ConP h _ ps) = isUnboxConstructor (conName h) >>= \ case
+compilePat (ConP h _ ps) = isUnboxConstructor (conName h) >>= \case
   Just s -> compileErasedConP ps >>= addPatBang s
   Nothing -> do
     ps <- compilePats ps

--- a/src/Agda2Hs/Compile/Imports.hs
+++ b/src/Agda2Hs/Compile/Imports.hs
@@ -19,7 +19,7 @@ import Agda2Hs.Compile.Utils
 import Agda2Hs.HsUtils
 
 type ImportSpecMap = Map (Hs.Name ()) (Set (Hs.Name ()))
-type ImportDeclMap = Map (Hs.ModuleName (), IsQualified) ImportSpecMap
+type ImportDeclMap = Map (Hs.ModuleName (), Qualifier) ImportSpecMap
 
 compileImports :: String -> Imports -> TCM [Hs.ImportDecl ()]
 compileImports top is0 = do
@@ -54,17 +54,17 @@ compileImports top is0 = do
       | Set.null qs = Hs.IVar () q
       | otherwise   = Hs.IThingWith () q $ map makeCName $ Set.toList qs
 
-    makeImportDecl :: Hs.ModuleName () -> IsQualified -> ImportSpecMap -> Hs.ImportDecl ()
+    makeImportDecl :: Hs.ModuleName () -> Qualifier -> ImportSpecMap -> Hs.ImportDecl ()
     makeImportDecl mod qual specs = Hs.ImportDecl ()
       mod (isQualified qual) False False Nothing (qualifiedAs qual)
       (Just $ Hs.ImportSpecList () False $ map (uncurry makeImportSpec) $ Map.toList specs)
 
-    isQualified :: IsQualified -> Bool
-    isQualified IsQualified     = True
-    isQualified IsQualifiedAs{} = True
-    isQualified IsUnqualified   = False
+    isQualified :: Qualifier -> Bool
+    isQualified = \case
+      Unqualified     -> False
+      (QualifiedAs _) -> True
 
-    qualifiedAs :: IsQualified -> Maybe (Hs.ModuleName ())
-    qualifiedAs IsQualified       = Nothing
-    qualifiedAs (IsQualifiedAs m) = Just m
-    qualifiedAs IsUnqualified     = Nothing
+    qualifiedAs :: Qualifier -> Maybe (Hs.ModuleName ())
+    qualifiedAs = \case
+      Unqualified     -> Nothing
+      (QualifiedAs m) -> m

--- a/src/Agda2Hs/Compile/Name.hs
+++ b/src/Agda2Hs/Compile/Name.hs
@@ -2,8 +2,11 @@ module Agda2Hs.Compile.Name where
 
 import Control.Arrow ( (>>>) )
 import Control.Monad
+import Control.Monad.Reader
 
 import Data.List ( intercalate, isPrefixOf )
+import qualified Data.Map as Map
+import qualified Data.Text as Text
 
 import qualified Language.Haskell.Exts as Hs
 
@@ -11,14 +14,21 @@ import Agda.Compiler.Backend hiding ( topLevelModuleName )
 import Agda.Compiler.Common ( topLevelModuleName )
 
 import Agda.Syntax.Common
+import qualified Agda.Syntax.Concrete as C
+import Agda.Syntax.Scope.Base ( Scope, scopeModules, scopeDatatypeModule, inverseScopeLookupName )
+import Agda.Syntax.Scope.Monad ( isDatatypeModule )
+import Agda.Syntax.TopLevelModuleName
+import Agda.Syntax.Translation.AbstractToConcrete ( abstractToConcrete_ )
 
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Records ( isRecordConstructor )
 
-import Agda.Utils.Maybe ( whenJust, fromMaybe )
+import qualified Agda.Utils.List1 as List1
+import Agda.Utils.Maybe ( isJust, whenJust, fromMaybe )
 import Agda.Utils.Pretty ( prettyShow )
 import qualified Agda.Utils.Pretty as P ( Pretty(pretty) )
 
+import Agda2Hs.AgdaUtils
 import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Utils
 import Agda2Hs.HsUtils
@@ -39,10 +49,12 @@ isSpecialName = prettyShow >>> \ case
     "Haskell.Prim._∘_"             -> noImport $ unqual "_._"
     "Haskell.Prim.seq"             -> noImport $ unqual "seq"
     "Haskell.Prim._$!_"            -> noImport $ unqual "_$!_"
+    "Haskell.Prim.Monad.Dont._>>=_" -> noImport $ unqual "_>>=_"
+    "Haskell.Prim.Monad.Dont._>>_"  -> noImport $ unqual "_>>_"
     _ -> Nothing
   where
     noImport x = Just (x, Nothing)
-    withImport mod x = Just (x, Just (Import (Hs.ModuleName () mod) Nothing (unQual x)))
+    withImport mod x = Just (x, Just (Import (Hs.ModuleName () mod) IsUnqualified Nothing (unQual x)))
     unqual n  = Hs.UnQual () $ hsName n
     special c = Hs.Special () $ c ()
 
@@ -56,18 +68,22 @@ compileQName f
       return x
   | otherwise = do
     reportSDoc "agda2hs.name" 25 $ text $ "compiling name: " ++ prettyShow f
-    parent <- parentName f
-    f <- isRecordConstructor f >>= \ case
+    f      <- isRecordConstructor f >>= \ case
       Just (r, Record{ recNamedCon = False }) -> return r -- Use the record name if no named constructor
       _                                       -> return f
-    hf  <- compileName (qnameName f)
-    mod <- compileModuleName $ qnameModule $ fromMaybe f parent
-    par <- traverse (compileName . qnameName) parent
-    unless (skipImport mod) $ tellImport (Import mod par hf)
-    -- TODO: this prints all names UNQUALIFIED. For names from
-    -- qualified imports, we need to add the proper qualification in
-    -- the Haskell code.
-    return $ Hs.UnQual () hf
+    hf     <- compileName (qnameName f)
+    reportSDoc "agda2hs.name" 25 $ text $ "haskell name: " ++ Hs.prettyPrint hf
+    parent <- parentName f
+    reportSDoc "agda2hs.name" 25 $ text $ "parent name: " ++ maybe "(none)" prettyShow parent
+    mod    <- compileModuleName $ qnameModule $ fromMaybe f parent
+    reportSDoc "agda2hs.name" 25 $ text $ "module name: " ++ Hs.prettyPrint mod
+    currMod <- hsTopLevelModuleName <$> asks currModule
+    qual   <- if | mod == currMod -> return IsUnqualified
+                 | otherwise      -> isQualified (fromMaybe f parent) mod
+    reportSDoc "agda2hs.name" 25 $ text $ "qualified? " ++ show qual
+    par    <- traverse (compileName . qnameName) parent
+    unless (skipImport mod) $ tellImport (Import mod qual par hf)
+    return $ qualify mod hf qual
 
   where
     skipImport mod =
@@ -82,7 +98,26 @@ compileQName f
         -> return $ Just $ unArg rt
       _ -> return Nothing
 
-compileModuleName :: Monad m => ModuleName -> m (Hs.ModuleName ())
+    isQualified :: QName -> Hs.ModuleName () -> C IsQualified
+    isQualified f mod = (inverseScopeLookupName f <$> getScope) >>= \case
+        (C.Qual as C.QName{} : _)
+          | hsModuleName (prettyShow as) /= mod -> 
+            return $ IsQualifiedAs $ hsModuleName $ prettyShow as
+        (C.Qual{} : _) -> return IsQualified
+        _              -> return IsUnqualified
+
+    qualify :: Hs.ModuleName () -> Hs.Name () -> IsQualified -> Hs.QName ()
+    qualify mod n IsQualified        = Hs.Qual () mod n
+    qualify _   n (IsQualifiedAs as) = Hs.Qual () as n
+    qualify _   n IsUnqualified      = Hs.UnQual () n
+
+hsTopLevelModuleName :: TopLevelModuleName -> Hs.ModuleName ()
+hsTopLevelModuleName = hsModuleName . intercalate "." . map Text.unpack . List1.toList . moduleNameParts
+
+compileModuleName :: ModuleName -> C (Hs.ModuleName ())
 compileModuleName m = do
-  ns <- traverse (pretty . nameConcrete) (mnameToList m)
-  return $ Hs.ModuleName () $ intercalate "." $ map show ns
+  tlmn <- liftTCM $ hsTopLevelModuleName <$> getTopLevelModuleForModuleName m
+  reportSDoc "agda2hs.compileModuleName" 20 $ 
+    text "Top-level module name for" <+> prettyTCM m <+> 
+    text "is" <+> text (show tlmn)
+  return tlmn

--- a/src/Agda2Hs/Compile/Name.hs
+++ b/src/Agda2Hs/Compile/Name.hs
@@ -1,6 +1,7 @@
 module Agda2Hs.Compile.Name where
 
 import Control.Arrow ( (>>>) )
+import Control.Applicative ( (<|>) )
 import Control.Monad
 import Control.Monad.Reader
 
@@ -13,6 +14,7 @@ import Agda.Compiler.Backend hiding ( topLevelModuleName )
 import Agda.Compiler.Common ( topLevelModuleName )
 
 import Agda.Syntax.Common
+import Agda.Syntax.Position
 import qualified Agda.Syntax.Concrete as C
 import Agda.Syntax.Scope.Base ( inverseScopeLookupName )
 import Agda.Syntax.TopLevelModuleName
@@ -21,7 +23,7 @@ import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Records ( isRecordConstructor )
 
 import qualified Agda.Utils.List1 as List1
-import Agda.Utils.Maybe ( whenJust, fromMaybe, caseMaybeM )
+import Agda.Utils.Maybe ( isJust, whenJust, fromMaybe, caseMaybeM )
 import Agda.Utils.Pretty ( prettyShow )
 import qualified Agda.Utils.Pretty as P ( Pretty(pretty) )
 
@@ -30,65 +32,81 @@ import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Utils
 import Agda2Hs.HsUtils
 
-isSpecialName :: QName -> Maybe (Hs.QName (), Maybe Import)
+isSpecialCon :: QName -> Maybe (Hs.QName ())
+isSpecialCon = prettyShow >>> \case
+    "Agda.Builtin.List.List"     -> special Hs.ListCon
+    "Agda.Builtin.List.List._∷_" -> special Hs.Cons
+    "Agda.Builtin.List.List.[]"  -> special Hs.ListCon
+    "Agda.Builtin.Unit.⊤"       -> special Hs.UnitCon
+    "Agda.Builtin.Unit.tt"       -> special Hs.UnitCon
+    _ -> Nothing
+  where special c = Just (Hs.Special () $ c ())
+
+isSpecialName :: QName -> Maybe (Hs.Name (), Maybe Import)
 isSpecialName = prettyShow >>> \case
-    "Agda.Builtin.Nat.Nat"         -> withImport "Numeric.Natural" $ unqual "Natural"
-    "Agda.Builtin.Int.Int"         -> noImport $ unqual "Integer"
-    "Agda.Builtin.Word.Word64"     -> noImport $ unqual "Word"
-    "Agda.Builtin.Float.Float"     -> noImport $ unqual "Double"
-    "Agda.Builtin.Bool.Bool.false" -> noImport $ unqual "False"
-    "Agda.Builtin.Bool.Bool.true"  -> noImport $ unqual "True"
-    "Agda.Builtin.List.List"       -> noImport $ special Hs.ListCon
-    "Agda.Builtin.List.List._∷_"   -> noImport $ special Hs.Cons
-    "Agda.Builtin.List.List.[]"    -> noImport $ special Hs.ListCon
-    "Agda.Builtin.Unit.⊤"          -> noImport $ special Hs.UnitCon
-    "Agda.Builtin.Unit.tt"         -> noImport $ special Hs.UnitCon
-    "Haskell.Prim._∘_"             -> noImport $ unqual "_._"
-    "Haskell.Prim.seq"             -> noImport $ unqual "seq"
-    "Haskell.Prim._$!_"            -> noImport $ unqual "_$!_"
-    "Haskell.Prim.Monad.Dont._>>=_" -> noImport $ unqual "_>>=_"
-    "Haskell.Prim.Monad.Dont._>>_"  -> noImport $ unqual "_>>_"
+    "Agda.Builtin.Nat.Nat"         -> withImport "Numeric.Natural" "Natural"
+    "Agda.Builtin.Int.Int"         -> noImport "Integer"
+    "Agda.Builtin.Word.Word64"     -> noImport "Word"
+    "Agda.Builtin.Float.Float"     -> noImport "Double"
+    "Agda.Builtin.Bool.Bool.false" -> noImport "False"
+    "Agda.Builtin.Bool.Bool.true"  -> noImport "True"
+    "Haskell.Prim._∘_"             -> noImport "_._"
+    "Haskell.Prim.seq"             -> noImport "seq"
+    "Haskell.Prim._$!_"            -> noImport "_$!_"
+    "Haskell.Prim.Monad.Dont._>>=_" -> noImport "_>>=_"
+    "Haskell.Prim.Monad.Dont._>>_"  -> noImport "_>>_"
     _ -> Nothing
   where
-    noImport x = Just (x, Nothing)
-    withImport mod x = Just (x, Just (Import (Hs.ModuleName () mod) Unqualified Nothing (unQual x)))
-    unqual n  = Hs.UnQual () $ hsName n
-    special c = Hs.Special () $ c ()
+    noImport x = Just (hsName x, Nothing)
+    withImport mod x =
+      let imp = Import (hsModuleName mod) Unqualified Nothing (hsName x)
+      in Just (hsName x, Just imp)
 
 compileName :: Applicative m => Name -> m (Hs.Name ())
 compileName n = hsName . show <$> pretty (nameConcrete n)
 
 compileQName :: QName -> C (Hs.QName ())
 compileQName f
-  | Just (x, mimp) <- isSpecialName f = do
-      whenJust mimp tellImport
-      return x
+  | Just c <- isSpecialCon f
+  = do
+    reportSDoc "agda2hs.name" 25 $ text $
+      "compiling name: " ++ prettyShow f ++
+      " to special constructor: " ++ Hs.prettyPrint c
+    return c
   | otherwise = do
-    f       <- isRecordConstructor f >>= return . \case
+    f <- isRecordConstructor f >>= return . \case
       Just (r, Record{recNamedCon = False}) -> r -- use record name for unnamed constructors
       _                                     -> f
-    hf      <- compileName (qnameName f)
-    parent  <- parentName f
-    mod     <- compileModuleName $ qnameModule $ fromMaybe f parent
+    hf0 <- compileName (qnameName f)
+    let (hf, mimpBuiltin) = fromMaybe (hf0, Nothing) (isSpecialName f)
+    parent <- parentName f
+    par <- traverse (compileName . qnameName) parent
+    let mod0 = qnameModule $ fromMaybe f parent
+    mod <- compileModuleName mod0
     currMod <- hsTopLevelModuleName <$> asks currModule
-    qual    <- if | mod == currMod -> return Unqualified
-                  | otherwise      -> getQualifier (fromMaybe f parent) mod
+    let skipModule = mod == currMod
+                  || isJust mimpBuiltin
+                  || prettyShow mod0 `elem` primMonadModules
+    qual <- if | skipModule -> return Unqualified
+               | otherwise  -> getQualifier (fromMaybe f parent) mod
+    let (mod', mimp) = mkImport mod qual par hf
+        qf = qualify mod' hf qual
+
+    -- add (possibly qualified) import
+    whenJust (mimpBuiltin <|> mimp) tellImport
+
     reportSDoc "agda2hs.name" 25 $ text
-       $ "compiling name: " ++ prettyShow f
+       $ "-------------------------------------------------"
+      ++ "\ncompiling name: " ++ prettyShow f
       ++ "\nhaskell name: " ++ Hs.prettyPrint hf
       ++ "\nparent name: " ++ prettyShow parent
+      ++ "\nmod0: " ++ prettyShow mod0
       ++ "\nmodule name: " ++ Hs.prettyPrint mod
+      ++ "\ncurrent module: " ++ Hs.prettyPrint currMod
       ++ "\nqualifier: " ++ prettyShow (fmap (fmap pp) qual)
-    par <- traverse (compileName . qnameName) parent
-    unless (skipImport mod) $ tellImport (Import mod qual par hf)
-    return $ qualify mod hf qual
-
+      ++ "\n(qualified) haskell name: " ++ pp qf
+    return qf
   where
-    skipImport mod =
-      "Agda.Builtin" `isPrefixOf` Hs.prettyPrint mod ||
-      "Haskell.Prim" `isPrefixOf` Hs.prettyPrint mod ||
-      "Haskell.Prelude" `isPrefixOf` Hs.prettyPrint mod
-
     parentName :: QName -> C (Maybe QName)
     parentName q = (theDef <$> getConstInfo q) >>= return . \case
       Constructor {conData = dt} -> Just dt
@@ -98,17 +116,31 @@ compileQName f
       _ -> Nothing
 
     getQualifier :: QName -> Hs.ModuleName () -> C Qualifier
-    getQualifier f mod = (inverseScopeLookupName f <$> getScope) >>= return . \case
-      (C.Qual as C.QName{} : _)
-        | qual <- hsModuleName $ prettyShow as, qual /= mod
-        -> QualifiedAs (Just qual)
-      (C.Qual{} : _) -> QualifiedAs Nothing
-      _ -> Unqualified
+    getQualifier f mod =
+      (inverseScopeLookupName f <$> getScope) >>= return . \case
+        (C.Qual as C.QName{} : _)
+          | qual <- hsModuleName $ prettyShow as, qual /= mod
+          -> QualifiedAs (Just qual)
+        (C.Qual{} : _) -> QualifiedAs Nothing
+        _ -> Unqualified
 
     qualify :: Hs.ModuleName () -> Hs.Name () -> Qualifier -> Hs.QName ()
     qualify mod n = \case
       (QualifiedAs as) -> Hs.Qual () (fromMaybe mod as) n
       Unqualified      -> Hs.UnQual () n
+
+    primModules = ["Agda.Builtin", "Haskell.Prim", "Haskell.Prelude"]
+    primMonadModules = ["Haskell.Prim.Monad.Dont", "Haskell.Prim.Monad.Do"]
+
+    mkImport mod qual par hf
+      -- make sure the Prelude is properly qualified
+      | any (`isPrefixOf` pp mod) primModules
+      = if isQualified qual then
+          let mod' = hsModuleName "Prelude"
+          in (mod', Just (Import mod' qual Nothing hf))
+        else (mod, Nothing)
+      | otherwise
+      = (mod, Just (Import mod qual par hf))
 
 hsTopLevelModuleName :: TopLevelModuleName -> Hs.ModuleName ()
 hsTopLevelModuleName = hsModuleName . intercalate "." . map unpack

--- a/src/Agda2Hs/Compile/Record.hs
+++ b/src/Agda2Hs/Compile/Record.hs
@@ -119,7 +119,7 @@ compileRecord target def = setCurrentRange (nameBindingSite $ qnameName $ defNam
 
     -- In Haskell, projections live in the same scope as the record type, so check here that the
     -- record module has been opened.
-    checkFieldInScope f = isInScopeUnqualified f >>= \ case
+    checkFieldInScope f = isInScopeUnqualified f >>= \case
       True  -> return ()
       False -> setCurrentRange (nameBindingSite $ qnameName f) $ genericError $
         "Record projections (`" ++ prettyShow (qnameName f) ++ "` in this case) must be brought into scope when compiling to Haskell record types. " ++

--- a/src/Agda2Hs/Compile/Term.hs
+++ b/src/Agda2Hs/Compile/Term.hs
@@ -44,8 +44,8 @@ isSpecialTerm q = case prettyShow q of
   "Haskell.Prim.Enum.Enum.enumFromThen"         -> Just mkEnumFromThen
   "Haskell.Prim.Enum.Enum.enumFromThenTo"       -> Just mkEnumFromThenTo
   "Haskell.Prim.case_of_"                       -> Just caseOf
-  "Haskell.Prim.Monad.Monad._>>=_"              -> Just bind
-  "Haskell.Prim.Monad.Monad._>>_"               -> Just sequ
+  "Haskell.Prim.Monad.Do.Monad._>>=_"           -> Just bind
+  "Haskell.Prim.Monad.Do.Monad._>>_"            -> Just sequ
   "Agda.Builtin.FromNat.Number.fromNat"         -> Just fromNat
   "Agda.Builtin.FromNeg.Negative.fromNeg"       -> Just fromNeg
   "Agda.Builtin.FromString.IsString.fromString" -> Just fromString

--- a/src/Agda2Hs/Compile/Term.hs
+++ b/src/Agda2Hs/Compile/Term.hs
@@ -52,24 +52,24 @@ isSpecialTerm q = case prettyShow q of
   _                                             -> Nothing
 
 isSpecialCon :: QName -> Maybe (ConHead -> ConInfo -> Elims -> C (Hs.Exp ()))
-isSpecialCon = prettyShow >>> \ case
+isSpecialCon = prettyShow >>> \case
   "Haskell.Prim.Tuple._;_" -> Just tupleTerm
   _ -> Nothing
 
 fromNat :: QName -> Elims -> C (Hs.Exp ())
-fromNat _ es = compileElims es <&> \ case
+fromNat _ es = compileElims es <&> \case
   _ : n@Hs.Lit{} : es' -> n `eApp` es'
   es'                  -> hsVar "fromIntegral" `eApp` drop 1 es'
 
 fromNeg :: QName -> Elims -> C (Hs.Exp ())
-fromNeg _ es = compileElims es <&> \ case
+fromNeg _ es = compileElims es <&> \case
   _ : n@Hs.Lit{} : es' -> Hs.NegApp () n `eApp` es'
   es'                  -> (hsVar "negate" `o` hsVar "fromIntegral") `eApp` drop 1 es'
   where
     f `o` g = Hs.InfixApp () f (Hs.QVarOp () $ Hs.UnQual () $ hsName "_._") g
 
 fromString :: QName -> Elims -> C (Hs.Exp ())
-fromString _ es = compileElims es <&> \ case
+fromString _ es = compileElims es <&> \case
   _ : s@Hs.Lit{} : es' -> s `eApp` es'
   es'                  -> hsVar "fromString" `eApp` drop 1 es'
 
@@ -148,7 +148,7 @@ sequ q (e:es) = do
 sequ q [] = return $ hsVar "_>>_"
 
 caseOf :: QName -> Elims -> C (Hs.Exp ())
-caseOf _ es = compileElims es >>= \ case
+caseOf _ es = compileElims es >>= \case
   -- applied to pattern lambda
   e : Hs.LCase _ alts : es' ->
     return $ eApp (Hs.Case () e alts) es'
@@ -214,9 +214,9 @@ compileTerm v = do
     -- args that need attention
     Def f es
       | Just semantics <- isSpecialTerm f -> semantics f es
-      | otherwise -> isClassFunction f >>= \ case
+      | otherwise -> isClassFunction f >>= \case
         True  -> compileClassFunApp f es
-        False -> (isJust <$> isUnboxProjection f) `or2M` isTransparentFunction f >>= \ case
+        False -> (isJust <$> isUnboxProjection f) `or2M` isTransparentFunction f >>= \case
           True  -> compileErasedApp es
           False -> do
             -- Drop module parameters (unless projection-like)
@@ -226,7 +226,7 @@ compileTerm v = do
             (`app` drop n es) . Hs.Var () =<< compileQName f
     Con h i es
       | Just semantics <- isSpecialCon (conName h) -> semantics h i es
-    Con h i es -> isUnboxConstructor (conName h) >>= \ case
+    Con h i es -> isUnboxConstructor (conName h) >>= \case
       Just _  -> compileErasedApp es
       Nothing -> (`app` es) . Hs.Con () =<< compileQName (conName h)
     Lit l -> compileLiteral l

--- a/src/Agda2Hs/Compile/Type.hs
+++ b/src/Agda2Hs/Compile/Type.hs
@@ -38,7 +38,7 @@ import Agda2Hs.AgdaUtils
 import Agda2Hs.HsUtils
 
 isSpecialType :: QName -> Maybe (QName -> Elims -> C (Hs.Type ()))
-isSpecialType = prettyShow >>> \ case
+isSpecialType = prettyShow >>> \case
   "Haskell.Prim.Tuple.Tuple" -> Just tupleType
   "Haskell.Prim.Tuple._×_"   -> Just tupleType
   "Haskell.Prim.Tuple._×_×_" -> Just tupleType

--- a/src/Agda2Hs/Compile/Types.hs
+++ b/src/Agda2Hs/Compile/Types.hs
@@ -5,6 +5,7 @@ import Control.Monad.Reader ( ReaderT )
 import Control.Monad.Writer ( WriterT )
 import Control.DeepSeq ( NFData(..) )
 
+import Data.Maybe ( fromMaybe, isJust )
 import Data.Set ( Set )
 
 import qualified Language.Haskell.Exts.SrcLoc as Hs
@@ -45,6 +46,9 @@ data CompileEnv = CompileEnv
 type Qualifier = Maybe (Maybe (Hs.ModuleName ()))
 pattern Unqualified   = Nothing
 pattern QualifiedAs m = Just m
+
+isQualified = isJust
+qualifiedAs = fromMaybe Nothing
 
 data Import = Import
   { importModule    :: Hs.ModuleName ()

--- a/src/Agda2Hs/Compile/Types.hs
+++ b/src/Agda2Hs/Compile/Types.hs
@@ -32,17 +32,26 @@ instance NFData Options where
   rnf _ = ()
 
 data CompileEnv = CompileEnv
-  { minRecordName :: Maybe ModuleName
+  { currModule :: TopLevelModuleName
+  -- ^ the current module we are compiling
+  , minRecordName :: Maybe ModuleName
   -- ^ keeps track of the current minimal record we are compiling
   , locals :: LocalDecls
   -- ^ keeps track of the current clause's where declarations
   , isCompilingInstance :: Bool
   }
 
+data IsQualified
+  = IsUnqualified
+  | IsQualified
+  | IsQualifiedAs (Hs.ModuleName ())
+  deriving (Show, Eq, Ord)
+
 data Import = Import
-  { importModule :: Hs.ModuleName ()
-  , importParent :: Maybe (Hs.Name ())
-  , importName   :: Hs.Name ()
+  { importModule    :: Hs.ModuleName ()
+  , importQualified :: IsQualified
+  , importParent    :: Maybe (Hs.Name ())
+  , importName      :: Hs.Name ()
   }
 type Imports = [Import]
 

--- a/src/Agda2Hs/Compile/Types.hs
+++ b/src/Agda2Hs/Compile/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PatternSynonyms #-}
 module Agda2Hs.Compile.Types where
 
 import Control.Monad.Reader ( ReaderT )
@@ -41,15 +42,13 @@ data CompileEnv = CompileEnv
   , isCompilingInstance :: Bool
   }
 
-data IsQualified
-  = IsUnqualified
-  | IsQualified
-  | IsQualifiedAs (Hs.ModuleName ())
-  deriving (Show, Eq, Ord)
+type Qualifier = Maybe (Maybe (Hs.ModuleName ()))
+pattern Unqualified   = Nothing
+pattern QualifiedAs m = Just m
 
 data Import = Import
   { importModule    :: Hs.ModuleName ()
-  , importQualified :: IsQualified
+  , importQualified :: Qualifier
   , importParent    :: Maybe (Hs.Name ())
   , importName      :: Hs.Name ()
   }

--- a/src/Agda2Hs/Compile/Utils.hs
+++ b/src/Agda2Hs/Compile/Utils.hs
@@ -129,7 +129,10 @@ canErase a = do
 -- Exploits the fact that the name of the record type and the name of the record module are the
 -- same, including the unique name ids.
 isClassFunction :: QName -> C Bool
-isClassFunction q
+isClassFunction = isClassModule . qnameModule
+
+isClassModule :: ModuleName -> C Bool
+isClassModule m
   | null $ mnameToList m = return False
   | otherwise            = do
     minRec <- asks minRecordName
@@ -142,8 +145,12 @@ isClassFunction q
           ExistingClassPragma -> True
           _                   -> False
       _                             -> return False
-  where
-    m = qnameModule q
+
+-- Drops the last (record) module for typeclass methods
+dropClassModule :: ModuleName -> C ModuleName
+dropClassModule m@(MName ns) = isClassModule m >>= \case
+  True  -> dropClassModule $ MName $ init ns
+  False -> return m
 
 isUnboxRecord :: QName -> C (Maybe Strictness)
 isUnboxRecord q = do

--- a/src/Agda2Hs/Compile/Utils.hs
+++ b/src/Agda2Hs/Compile/Utils.hs
@@ -136,11 +136,11 @@ isClassModule m
   | null $ mnameToList m = return False
   | otherwise            = do
     minRec <- asks minRecordName
-    getConstInfo' (mnameToQName m) >>= \ case
+    getConstInfo' (mnameToQName m) >>= \case
       _ | Just m == minRec -> return True
       Right Defn{defName = r, theDef = Record{}} ->
         -- It would be nicer if we remembered this from when we looked at the record the first time.
-        processPragma r <&> \ case
+        processPragma r <&> \case
           ClassPragma _       -> True
           ExistingClassPragma -> True
           _                   -> False

--- a/src/Agda2Hs/HsUtils.hs
+++ b/src/Agda2Hs/HsUtils.hs
@@ -121,6 +121,7 @@ pp = prettyPrintWithMode defaultMode{ spacing = False
                                     , whereIndent = 2
                                     }
 
+
 -- exactPrint really looks at the line numbers (and we're using the locations from the agda source
 -- to report Haskell parse errors at the right location), so shift everything to start at line 1.
 moveToTop :: Annotated ast => (ast SrcSpanInfo, [Comment]) -> (ast SrcSpanInfo, [Comment])

--- a/src/Agda2Hs/HsUtils.hs
+++ b/src/Agda2Hs/HsUtils.hs
@@ -69,6 +69,9 @@ hsName x
 extToName :: KnownExtension -> Name ()
 extToName = Ident () . show
 
+hsModuleName :: String -> ModuleName ()
+hsModuleName = ModuleName ()
+
 isOp :: QName () -> Bool
 isOp (UnQual _ Symbol{}) = True
 isOp (Special _ Cons{})  = True

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -37,9 +37,13 @@ import Issue115
 import BangPatterns
 import Issue94
 import Issue107
-import Importer
 import DoNotation
 import NewTypePragma
+import Importer
+import QualifiedImports
+import CommonQualifiedImports
+import RequalifiedImports
+import QualifiedPrelude
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -77,7 +81,11 @@ import TransparentFun
 import Issue115
 import BangPatterns
 import Issue94
-import Importer
 import DoNotation
 import NewTypePragma
+import Importer
+import QualifiedImports
+import CommonQualifiedImports
+import RequalifiedImports
+import QualifiedPrelude
 #-}

--- a/test/CommonQualifiedImports.agda
+++ b/test/CommonQualifiedImports.agda
@@ -1,0 +1,13 @@
+{-# FOREIGN AGDA2HS
+-- ** common qualification
+#-}
+
+import Haskell.Prelude as Common
+import Importee as Common
+  using (foo)
+import Importee as Common
+  using (anotherFoo)
+
+foos : Common.Int
+foos = Common.foo Common.+ Common.anotherFoo
+{-# COMPILE AGDA2HS foos #-}

--- a/test/DefaultMethods.agda
+++ b/test/DefaultMethods.agda
@@ -1,12 +1,8 @@
 {-# OPTIONS --no-auto-inline #-}
 module DefaultMethods where
 
-open import Haskell.Prim
-open import Haskell.Prim.Bool
-open import Haskell.Prim.Maybe
-open import Haskell.Prim.Foldable
-open import Haskell.Prim.List
-open import Haskell.Prim.String
+open import Haskell.Prim using (ltNat)
+open import Haskell.Prelude hiding (Show; ShowS; show; showList; showString; showParen; Ord; _<_; _>_; defaultShowList)
 
 {-# FOREIGN AGDA2HS
 {-# LANGUAGE TypeSynonymInstances #-}

--- a/test/Fail/ClashingImport.agda
+++ b/test/Fail/ClashingImport.agda
@@ -1,0 +1,12 @@
+module Fail.ClashingImport where
+
+open import Importee
+open import OtherImportee
+
+testFoo : Foo
+testFoo = MkFoo
+{-# COMPILE AGDA2HS testFoo #-}
+
+otherFoo : OtherFoo
+otherFoo = MkFoo
+{-# COMPILE AGDA2HS otherFoo #-}

--- a/test/Importee.agda
+++ b/test/Importee.agda
@@ -2,30 +2,33 @@ open import Haskell.Prelude
 
 foo : Int
 foo = 42
-
 {-# COMPILE AGDA2HS foo #-}
 
 _!#_ : Int → Int → Int
 x !# y = x + y
-
 {-# COMPILE AGDA2HS _!#_ #-}
 
 data Foo : Set where
   MkFoo : Foo
-
 {-# COMPILE AGDA2HS Foo #-}
 
+-- ** base
 record Fooable (a : Set) : Set where
-  field
-    doTheFoo : a
-open Fooable {{...}} public
+  field doTheFoo defaultFoo : a
+-- ** defaults
+record DefaultFooable (a : Set) : Set where
+  field doTheFoo : a
 
-{-# COMPILE AGDA2HS Fooable class #-}
-
+  defaultFoo : a
+  defaultFoo = doTheFoo
+-- ** export
+open Fooable ⦃...⦄ public
+{-# COMPILE AGDA2HS Fooable class DefaultFooable #-}
+-- ** instances
 instance
   FF : Fooable Foo
-  FF .doTheFoo = MkFoo
-
+  FF = record {DefaultFooable (λ where .doTheFoo → MkFoo)}
+    where open DefaultFooable
 {-# COMPILE AGDA2HS FF #-}
 
 open import SecondImportee public

--- a/test/Importer.agda
+++ b/test/Importer.agda
@@ -1,44 +1,52 @@
 open import Haskell.Prelude
+
+{-# FOREIGN AGDA2HS
+-- ** simple imports (possibly with transitive dependencies)
+#-}
+
 open import Importee
-open import OtherImportee using ( MkFoo )
-import QualifiedImportee as Qually
+open import OtherImportee using (MkFoo)
 
 bar : Int
 bar = foo
-
 {-# COMPILE AGDA2HS bar #-}
 
-otherBar : Int
-otherBar = anotherFoo
-
-{-# COMPILE AGDA2HS otherBar #-}
-
-thirdBar : Int
-thirdBar = Qually.foo
-
-{-# COMPILE AGDA2HS thirdBar #-}
+anotherBar : Int
+anotherBar = anotherFoo
+{-# COMPILE AGDA2HS anotherBar #-}
 
 baz : Int
 baz = 21 !# 21
-
 {-# COMPILE AGDA2HS baz #-}
 
-otherBaz : Int
-otherBaz = 2 Qually.!# 2
+mkFoo : Foo
+mkFoo = MkFoo -- This is MkFoo from Importee, NOT from OtherImportee!!
+{-# COMPILE AGDA2HS mkFoo #-}
 
-{-# COMPILE AGDA2HS otherBaz #-}
+fooable : Foo
+fooable = doTheFoo
+{-# COMPILE AGDA2HS fooable #-}
 
-myFoo : Foo
-myFoo = MkFoo -- This is MkFoo from Importee, NOT from OtherImportee!!
+{-# FOREIGN AGDA2HS
+-- ** interplay with class default methods
+#-}
 
-{-# COMPILE AGDA2HS myFoo #-}
+defaultBar : Foo
+defaultBar = defaultFoo
+{-# COMPILE AGDA2HS defaultBar #-}
 
-myOtherFoo : Foo
-myOtherFoo = doTheFoo
+{-# FOREIGN AGDA2HS
+-- ** interplay with methods of existing class
+#-}
 
-{-# COMPILE AGDA2HS myOtherFoo #-}
+testFoldMap : List Nat → List Nat
+testFoldMap = foldMap _∷_ []
+{-# COMPILE AGDA2HS testFoldMap #-}
 
-thirdFoo : Qually.Foo
-thirdFoo = Qually.doTheFoo
+{-# FOREIGN AGDA2HS
+-- ** interplay with default methods of existing class
+#-}
 
-{-# COMPILE AGDA2HS thirdFoo #-}
+testFoldr : List Nat → Nat
+testFoldr = foldr (λ _ x → x) 0
+{-# COMPILE AGDA2HS testFoldr #-}

--- a/test/Importer.agda
+++ b/test/Importer.agda
@@ -1,16 +1,32 @@
 open import Haskell.Prelude
 open import Importee
 open import OtherImportee using ( MkFoo )
+import QualifiedImportee as Qually
 
 bar : Int
 bar = foo
 
 {-# COMPILE AGDA2HS bar #-}
 
+otherBar : Int
+otherBar = anotherFoo
+
+{-# COMPILE AGDA2HS otherBar #-}
+
+thirdBar : Int
+thirdBar = Qually.foo
+
+{-# COMPILE AGDA2HS thirdBar #-}
+
 baz : Int
 baz = 21 !# 21
 
 {-# COMPILE AGDA2HS baz #-}
+
+otherBaz : Int
+otherBaz = 2 Qually.!# 2
+
+{-# COMPILE AGDA2HS otherBaz #-}
 
 myFoo : Foo
 myFoo = MkFoo -- This is MkFoo from Importee, NOT from OtherImportee!!
@@ -22,7 +38,7 @@ myOtherFoo = doTheFoo
 
 {-# COMPILE AGDA2HS myOtherFoo #-}
 
-otherBar : Int
-otherBar = anotherFoo
+thirdFoo : Qually.Foo
+thirdFoo = Qually.doTheFoo
 
-{-# COMPILE AGDA2HS otherBar #-}
+{-# COMPILE AGDA2HS thirdFoo #-}

--- a/test/QualifiedImportee.agda
+++ b/test/QualifiedImportee.agda
@@ -15,15 +15,21 @@ data Foo : Set where
 
 {-# COMPILE AGDA2HS Foo #-}
 
+-- ** base
 record Fooable (a : Set) : Set where
-  field
-    doTheFoo : a
-open Fooable {{...}} public
+  field doTheFoo defaultFoo : a
+-- ** defaults
+record DefaultFooable (a : Set) : Set where
+  field doTheFoo : a
 
-{-# COMPILE AGDA2HS Fooable class #-}
-
+  defaultFoo : a
+  defaultFoo = doTheFoo
+-- ** export
+open Fooable ⦃...⦄ public
+{-# COMPILE AGDA2HS Fooable class DefaultFooable #-}
+-- ** instances
 instance
   FF : Fooable Foo
-  FF .doTheFoo = MkFoo
-
+  FF = record {DefaultFooable (λ where .doTheFoo → MkFoo)}
+    where open DefaultFooable
 {-# COMPILE AGDA2HS FF #-}

--- a/test/QualifiedImportee.agda
+++ b/test/QualifiedImportee.agda
@@ -1,0 +1,29 @@
+open import Haskell.Prelude
+
+foo : Int
+foo = 43
+
+{-# COMPILE AGDA2HS foo #-}
+
+_!#_ : Int → Int → Int
+x !# y = x - y
+
+{-# COMPILE AGDA2HS _!#_ #-}
+
+data Foo : Set where
+  MkFoo : Foo
+
+{-# COMPILE AGDA2HS Foo #-}
+
+record Fooable (a : Set) : Set where
+  field
+    doTheFoo : a
+open Fooable {{...}} public
+
+{-# COMPILE AGDA2HS Fooable class #-}
+
+instance
+  FF : Fooable Foo
+  FF .doTheFoo = MkFoo
+
+{-# COMPILE AGDA2HS FF #-}

--- a/test/QualifiedImports.agda
+++ b/test/QualifiedImports.agda
@@ -1,0 +1,37 @@
+open import Haskell.Prelude
+
+{-# FOREIGN AGDA2HS
+-- ** simple qualification
+#-}
+
+import Importee
+
+simpqualBar : Int
+simpqualBar = Importee.foo
+{-# COMPILE AGDA2HS simpqualBar #-}
+
+simpfoo : Importee.Foo
+simpfoo = Importee.Foo.MkFoo
+{-# COMPILE AGDA2HS simpfoo #-}
+
+{-# FOREIGN AGDA2HS
+-- ** qualified imports
+#-}
+
+import QualifiedImportee as Qually
+
+qualBar : Int
+qualBar = Qually.foo
+{-# COMPILE AGDA2HS qualBar #-}
+
+qualBaz : Int
+qualBaz = 2 Qually.!# 2
+{-# COMPILE AGDA2HS qualBaz #-}
+
+qualFooable : Qually.Foo
+qualFooable = Qually.doTheFoo
+{-# COMPILE AGDA2HS qualFooable #-}
+
+qualDefaultBar : Qually.Foo
+qualDefaultBar = Qually.defaultFoo
+{-# COMPILE AGDA2HS qualDefaultBar #-}

--- a/test/QualifiedModule.agda
+++ b/test/QualifiedModule.agda
@@ -21,4 +21,4 @@ module A where
       h = C
   {-# COMPILE AGDA2HS g #-}
 
-open A
+open A public

--- a/test/QualifiedPrelude.agda
+++ b/test/QualifiedPrelude.agda
@@ -1,0 +1,37 @@
+{-# FOREIGN AGDA2HS
+-- ** qualifying the Prelude
+#-}
+import Haskell.Prelude as Pre
+
+_+_ : Pre.Nat → Pre.Nat → Pre.Nat
+x + y = x
+{-# COMPILE AGDA2HS _+_ #-}
+
+comp : (Pre.Nat → Pre.Nat) → (Pre.Nat → Pre.Nat) → (Pre.Nat → Pre.Nat)
+comp f g = f Pre.∘ g
+{-# COMPILE AGDA2HS comp #-}
+
+test : Pre.Nat
+test = 0 Pre.+ 1 + 0
+{-# COMPILE AGDA2HS test #-}
+
+testComp : Pre.Nat
+testComp = comp (_+ 0) (Pre._+ 1) 0
+{-# COMPILE AGDA2HS testComp #-}
+
+{-# FOREIGN AGDA2HS
+-- ** interplay with (qualified) default methods of existing class
+#-}
+
+testFoldr : Pre.List Pre.Nat → Pre.Nat
+testFoldr = Pre.foldr (λ _ x → x) 0
+{-# COMPILE AGDA2HS testFoldr #-}
+
+{-# FOREIGN AGDA2HS
+-- ** re-qualifying the Prelude
+#-}
+import Haskell.Prelude as pre
+
+retest : pre.Nat
+retest = 0 pre.+ 1 + 0
+{-# COMPILE AGDA2HS retest #-}

--- a/test/RequalifiedImports.agda
+++ b/test/RequalifiedImports.agda
@@ -1,0 +1,44 @@
+open import Haskell.Prelude
+
+{-# FOREIGN AGDA2HS
+-- ** conflicting imports are all replaced with the "smallest" qualifier
+--   * the characters are ordered based on their ASCII value (i.e. capitals first)
+--   * the order of the imports in the file does not matter
+--   * the scope-checker has already replaced previous definitions in the file
+#-}
+
+import QualifiedImportee as C
+
+requalBar : Int
+requalBar = C.foo
+{-# COMPILE AGDA2HS requalBar #-}
+
+import QualifiedImportee as A
+
+requalBaz : Int
+requalBaz = 2 A.!# 2
+{-# COMPILE AGDA2HS requalBaz #-}
+
+requalFooable : A.Foo
+requalFooable = C.doTheFoo
+{-# COMPILE AGDA2HS requalFooable #-}
+
+import QualifiedImportee as B
+
+requalDefaultBar : B.Foo
+requalDefaultBar = B.defaultFoo
+{-# COMPILE AGDA2HS requalDefaultBar #-}
+
+{-# FOREIGN AGDA2HS
+-- ** qualifying an open'ed module has no effect
+#-}
+import Haskell.Prelude as Pre
+import OtherImportee as Other
+open import OtherImportee using (OtherFoo)
+
+T = Pre.Int
+{-# COMPILE AGDA2HS T #-}
+
+otherFoo : OtherFoo
+otherFoo = Other.MkFoo -- this qualification is not retained
+{-# COMPILE AGDA2HS otherFoo #-}

--- a/test/Test.agda
+++ b/test/Test.agda
@@ -187,7 +187,9 @@ instance
   SemigroupNatSum ._<>_ (MkSum a) (MkSum b) = MkSum (a + b)
 
   MonoidNatSum : Monoid NatSum
-  MonoidNatSum .mempty = MkSum 0
+  MonoidNatSum = record {DefaultMonoid (λ where
+    .mempty → MkSum 0
+   )} where open DefaultMonoid
 
 double : ⦃ Monoid a ⦄ → a → a
 double x = x <> x

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -35,7 +35,11 @@ import TransparentFun
 import Issue115
 import BangPatterns
 import Issue94
-import Importer
 import DoNotation
 import NewTypePragma
+import Importer
+import QualifiedImports
+import CommonQualifiedImports
+import RequalifiedImports
+import QualifiedPrelude
 

--- a/test/golden/ClashingImport.err
+++ b/test/golden/ClashingImport.err
@@ -1,0 +1,1 @@
+Clashing import: MkFoo (both from Foo and OtherFoo)

--- a/test/golden/CommonQualifiedImports.hs
+++ b/test/golden/CommonQualifiedImports.hs
@@ -1,0 +1,11 @@
+module CommonQualifiedImports where
+
+import qualified Importee as Common (foo)
+import qualified Prelude as Common (Int, (+))
+import qualified SecondImportee as Common (anotherFoo)
+
+-- ** common qualification
+
+foos :: Common.Int
+foos = (Common.+) Common.foo Common.anotherFoo
+

--- a/test/golden/DefaultMethods.hs
+++ b/test/golden/DefaultMethods.hs
@@ -2,10 +2,8 @@
 
 module DefaultMethods where
 
-import Numeric.Natural (Natural)
 
-
-import Prelude hiding (Show, ShowS, show, showList, showString, showParen, Ord, (<), (>))
+import Prelude hiding (Show, show, showsPrec, showList, Ord, (<), (>))
 
 class Ord a where
     (<) :: a -> a -> Bool
@@ -69,15 +67,6 @@ instance Ord Bool6 where
     Mk6 False > _ = False
     Mk6 True > Mk6 b = not b
 
-type ShowS = String -> String
-
-showString :: String -> ShowS
-showString = (++)
-
-showParen :: Bool -> ShowS -> ShowS
-showParen False s = s
-showParen True s = showString "(" . s . showString ")"
-
 defaultShowList :: (a -> ShowS) -> [a] -> ShowS
 defaultShowList _ [] = showString "[]"
 defaultShowList shows (x : xs)
@@ -87,12 +76,12 @@ defaultShowList shows (x : xs)
 
 class Show a where
     show :: a -> String
-    showPrec :: Natural -> a -> ShowS
+    showsPrec :: Int -> a -> ShowS
     showList :: [a] -> ShowS
-    {-# MINIMAL showPrec | show #-}
-    show x = showPrec 0 x ""
-    showList = defaultShowList (showPrec 0)
-    showPrec _ x s = show x ++ s
+    {-# MINIMAL showsPrec | show #-}
+    show x = showsPrec 0 x ""
+    showList = defaultShowList (showsPrec 0)
+    showsPrec _ x s = show x ++ s
 
 instance Show Bool where
     show True = "True"
@@ -102,10 +91,10 @@ instance Show Bool where
     showList (False : bs) = showString "0" . showList bs
 
 instance (Show a) => Show (Maybe a) where
-    showPrec n Nothing = showString "nothing"
-    showPrec n (Just x)
-      = showParen True (showString "just " . showPrec 10 x)
+    showsPrec n Nothing = showString "nothing"
+    showsPrec n (Just x)
+      = showParen True (showString "just " . showsPrec 10 x)
 
 instance (Show a) => Show ([a]) where
-    showPrec _ = showList
+    showsPrec _ = showList
 

--- a/test/golden/Importee.hs
+++ b/test/golden/Importee.hs
@@ -10,6 +10,9 @@ data Foo = MkFoo
 
 class Fooable a where
     doTheFoo :: a
+    defaultFoo :: a
+    {-# MINIMAL doTheFoo #-}
+    defaultFoo = doTheFoo
 
 instance Fooable Foo where
     doTheFoo = MkFoo

--- a/test/golden/Importer.hs
+++ b/test/golden/Importer.hs
@@ -1,13 +1,24 @@
 module Importer where
 
 import Importee (Foo(MkFoo), Fooable(doTheFoo), foo, (!#))
+import qualified QualifiedImportee as Qually
+       (Foo, Fooable(doTheFoo), foo, (!#))
 import SecondImportee (anotherFoo)
 
 bar :: Int
 bar = foo
 
+otherBar :: Int
+otherBar = anotherFoo
+
+thirdBar :: Int
+thirdBar = Qually.foo
+
 baz :: Int
 baz = 21 !# 21
+
+otherBaz :: Int
+otherBaz = (Qually.!#) 2 2
 
 myFoo :: Foo
 myFoo = MkFoo
@@ -15,6 +26,6 @@ myFoo = MkFoo
 myOtherFoo :: Foo
 myOtherFoo = doTheFoo
 
-otherBar :: Int
-otherBar = anotherFoo
+thirdFoo :: Qually.Foo
+thirdFoo = Qually.doTheFoo
 

--- a/test/golden/Importer.hs
+++ b/test/golden/Importer.hs
@@ -1,31 +1,39 @@
 module Importer where
 
-import Importee (Foo(MkFoo), Fooable(doTheFoo), foo, (!#))
-import qualified QualifiedImportee as Qually
-       (Foo, Fooable(doTheFoo), foo, (!#))
+import Importee
+       (Foo(MkFoo), Fooable(defaultFoo, doTheFoo), foo, (!#))
+import Numeric.Natural (Natural)
 import SecondImportee (anotherFoo)
+
+-- ** simple imports (possibly with transitive dependencies)
 
 bar :: Int
 bar = foo
 
-otherBar :: Int
-otherBar = anotherFoo
-
-thirdBar :: Int
-thirdBar = Qually.foo
+anotherBar :: Int
+anotherBar = anotherFoo
 
 baz :: Int
 baz = 21 !# 21
 
-otherBaz :: Int
-otherBaz = (Qually.!#) 2 2
+mkFoo :: Foo
+mkFoo = MkFoo
 
-myFoo :: Foo
-myFoo = MkFoo
+fooable :: Foo
+fooable = doTheFoo
 
-myOtherFoo :: Foo
-myOtherFoo = doTheFoo
+-- ** interplay with class default methods
 
-thirdFoo :: Qually.Foo
-thirdFoo = Qually.doTheFoo
+defaultBar :: Foo
+defaultBar = defaultFoo
+
+-- ** interplay with methods of existing class
+
+testFoldMap :: [Natural] -> [Natural]
+testFoldMap = foldMap (:) []
+
+-- ** interplay with default methods of existing class
+
+testFoldr :: [Natural] -> Natural
+testFoldr = foldr (\ _ x -> x) 0
 

--- a/test/golden/QualifiedImportee.hs
+++ b/test/golden/QualifiedImportee.hs
@@ -10,6 +10,9 @@ data Foo = MkFoo
 
 class Fooable a where
     doTheFoo :: a
+    defaultFoo :: a
+    {-# MINIMAL doTheFoo #-}
+    defaultFoo = doTheFoo
 
 instance Fooable Foo where
     doTheFoo = MkFoo

--- a/test/golden/QualifiedImportee.hs
+++ b/test/golden/QualifiedImportee.hs
@@ -1,0 +1,16 @@
+module QualifiedImportee where
+
+foo :: Int
+foo = 43
+
+(!#) :: Int -> Int -> Int
+x !# y = x - y
+
+data Foo = MkFoo
+
+class Fooable a where
+    doTheFoo :: a
+
+instance Fooable Foo where
+    doTheFoo = MkFoo
+

--- a/test/golden/QualifiedImports.hs
+++ b/test/golden/QualifiedImports.hs
@@ -1,0 +1,28 @@
+module QualifiedImports where
+
+import qualified Importee (Foo(MkFoo), foo)
+import qualified QualifiedImportee as Qually
+       (Foo, Fooable(defaultFoo, doTheFoo), foo, (!#))
+
+-- ** simple qualification
+
+simpqualBar :: Int
+simpqualBar = Importee.foo
+
+simpfoo :: Importee.Foo
+simpfoo = Importee.MkFoo
+
+-- ** qualified imports
+
+qualBar :: Int
+qualBar = Qually.foo
+
+qualBaz :: Int
+qualBaz = (Qually.!#) 2 2
+
+qualFooable :: Qually.Foo
+qualFooable = Qually.doTheFoo
+
+qualDefaultBar :: Qually.Foo
+qualDefaultBar = Qually.defaultFoo
+

--- a/test/golden/QualifiedPrelude.hs
+++ b/test/golden/QualifiedPrelude.hs
@@ -1,0 +1,30 @@
+module QualifiedPrelude where
+
+import Numeric.Natural (Natural)
+import qualified Prelude as Pre (foldr, (+), (.))
+
+-- ** qualifying the Prelude
+
+(+) :: Natural -> Natural -> Natural
+x + y = x
+
+comp ::
+     (Natural -> Natural) -> (Natural -> Natural) -> Natural -> Natural
+comp f g = (Pre..) f g
+
+test :: Natural
+test = (Pre.+) 0 (1 + 0)
+
+testComp :: Natural
+testComp = comp (+ 0) (\ section -> (Pre.+) section 1) 0
+
+-- ** interplay with (qualified) default methods of existing class
+
+testFoldr :: [Natural] -> Natural
+testFoldr = Pre.foldr (\ _ x -> x) 0
+
+-- ** re-qualifying the Prelude
+
+retest :: Natural
+retest = (Pre.+) 0 (1 + 0)
+

--- a/test/golden/RequalifiedImports.hs
+++ b/test/golden/RequalifiedImports.hs
@@ -1,0 +1,30 @@
+module RequalifiedImports where
+
+import OtherImportee (OtherFoo(MkFoo))
+import qualified QualifiedImportee as A
+       (Foo, Fooable(defaultFoo, doTheFoo), foo, (!#))
+
+-- ** conflicting imports are all replaced with the "smallest" qualifier
+--   * the characters are ordered based on their ASCII value (i.e. capitals first)
+--   * the order of the imports in the file does not matter
+--   * the scope-checker has already replaced previous definitions in the file
+
+requalBar :: Int
+requalBar = A.foo
+
+requalBaz :: Int
+requalBaz = (A.!#) 2 2
+
+requalFooable :: A.Foo
+requalFooable = A.doTheFoo
+
+requalDefaultBar :: A.Foo
+requalDefaultBar = A.defaultFoo
+
+-- ** qualifying an open'ed module has no effect
+
+type T = Int
+
+otherFoo :: OtherFoo
+otherFoo = MkFoo
+


### PR DESCRIPTION
This fixes #123 by trying to detect which names are used in a qualified way through the reverse scope map that's used internally by Agda. There are a few dirty tricks here to ensure that names of internal Agda modules (e.g. record modules) do not appear in the generated Haskell code, but I *think* my approach does the right thing in all "normal" use cases.

One thing that could still be improved here is that agda2hs could throw an error when you use local modules in your Agda code and you do not `open public` them. Currently this will just lead to agda2hs generating bogus qualifiers. For this reason I also had to move the functions that are defined in the `Foldable` class out of the record, a proper solution here would be to instead make use of the support for default methods added in https://github.com/agda/agda2hs/pull/72.

The main thing this still needs is more testing, so if you can please write some code with qualified imports and report back on if it works!