### PR TITLE
[ fix #143 ] allow function kind

### DIFF
--- a/src/Agda2Hs/Compile/Type.hs
+++ b/src/Agda2Hs/Compile/Type.hs
@@ -183,8 +183,7 @@ compileKeptTeleBind :: Hs.Name () -> Type -> C (Hs.TyVarBind ())
 compileKeptTeleBind x t = do
   checkValidTyVarName x
   case compileKind t of
-    Just (Hs.TyStar ()) -> pure $ Hs.UnkindedVar () x
-    Just k              -> pure $ Hs.KindedVar () x k
+    Just k              -> pure $ Hs.UnkindedVar () x -- In the future we may want to show kind annotations
     _                   -> genericDocError =<<
       text "Kind of bound argument not supported:"
       <+> parens (text (Hs.prettyPrint x) <> text " : " <> prettyTCM t)

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -47,6 +47,7 @@ import QualifiedPrelude
 import AutoLambdaCaseInCase
 import AutoLambdaCaseInBind
 import WitnessedFlows
+import Kinds
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -94,4 +95,5 @@ import QualifiedPrelude
 import AutoLambdaCaseInCase
 import AutoLambdaCaseInBind
 import WitnessedFlows
+import Kinds
 #-}

--- a/test/Kinds.agda
+++ b/test/Kinds.agda
@@ -1,0 +1,16 @@
+module Kinds where
+
+open import Haskell.Prelude
+
+record ReaderT (r : Set) (m : Set → Set) (a  : Set) : Set where
+  constructor RdrT
+  field runReaderT : r → m a
+open ReaderT public
+
+{-# COMPILE AGDA2HS ReaderT #-}
+
+data Kleisli (m : Set → Set) (a b : Set) : Set where
+  K : (a → m b) → Kleisli m a b
+
+{-# COMPILE AGDA2HS Kleisli #-}
+

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -45,4 +45,5 @@ import QualifiedPrelude
 import AutoLambdaCaseInCase
 import AutoLambdaCaseInBind
 import WitnessedFlows
+import Kinds
 

--- a/test/golden/Kinds.hs
+++ b/test/golden/Kinds.hs
@@ -1,0 +1,6 @@
+module Kinds where
+
+data ReaderT r m a = RdrT{runReaderT :: r -> m a}
+
+data Kleisli m a b = K (a -> m b)
+

--- a/test/golden/NonStarDatatypeIndex.err
+++ b/test/golden/NonStarDatatypeIndex.err
@@ -1,1 +1,1 @@
-Kind not supported: Nat
+Kind of bound argument not supported: (n : Nat)

--- a/test/golden/NonStarRecordIndex.err
+++ b/test/golden/NonStarRecordIndex.err
@@ -1,2 +1,2 @@
 test/Fail/NonStarRecordIndex.agda:5,8-9
-Kind not supported: Nat
+Kind of bound argument not supported: (n : Nat)


### PR DESCRIPTION
Added support for kind of type families. The error reporting felt somewhat redundant so I removed part of it. ~~For now kinds that are not `*` are annotated in the output Haskell, but maybe we never want annotations?~~

Next:
- [x] Add tests.
- [ ] I suspect more checks have to be done when compiling the Type to a Haskell kind, like making sure that the domain doesn't have some weird modality? Wouldn't mind some comments on this. 