### PR TITLE
Add witnesses to flow control constructs

### DIFF
--- a/lib/Haskell/Prelude.agda
+++ b/lib/Haskell/Prelude.agda
@@ -8,7 +8,7 @@ open Haskell.Prim public using
     TypeError; ⊥; iNumberNat; IsTrue; IsFalse;
     All; allNil; allCons; NonEmpty; lengthNat;
     id; _∘_; _$_; flip; const;
-    if_then_else_; if'_then_else_; case_of_; case'_of_;
+    if_then_else_; case_of_;
     Number; fromNat; Negative; fromNeg;
     IsString; fromString;
     _≡_; refl;

--- a/lib/Haskell/Prelude.agda
+++ b/lib/Haskell/Prelude.agda
@@ -8,7 +8,7 @@ open Haskell.Prim public using
     TypeError; ⊥; iNumberNat; IsTrue; IsFalse;
     All; allNil; allCons; NonEmpty; lengthNat;
     id; _∘_; _$_; flip; const;
-    if_then_else_; case_of_;
+    if_then_else_; if'_then_else_; case_of_; case'_of_;
     Number; fromNat; Negative; fromNeg;
     IsString; fromString;
     _≡_; refl;

--- a/lib/Haskell/Prim.agda
+++ b/lib/Haskell/Prim.agda
@@ -53,7 +53,7 @@ f $ x = f x
 -- Language constructs
 
 infix -1 case_of_
-case_of_ : {@0 a b : Set ℓ} → (a' : a) → ((a'' : a) → @0 {{ a' ≡ a'' }} → b) → b
+case_of_ : (a' : a) → ((a'' : a) → @0 {{ a' ≡ a'' }} → b) → b
 case x of f = f x
 
 infix -2 if_then_else_

--- a/lib/Haskell/Prim.agda
+++ b/lib/Haskell/Prim.agda
@@ -53,22 +53,13 @@ f $ x = f x
 -- Language constructs
 
 infix -1 case_of_
-case_of_ : a → (a → b) → b
+case_of_ : {@0 a b : Set ℓ} → (a' : a) → ((a'' : a) → @0 {{ a' ≡ a'' }} → b) → b
 case x of f = f x
 
