### PR TITLE
Only run the CI when source files are changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,14 @@ name: CI
 on:
   pull_request:
   push:
+    paths:
+      - 'lib/**'
+      - 'src/**'
+      - 'test/**'
+      - 'agda2hs.agda-lib'
+      - 'agda2hs.cabal'
+      - 'cabal.project'
+      - 'Makefile'
     branches: [master]
 
 jobs:


### PR DESCRIPTION
Since the CI is quite expensive to run, this change will limit it to running only when files related to the source code are changed (so not when documentation is).