### PR TITLE
Add the newtype pragma

### DIFF
--- a/docs/source/features.md
+++ b/docs/source/features.md
@@ -2,17 +2,39 @@
 
 By default, all of the following Agda examples are implicitly prefixed (if
 necessary) with the following snippet.
+
 ```agda
 open import Haskell.Prelude
 ```
 
-## Datatypes
+## Data & Type Declarations
+
+### Types
+
+Creating a type synonym using the `type` keyword requires only a simple declaration in Agda.
+
+Agda:
+```agda
+Entry = Int × List String
+
+{-# COMPILE AGDA2HS Entry #-}
+```
+
+Haskell:
+```hs
+type Entry = (Int, [String])
+```
+
+### Datatypes
+
+Standard data type declarations have a simple equivalent in Agda.
 
 Agda:
 ```agda
 data Nat : Set where
     Zero : Nat 
     Suc : Nat → Nat
+
 {-# COMPILE AGDA2HS Nat #-}
 ```
 
@@ -21,11 +43,108 @@ Haskell:
 data Nat = Zero | Suc Nat
 ```
 
+You can also use polymorphic types in the data declarations.
+
+Agda:
+```agda
+data Tree (a : Set) : Set where
+    Leaf   : a → Tree a
+    Branch : a → Tree a → Tree a → Tree a
+    
+{-# COMPILE AGDA2HS Tree #-}
+```
+
+Haskell:
+```hs
+data Tree a = Leaf a
+            | Branch a (Tree a) (Tree a)
+```
+
 **UNSUPPORTED: term-indexed datatypes**
+
+### Records
+
+Data definitions with fields are represented by records on the Agda side.
+
+Agda:
+```agda
+record Citation : Set where
+    field
+        id     : Int
+        author : String
+        title  : String
+        url    : String
+        year   : Int
+open Citation public
+
+{-# COMPILE AGDA2HS Citation #-}
+```
+
+Haskell:
+```hs
+data Citation = Citation{id :: Int, author :: String,
+                         title :: String, url :: String, year :: Int}
+```
+
+### Newtypes
+
+Data declaration using the `newtype` keyword can be created by adding a `newtype` annotation to the compile pragma.
+
+Agda:
+```agda
+-- data newtype
+data Indexed (a : Set) : Set where
+    MkIndexed : Int × a → Indexed a
+
+{-# COMPILE AGDA2HS Indexed newtype #-}
+
+-- data newtype with deriving
+data Pair (a b : Set) : Set where
+    MkPair : a × b → Pair a b
+
+{-# COMPILE AGDA2HS Pair newtype deriving ( Show, Eq ) #-}
+
+-- record newtype
+record Identity (a : Set) : Set where
+    constructor MkIdentity
+    field
+        runIdentity : a
+open Identity public
+
+{-# COMPILE AGDA2HS Identity newtype #-}
+
+-- record newtype with erased proof
+record Equal (a : Set) : Set where
+    constructor MkEqual
+    field
+        pair : a × a
+        @0 proof : (fst pair) ≡ (snd pair)
+open Equal public
+
+{-# COMPILE AGDA2HS Equal newtype #-}
+```
+
+Haskell:
+```hs
+-- data newtype
+newtype Indexed a = MkIndexed (Int, a)
+
+-- data newtype with deriving
+newtype Pair a b = MkPair (a, b)
+                     deriving (Show, Eq)
+
+-- record newtype
+newtype Identity a = MkIdentity{runIdentity :: a}
+
+-- record newtype with erased proof
+newtype Equal a = MkEqual{pair :: (a, a)}
+```
+
+_Note: Unfortunately, Agda does not allow the constructor name to be the same as the data/record name._
 
 ## Pattern Matching on Datatype Values
 
-Agda
+Agda:
 ```agda
 {-# FOREIGN AGDA2HS {-# LANGUAGE LambdaCase #-} #-}
 

--- a/src/Agda2Hs/Compile.hs
+++ b/src/Agda2Hs/Compile.hs
@@ -49,8 +49,12 @@ compile _ _ _ def = withCurrentModule (qnameModule $ defName def) $ runC $
         checkTransparentPragma def >> return [] -- also no code generation
       (ClassPragma ms, _, Record{}) ->
         tag . single <$> compileRecord (ToClass ms) def
+      (NewTypePragma ds, _, Record{}) ->
+        tag . single <$> compileRecord (ToRecordNewType ds) def
+      (NewTypePragma ds, _, Datatype{}) ->
+        tag <$> compileData (ToDataNewType) ds def
       (DefaultPragma ds, _, Datatype{}) ->
-        tag <$> compileData ds def
+        tag <$> compileData (ToData) ds def
       (DefaultPragma _, Just _, _) ->
         tag . single <$> compileInstance def
       (DefaultPragma _, _, Axiom{}) ->

--- a/src/Agda2Hs/Compile.hs
+++ b/src/Agda2Hs/Compile.hs
@@ -52,9 +52,9 @@ compile _ _ _ def = withCurrentModule (qnameModule $ defName def) $ runC $
       (NewTypePragma ds, _, Record{}) ->
         tag . single <$> compileRecord (ToRecordNewType ds) def
       (NewTypePragma ds, _, Datatype{}) ->
-        tag <$> compileData (ToDataNewType) ds def
+        tag <$> compileData ToDataNewType ds def
       (DefaultPragma ds, _, Datatype{}) ->
-        tag <$> compileData (ToData) ds def
+        tag <$> compileData ToData ds def
       (DefaultPragma _, Just _, _) ->
         tag . single <$> compileInstance def
       (DefaultPragma _, _, Axiom{}) ->

--- a/src/Agda2Hs/Compile/Record.hs
+++ b/src/Agda2Hs/Compile/Record.hs
@@ -85,6 +85,18 @@ compileMinRecords def sls = do
   -- TODO: order default implementations differently?
   return ([minPragma | not (null prims)] ++ Map.elems decls)
 
+-- compileDataRecord :: Hs.Name () -> (Hs.Name () -> Hs.Type () -> b)
+--                      -> [Dom QName] -> Telescope -> C ([Hs.Asst ()], [b])
+--                      -> Hs.DataOrNew () -> Hs.DeclHead () -> [Hs.Deriving ()]
+--                      -> C (Hs.Decl ())
+-- compileDataRecord cName fieldDecl recFields fieldTel don hd ds = do
+--   checkValidConName cName
+--   (constraints, fieldDecls) <- compileRecFields fieldDecl recFields fieldTel
+--   unless (null constraints) __IMPOSSIBLE__ -- no constraints for records
+--   mapM_ checkFieldInScope (map unDom recFields)
+--   let conDecl = Hs.QualConDecl () Nothing Nothing $ Hs.RecDecl () cName fieldDecls
+--   return $ Hs.DataDecl () (don) Nothing hd [conDecl] ds
+
 compileRecord :: RecordTarget -> Definition -> C (Hs.Decl ())
 compileRecord target def = setCurrentRange (nameBindingSite $ qnameName $ defName def) $ do
   TelV tel _ <- telViewUpTo recPars (defType def)
@@ -109,12 +121,19 @@ compileRecord target def = setCurrentRange (nameBindingSite $ qnameName $ defNam
         mapM_ checkFieldInScope (map unDom recFields)
         let conDecl = Hs.QualConDecl () Nothing Nothing $ Hs.RecDecl () cName fieldDecls
         return $ Hs.DataDecl () (Hs.DataType ()) Nothing hd [conDecl] ds
+      ToRecordNewType ds -> do
+        checkValidConName cName
+        (constraints, fieldDecls) <- compileRecFields fieldDecl recFields fieldTel
+        checkSingleField rName fieldDecls -- must have exactly 1 field
+        unless (null constraints) __IMPOSSIBLE__ -- no constraints for records
+        mapM_ checkFieldInScope (map unDom recFields)
+        let conDecl = Hs.QualConDecl () Nothing Nothing $ Hs.RecDecl () cName fieldDecls
+        return $ Hs.DataDecl () (Hs.NewType ()) Nothing hd [conDecl] ds
 
   where
     rName = hsName $ prettyShow $ qnameName $ defName def
     cName | recNamedCon = hsName $ prettyShow $ qnameName $ conName recConHead
           | otherwise   = rName   -- Reuse record name for constructor if no given name
-
 
     -- In Haskell, projections live in the same scope as the record type, so check here that the
     -- record module has been opened.

--- a/src/Agda2Hs/Compile/Record.hs
+++ b/src/Agda2Hs/Compile/Record.hs
@@ -85,18 +85,6 @@ compileMinRecords def sls = do
   -- TODO: order default implementations differently?
   return ([minPragma | not (null prims)] ++ Map.elems decls)
 
--- compileDataRecord :: Hs.Name () -> (Hs.Name () -> Hs.Type () -> b)
---                      -> [Dom QName] -> Telescope -> C ([Hs.Asst ()], [b])
---                      -> Hs.DataOrNew () -> Hs.DeclHead () -> [Hs.Deriving ()]
---                      -> C (Hs.Decl ())
--- compileDataRecord cName fieldDecl recFields fieldTel don hd ds = do
---   checkValidConName cName
---   (constraints, fieldDecls) <- compileRecFields fieldDecl recFields fieldTel
---   unless (null constraints) __IMPOSSIBLE__ -- no constraints for records
---   mapM_ checkFieldInScope (map unDom recFields)
---   let conDecl = Hs.QualConDecl () Nothing Nothing $ Hs.RecDecl () cName fieldDecls
---   return $ Hs.DataDecl () (don) Nothing hd [conDecl] ds
-
 compileRecord :: RecordTarget -> Definition -> C (Hs.Decl ())
 compileRecord target def = setCurrentRange (nameBindingSite $ qnameName $ defName def) $ do
   TelV tel _ <- telViewUpTo recPars (defType def)
@@ -121,7 +109,7 @@ compileRecord target def = setCurrentRange (nameBindingSite $ qnameName $ defNam
       ToRecordNewType ds -> do
         checkValidConName cName
         (constraints, fieldDecls) <- compileRecFields fieldDecl recFields fieldTel
-        checkSingleField rName fieldDecls -- must have exactly 1 field
+        checkSingleField rName fieldDecls
         compileDataRecord constraints fieldDecls (Hs.NewType ()) hd ds
 
   where
@@ -174,7 +162,7 @@ compileRecord target def = setCurrentRange (nameBindingSite $ qnameName $ defNam
       unless (null constraints) __IMPOSSIBLE__ -- no constraints for records
       mapM_ checkFieldInScope (map unDom recFields)
       let conDecl = Hs.QualConDecl () Nothing Nothing $ Hs.RecDecl () cName fieldDecls
-      return $ Hs.DataDecl () (don) Nothing hd [conDecl] ds
+      return $ Hs.DataDecl () don Nothing hd [conDecl] ds
 
 checkUnboxPragma :: Defn -> C ()
 checkUnboxPragma def@Record{ recFields = (f:fs) }

--- a/src/Agda2Hs/Compile/Types.hs
+++ b/src/Agda2Hs/Compile/Types.hs
@@ -73,4 +73,6 @@ data CompiledDom
 
 type LocalDecls = [QName]
 
-data RecordTarget = ToRecord [Hs.Deriving ()] | ToClass [String]
+data DataTarget = ToData | ToDataNewType
+
+data RecordTarget = ToRecord [Hs.Deriving ()] | ToRecordNewType [Hs.Deriving ()] | ToClass [String]

--- a/src/Agda2Hs/Compile/Utils.hs
+++ b/src/Agda2Hs/Compile/Utils.hs
@@ -243,8 +243,3 @@ addTyBang Lazy   ty = return ty
 checkSingleField :: Hs.Name () -> [b] -> C ()
 checkSingleField name fs = unless (length fs == 1) $ genericDocError =<< do
   text "Newtype must have exactly one field in definition: " <+> text (Hs.prettyPrint name)
-
-checkValidNewtype :: Hs.Name () -> Hs.Name () -> [b] -> C ()
-checkValidNewtype cName rName fs = do
-  checkValidConName cName
-  checkSingleField rName fs

--- a/src/Agda2Hs/Compile/Utils.hs
+++ b/src/Agda2Hs/Compile/Utils.hs
@@ -239,3 +239,12 @@ addTyBang :: Strictness -> Hs.Type () -> C (Hs.Type ())
 addTyBang Strict ty = tellExtension Hs.BangPatterns >>
   return (Hs.TyBang () (Hs.BangedTy ()) (Hs.NoUnpackPragma ()) ty)
 addTyBang Lazy   ty = return ty
+
+checkSingleField :: Hs.Name () -> [b] -> C ()
+checkSingleField name fs = unless (length fs == 1) $ genericDocError =<< do
+  text "Newtype must have exactly one field in definition: " <+> text (Hs.prettyPrint name)
+
+checkValidNewtype :: Hs.Name () -> Hs.Name () -> [b] -> C ()
+checkValidNewtype cName rName fs = do
+  checkValidConName cName
+  checkSingleField rName fs

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -39,6 +39,7 @@ import Issue94
 import Issue107
 import Importer
 import DoNotation
+import NewTypePragma
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -78,4 +79,5 @@ import BangPatterns
 import Issue94
 import Importer
 import DoNotation
+import NewTypePragma
 #-}

--- a/test/NewTypePragma.agda
+++ b/test/NewTypePragma.agda
@@ -1,0 +1,48 @@
+open import Haskell.Prelude using ( Int ; fst ; snd
+                                  ; a ; b
+                                  ; _×_ ; _≡_
+                                  )
+
+-- data newtype
+{-# FOREIGN AGDA2HS -- data newtype #-}
+
+data Indexed (a : Set) : Set where
+    MkIndexed : Int × a → Indexed a
+
+{-# COMPILE AGDA2HS Indexed newtype #-}
+
+index : Int × a → Indexed a
+index = MkIndexed
+
+{-# COMPILE AGDA2HS index #-}
+
+-- data newtype with deriving
+{-# FOREIGN AGDA2HS -- data newtype with deriving #-}
+
+data Pair (a b : Set) : Set where
+    MkPair : a × b → Pair a b
+
+{-# COMPILE AGDA2HS Pair newtype deriving ( Show, Eq ) #-}
+
+-- record newtype
+{-# FOREIGN AGDA2HS -- record newtype #-}
+
+record Identity (a : Set) : Set where
+    constructor MkIdentity
+    field
+        runIdentity : a
+open Identity public
+
+{-# COMPILE AGDA2HS Identity newtype #-}
+
+-- record newtype with erased proof
+{-# FOREIGN AGDA2HS -- record newtype with erased proof #-}
+
+record Equal (a : Set) : Set where
+    constructor MkEqual
+    field
+        pair : a × a
+        @0 proof : (fst pair) ≡ (snd pair)
+open Equal public
+
+{-# COMPILE AGDA2HS Equal newtype #-}

--- a/test/NewTypePragma.agda
+++ b/test/NewTypePragma.agda
@@ -3,8 +3,9 @@ open import Haskell.Prelude using ( Int ; fst ; snd
                                   ; _×_ ; _≡_
                                   )
 
+{-# FOREIGN AGDA2HS
 -- data newtype
-{-# FOREIGN AGDA2HS -- data newtype #-}
+#-}
 
 data Indexed (a : Set) : Set where
     MkIndexed : Int × a → Indexed a
@@ -16,16 +17,18 @@ index = MkIndexed
 
 {-# COMPILE AGDA2HS index #-}
 
+{-# FOREIGN AGDA2HS
 -- data newtype with deriving
-{-# FOREIGN AGDA2HS -- data newtype with deriving #-}
+#-}
 
 data Pair (a b : Set) : Set where
     MkPair : a × b → Pair a b
 
 {-# COMPILE AGDA2HS Pair newtype deriving ( Show, Eq ) #-}
 
+{-# FOREIGN AGDA2HS
 -- record newtype
-{-# FOREIGN AGDA2HS -- record newtype #-}
+#-}
 
 record Identity (a : Set) : Set where
     constructor MkIdentity
@@ -35,14 +38,15 @@ open Identity public
 
 {-# COMPILE AGDA2HS Identity newtype #-}
 
+{-# FOREIGN AGDA2HS
 -- record newtype with erased proof
-{-# FOREIGN AGDA2HS -- record newtype with erased proof #-}
+#-}
 
 record Equal (a : Set) : Set where
     constructor MkEqual
     field
         pair : a × a
-        @0 proof : (fst pair) ≡ (snd pair)
+        @0 proof : fst pair ≡ snd pair
 open Equal public
 
 {-# COMPILE AGDA2HS Equal newtype #-}

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -37,4 +37,5 @@ import BangPatterns
 import Issue94
 import Importer
 import DoNotation
+import NewTypePragma
 

--- a/test/golden/NewTypePragma.hs
+++ b/test/golden/NewTypePragma.hs
@@ -1,0 +1,22 @@
+module NewTypePragma where
+
+-- data newtype
+
+newtype Indexed a = MkIndexed (Int, a)
+
+index :: (Int, a) -> Indexed a
+index = MkIndexed
+
+-- data newtype with deriving
+
+newtype Pair a b = MkPair (a, b)
+                     deriving (Show, Eq)
+
+-- record newtype
+
+newtype Identity a = MkIdentity{runIdentity :: a}
+
+-- record newtype with erased proof
+
+newtype Equal a = MkEqual{pair :: (a, a)}
+


### PR DESCRIPTION
This PR adds the `newtype` pragma to allow compiling from `data` and `record` definitions in Agda to `newtype` definitions in Haskell (under the constraint that the definition has **exactly one** non-erased field).

<details>
<summary>Output for the compiled <code>test/NewTypePragma.agda</code> file.</summary>

```hs
module NewType.Example where

-- data newtype

newtype Indexed a = MkIndexed (Int, a)

index :: (Int, a) -> Indexed a
index = MkIndexed

-- data newtype with deriving

newtype Pair a b = MkPair (a, b)
                     deriving (Show, Eq)

-- record newtype

newtype Identity a = MkIdentity{runIdentity :: a}

-- record newtype with erased proof

newtype Equal a = MkEqual{pair :: (a, a)}
```

</details>

There are still a few things I would like to change (input welcome):

* [x] Reusing code within the `compileRecord` branches. The constraints are the problematic part here.
* [x] Make the test file actually be part of `make test`?
* [x] Add documentation about data and type declarations.