-infix -1 case'_of_
-case'_of_ : {@0 A b : Set ℓ} → (a : A) → ((a' : A) → @0 {{ a ≡ a' }} → b) → b
-case' x of f = f x
-
 infix -2 if_then_else_
-if_then_else_ : {@0 a : Set ℓ} → Bool → a → a → a
+if_then_else_ : {@0 a : Set ℓ} → (flg : Bool) → (@0 {{ flg ≡ True }} → a) → (@0 {{ flg ≡ False }} → a) → a
 if False then x else y = y
 if True  then x else y = x
-
-infix -2 if'_then_else_
-if'_then_else_ : {@0 a : Set ℓ} → (flg : Bool) → (@0 {{ flg ≡ True }} → a) → (@0 {{ flg ≡ False }} → a) → a
-if' False then x else y = y
-if' True  then x else y = x
 
 --------------------------------------------------
 -- Agda strings

--- a/lib/Haskell/Prim.agda
+++ b/lib/Haskell/Prim.agda
@@ -56,10 +56,19 @@ infix -1 case_of_
 case_of_ : a → (a → b) → b
 case x of f = f x
 
+infix -1 case'_of_
+case'_of_ : {@0 A b : Set ℓ} → (a : A) → ((a' : A) → @0 {{ a ≡ a' }} → b) → b
+case' x of f = f x
+
 infix -2 if_then_else_
 if_then_else_ : {@0 a : Set ℓ} → Bool → a → a → a
 if False then x else y = y
 if True  then x else y = x
+
+infix -2 if'_then_else_
+if'_then_else_ : {@0 a : Set ℓ} → (flg : Bool) → (@0 {{ flg ≡ True }} → a) → (@0 {{ flg ≡ False }} → a) → a
+if' False then x else y = y
+if' True  then x else y = x
 
 --------------------------------------------------
 -- Agda strings

--- a/src/Agda2Hs/Compile/Term.hs
+++ b/src/Agda2Hs/Compile/Term.hs
@@ -39,11 +39,15 @@ isSpecialTerm :: QName -> Maybe (QName -> Elims -> C (Hs.Exp ()))
 isSpecialTerm q = case prettyShow q of
   _ | isExtendedLambdaName q                    -> Just lambdaCase
   "Haskell.Prim.if_then_else_"                  -> Just ifThenElse
+  "Haskell.Prim.if'_then_else_"                 -> Just ifThenElse
   "Haskell.Prim.Enum.Enum.enumFrom"             -> Just mkEnumFrom
   "Haskell.Prim.Enum.Enum.enumFromTo"           -> Just mkEnumFromTo
   "Haskell.Prim.Enum.Enum.enumFromThen"         -> Just mkEnumFromThen
   "Haskell.Prim.Enum.Enum.enumFromThenTo"       -> Just mkEnumFromThenTo
   "Haskell.Prim.case_of_"                       -> Just caseOf
+  "Haskell.Prim.Monad.Do.Monad._>>=_"           -> Just bind
+  "Haskell.Prim.Monad.Do.Monad._>>_"            -> Just sequ
+  "Haskell.Prim.case'_of_"                      -> Just caseOf
   "Haskell.Prim.Monad.Do.Monad._>>=_"           -> Just bind
   "Haskell.Prim.Monad.Do.Monad._>>_"            -> Just sequ
   "Agda.Builtin.FromNat.Number.fromNat"         -> Just fromNat

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -46,6 +46,7 @@ import RequalifiedImports
 import QualifiedPrelude
 import AutoLambdaCaseInCase
 import AutoLambdaCaseInBind
+import WitnessedFlows
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -92,4 +93,5 @@ import RequalifiedImports
 import QualifiedPrelude
 import AutoLambdaCaseInCase
 import AutoLambdaCaseInBind
+import WitnessedFlows
 #-}

--- a/test/Fail/PartialCase.agda
+++ b/test/Fail/PartialCase.agda
@@ -1,0 +1,7 @@
+module Fail.PartialCase where
+
+open import Haskell.Prelude
+
+caseOf : (i : Int) → ((i' : Int) → @0 {{ i ≡ i' }} → Nat) → Nat
+caseOf = case_of_
+{-# COMPILE AGDA2HS caseOf #-}

--- a/test/Fail/PartialCaseNoLambda.agda
+++ b/test/Fail/PartialCaseNoLambda.agda
@@ -1,0 +1,7 @@
+module Fail.PartialCaseNoLambda where
+
+open import Haskell.Prelude
+
+applyToFalse : ((b : Bool) → @0 {{ False ≡ b }} → Int) → Int
+applyToFalse = case False of_
+{-# COMPILE AGDA2HS applyToFalse #-}

--- a/test/Fail/PartialIf.agda
+++ b/test/Fail/PartialIf.agda
@@ -1,0 +1,7 @@
+module Fail.PartialIf where
+
+open import Haskell.Prelude
+
+if_partial : (flg : Bool) → (@0 {{ flg ≡ True }} → Nat) → (@0 {{ flg ≡ False }} → Nat) → Nat
+if_partial = if_then_else_
+{-# COMPILE AGDA2HS if_partial #-}

--- a/test/LanguageConstructs.agda
+++ b/test/LanguageConstructs.agda
@@ -43,21 +43,6 @@ plus5minus5 : Int → Int
 plus5minus5 n = case n + 5 of λ m → m - 5
 {-# COMPILE AGDA2HS plus5minus5 #-}
 
--- Applied to non-lambda
-len : List a → Int
-len xs = case xs of length
-{-# COMPILE AGDA2HS len #-}
-
--- Underapplied
-applyToFalse : (Bool → a) → a
-applyToFalse = case False of_
-{-# COMPILE AGDA2HS applyToFalse #-}
-
-caseOf : a → (a → b) → b
-caseOf = case_of_
-{-# COMPILE AGDA2HS caseOf #-}
-
-
 --------------------------------------------------
 -- Enums
 

--- a/test/Test.agda
+++ b/test/Test.agda
@@ -225,27 +225,3 @@ ex_if = if True then 1 else 0
 if_over : Nat
 if_over = (if True then (λ x → x) else (λ x → x + 1)) 0
 {-# COMPILE AGDA2HS if_over #-}
-
-if_partial₁ : List Nat → List Nat
-if_partial₁ = map (if True then 1 else_)
-{-# COMPILE AGDA2HS if_partial₁ #-}
-
-if_partial₂ : List Nat → List (Nat → Nat)
-if_partial₂ = map (if True then_else_)
-{-# COMPILE AGDA2HS if_partial₂ #-}
-
-if_partial₃ : List Bool → List (Nat → Nat → Nat)
-if_partial₃ = map if_then_else_
-{-# COMPILE AGDA2HS if_partial₃ #-}
-
-if_partial₄ : List Bool → List (Nat → Nat)
-if_partial₄ = map (if_then 1 else_)
-{-# COMPILE AGDA2HS if_partial₄ #-}
-
-if_partial₅ : Bool → Nat → List Nat → List Nat
-if_partial₅ b f = map (if b then f else_)
-{-# COMPILE AGDA2HS if_partial₅ #-}
-
-if_partial₆ : Bool → Nat → List Nat → List Nat
-if_partial₆ b f0 = map (if b then f0 else_)
-{-# COMPILE AGDA2HS if_partial₆ #-}

--- a/test/WitnessedFlows.agda
+++ b/test/WitnessedFlows.agda
@@ -8,13 +8,21 @@ data Range : Set where
 {-# COMPILE AGDA2HS Range #-}
 
 createRange : Int → Int → Maybe Range
-createRange low high = if' low <= high then Just (MkRange low high) else Nothing
+createRange low high = if low <= high then Just (MkRange low high) else Nothing
 
 {-# COMPILE AGDA2HS createRange #-}
 
+createRange' : Int → Int → Maybe Range
+createRange' low high =
+    if low <= high then
+        (λ {{ h }} → if low <= high then Just (MkRange low high {{ h }}) else Nothing)
+    else Nothing
+
+{-# COMPILE AGDA2HS createRange' #-}
+
 createRangeCase : Int → Int → Maybe Range
 createRangeCase low high = 
-    case' low <= high of λ where
+    case low <= high of λ where
         True → Just (MkRange low high)
         False → Nothing
 

--- a/test/WitnessedFlows.agda
+++ b/test/WitnessedFlows.agda
@@ -1,0 +1,21 @@
+open import Haskell.Prelude
+
+data Range : Set where
+    MkRange : (low high : Int)
+            → {{ @0 h : ((low <= high) ≡ True) }}
+            → Range
+
+{-# COMPILE AGDA2HS Range #-}
+
+createRange : Int → Int → Maybe Range
+createRange low high = if' low <= high then Just (MkRange low high) else Nothing
+
+{-# COMPILE AGDA2HS createRange #-}
+
+createRangeCase : Int → Int → Maybe Range
+createRangeCase low high = 
+    case' low <= high of λ where
+        True → Just (MkRange low high)
+        False → Nothing
+
+{-# COMPILE AGDA2HS createRangeCase #-}

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -44,4 +44,5 @@ import RequalifiedImports
 import QualifiedPrelude
 import AutoLambdaCaseInCase
 import AutoLambdaCaseInBind
+import WitnessedFlows
 

--- a/test/golden/LanguageConstructs.hs
+++ b/test/golden/LanguageConstructs.hs
@@ -28,15 +28,6 @@ plus5minus5 n
   = case n + 5 of
         m -> m - 5
 
-len :: [a] -> Int
-len xs = length xs
-
-applyToFalse :: (Bool -> a) -> a
-applyToFalse = ($ False)
-
-caseOf :: a -> (a -> b) -> b
-caseOf = flip ($)
-
 enum₁ :: [Int]
 enum₁ = [5 .. 10]
 

--- a/test/golden/PartialCase.err
+++ b/test/golden/PartialCase.err
@@ -1,0 +1,2 @@
+test/Fail/PartialCase.agda:5,1-7
+case_of_ must be fully applied to a lambda

--- a/test/golden/PartialCaseNoLambda.err
+++ b/test/golden/PartialCaseNoLambda.err
@@ -1,0 +1,2 @@
+test/Fail/PartialCaseNoLambda.agda:5,1-13
+case_of_ must be fully applied to a lambda

--- a/test/golden/PartialIf.err
+++ b/test/golden/PartialIf.err
@@ -1,0 +1,2 @@
+test/Fail/PartialIf.agda:5,1-11
+if_then_else must be fully applied

--- a/test/golden/Test.hs
+++ b/test/golden/Test.hs
@@ -132,21 +132,3 @@ ex_if = if True then 1 else 0
 if_over :: Natural
 if_over = (if True then \ x -> x else \ x -> x + 1) 0
 
-if_partial₁ :: [Natural] -> [Natural]
-if_partial₁ = map (\ f0 -> if True then 1 else f0)
-
-if_partial₂ :: [Natural] -> [Natural -> Natural]
-if_partial₂ = map (\ t0 f0 -> if True then t0 else f0)
-
-if_partial₃ :: [Bool] -> [Natural -> Natural -> Natural]
-if_partial₃ = map (\ b0 t0 f0 -> if b0 then t0 else f0)
-
-if_partial₄ :: [Bool] -> [Natural -> Natural]
-if_partial₄ = map (\ section f0 -> if section then 1 else f0)
-
-if_partial₅ :: Bool -> Natural -> [Natural] -> [Natural]
-if_partial₅ b f = map (\ f0 -> if b then f else f0)
-
-if_partial₆ :: Bool -> Natural -> [Natural] -> [Natural]
-if_partial₆ b f0 = map (\ f1 -> if b then f0 else f1)
-

--- a/test/golden/WitnessedFlows.hs
+++ b/test/golden/WitnessedFlows.hs
@@ -6,6 +6,12 @@ createRange :: Int -> Int -> Maybe Range
 createRange low high
   = if low <= high then Just (MkRange low high) else Nothing
 
+createRange' :: Int -> Int -> Maybe Range
+createRange' low high
+  = if low <= high then
+      if low <= high then Just (MkRange low high) else Nothing else
+      Nothing
+
 createRangeCase :: Int -> Int -> Maybe Range
 createRangeCase low high
   = case low <= high of

--- a/test/golden/WitnessedFlows.hs
+++ b/test/golden/WitnessedFlows.hs
@@ -1,0 +1,14 @@
+module WitnessedFlows where
+
+data Range = MkRange Int Int
+
+createRange :: Int -> Int -> Maybe Range
+createRange low high
+  = if low <= high then Just (MkRange low high) else Nothing
+
+createRangeCase :: Int -> Int -> Maybe Range
+createRangeCase low high
+  = case low <= high of
+        True -> Just (MkRange low high)
+        False -> Nothing
+


### PR DESCRIPTION
This PR adds (erased) witness instances to `if_then_else` and `case_of_`, allowing for their use in cases such as displayed in the `WitnessedFlows` test.

Related to #74 .

This change has several consequences and side effects:

1. Inline functions instead of lambdas in `case_of_` are no longer supported. It does not work anymore with simple functions such as `length` due to the change in the required type signature and the feature is arguably redundant, since the generated Haskell can be achieved (much more straightforwardly) without using `case_of_` (i.e. writing `len xs = length xs` instead of `len xs = case xs of length` in Agda to achieve `len xs = length xs` in Haskell).

2. Support for partially applied `if_then_else`_ and `case_of_` is removed. While Haskell does offer infix operators for user defined data types, it does not do so for `if_then_else_` and `case_of_`, which are native constructs. This requires a user to explicitly write a lambda if they wish to partially apply it, which is now also the case in Agda2HS.
 
3. Finally, there are cases in which partially applied  `if_then_else_` and `case_of_` will compile to incorrect Haskell. This is due to an issue in Agda when generating sections: if Agda has to unify the type with and without the proof instance (as in the `if_partial` examples below), it will generate a section which is compiled incorrectly to contain a `₁` on the left of the arrow, but not on the right of the arrow.

   If the type signature of the method does contain the proof instances (as in the `if'_partial` example below), this problem doesn't occur and the correct error is thrown. The proposal is to therefore warn of this in the documentation and to create an issue for fixing this once it is fixed in Agda.

The following Agda code:
```agda
if_partial : Bool → Nat → Nat
if_partial = if_then 1 else_
{-# COMPILE AGDA2HS if_partial #-}
```

generates this incorrect Haskell:
```haskell
if_partial :: Bool -> Natural -> Natural
if_partial = \ section section₁ -> if section then 1 else section
```

and this Agda code:
```agda
if'_partial : (flg : Bool) → (@0 {{ flg ≡ False }} → Nat) → Nat
if'_partial = if_then 1 else_
{-# COMPILE AGDA2HS if'_partial #-}
```

correctly reports this error:
```shell
if_then_else must be fully applied
```
