### PR TITLE
[ fix #146 ] prevent copatterns in instance field clause

### DIFF
--- a/src/Agda2Hs/Compile.hs
+++ b/src/Agda2Hs/Compile.hs
@@ -19,7 +19,7 @@ initCompileEnv :: CompileEnv
 initCompileEnv = CompileEnv
   { minRecordName = Nothing
   , locals = []
-  , isCompilingInstance = False
+  , copatternsEnabled = False
   }
 
 runC :: C a -> TCM (a, CompileOutput)

--- a/src/Agda2Hs/Compile/ClassInstance.hs
+++ b/src/Agda2Hs/Compile/ClassInstance.hs
@@ -36,14 +36,14 @@ import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Utils
 import Agda2Hs.HsUtils
 
-compilingInstance :: C a -> C a
-compilingInstance = local $ \e -> e { isCompilingInstance = True }
+enableCopatterns :: C a -> C a
+enableCopatterns = local $ \e -> e { copatternsEnabled = True }
 
-outsideInstanceCompilation :: C a -> C a
-outsideInstanceCompilation = local $ \ e -> e { isCompilingInstance = False }
+disableCopatterns :: C a -> C a
+disableCopatterns = local $ \e -> e { copatternsEnabled = False }
 
 compileInstance :: Definition -> C (Hs.Decl ())
-compileInstance def@Defn{..} = compilingInstance $ setCurrentRange (nameBindingSite $ qnameName defName) $ do
+compileInstance def@Defn{..} = enableCopatterns $ setCurrentRange (nameBindingSite $ qnameName defName) $ do
   ir <- compileInstRule [] (unEl defType)
   withFunctionLocals defName $ do
     (ds, rs) <- concatUnzip <$> mapM (compileInstanceClause (qnameModule defName)) funClauses
@@ -163,7 +163,7 @@ compileInstanceClause curModule c = withClauseLocals curModule c $ do
 
          -- No minimal dictionary used, proceed with compiling as a regular clause.
          | otherwise
-         -> do ms <- outsideInstanceCompilation $ compileClause curModule uf c'
+         -> do ms <- disableCopatterns $ compileClause curModule uf c'
                return ([Hs.InsDecl () (Hs.FunBind () [ms]) | keepArg arg], [])
 
 fieldArgInfo :: QName -> C ArgInfo

--- a/src/Agda2Hs/Compile/ClassInstance.hs
+++ b/src/Agda2Hs/Compile/ClassInstance.hs
@@ -39,6 +39,10 @@ import Agda2Hs.HsUtils
 compilingInstance :: C a -> C a
 compilingInstance = local $ \e -> e { isCompilingInstance = True }
 
+outsideInstanceCompilation :: C a -> C a
+outsideInstanceCompilation = local $ \ e -> e { isCompilingInstance = False }
+
+compileInstance :: Definition -> C (Hs.Decl ())
 compileInstance def@Defn{..} = compilingInstance $ setCurrentRange (nameBindingSite $ qnameName defName) $ do
   ir <- compileInstRule [] (unEl defType)
   withFunctionLocals defName $ do
@@ -159,7 +163,7 @@ compileInstanceClause curModule c = withClauseLocals curModule c $ do
 
          -- No minimal dictionary used, proceed with compiling as a regular clause.
          | otherwise
-         -> do ms <- compileClause curModule uf c'
+         -> do ms <- outsideInstanceCompilation $ compileClause curModule uf c'
                return ([Hs.InsDecl () (Hs.FunBind () [ms]) | keepArg arg], [])
 
 fieldArgInfo :: QName -> C ArgInfo

--- a/src/Agda2Hs/Compile/Function.hs
+++ b/src/Agda2Hs/Compile/Function.hs
@@ -97,7 +97,7 @@ compileFun' withSig def@(Defn {..}) = do
   withCurrentModule m $ setCurrentRange (nameBindingSite n) $ do
     ifM (endsInSort defType) (ensureNoLocals err >> compileTypeDef x def) $ do
       when withSig $ checkValidFunName x
-      compileTopLevelType defType $ \ty -> do
+      compileTopLevelType withSig defType $ \ty -> do
         -- Instantiate the clauses to the current module parameters
         pars <- getContextArgs
         reportSDoc "agda2hs.compile" 10 $ text "applying clauses to parameters: " <+> prettyTCM pars
@@ -181,7 +181,7 @@ compilePat (ConP h _ ps) = isUnboxConstructor (conName h) >>= \ case
 compilePat (LitP _ l) = compileLitPat l
 compilePat (ProjP _ q) = do
   reportSDoc "agda2hs.compile" 6 $ text "compiling copattern: " <+> text (prettyShow q)
-  unlessM (asks isCompilingInstance) $
+  unlessM (asks copatternsEnabled) $
     genericDocError =<< text "not supported in Haskell: copatterns"
   let x = hsName $ prettyShow q
   return $ Hs.PVar () x

--- a/src/Agda2Hs/Compile/Types.hs
+++ b/src/Agda2Hs/Compile/Types.hs
@@ -36,7 +36,8 @@ data CompileEnv = CompileEnv
   -- ^ keeps track of the current minimal record we are compiling
   , locals :: LocalDecls
   -- ^ keeps track of the current clause's where declarations
-  , isCompilingInstance :: Bool
+  , copatternsEnabled :: Bool
+  -- ^ whether copatterns should be allowed when compiling patterns
   }
 
 data Import = Import

--- a/test/Fail/Issue146.agda
+++ b/test/Fail/Issue146.agda
@@ -1,0 +1,24 @@
+module Fail.Issue146 where
+
+open import Haskell.Prelude
+
+record Wrap (a : Set) : Set where
+  constructor MkWrap
+  field wrapped : a
+open Wrap public
+
+{-# COMPILE AGDA2HS Wrap #-}
+
+record Class (a : Set) : Set where
+  field
+    method : Wrap a → Wrap a
+open Class ⦃...⦄ public
+
+{-# COMPILE AGDA2HS Class class #-}
+
+instance
+  BoolClass : Class Bool
+  BoolClass .method (MkWrap x) .wrapped = x
+
+  {-# COMPILE AGDA2HS BoolClass #-}
+

--- a/test/golden/Issue146.err
+++ b/test/golden/Issue146.err
@@ -1,0 +1,2 @@
+test/Fail/Issue146.agda:20,3-12
+not supported in Haskell: copatterns


### PR DESCRIPTION
Very simple fix, but the naming could be improved upon.
Let's see how #149 evolves before improving this PR.

I suspect we could rename `isCompilingInstance` to `copatternsEnabled` and have switches `enableCopatterns`/`disableCopatterns` rather than `compilingInstance` and the badly named `outsideCompilationInstance`.