### PR TITLE
Fix `newtype` to allow only single field

### DIFF
--- a/src/Agda2Hs/Compile/Data.hs
+++ b/src/Agda2Hs/Compile/Data.hs
@@ -19,6 +19,13 @@ import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Utils
 import Agda2Hs.HsUtils
 
+checkNewtype :: Hs.Name () -> [Hs.QualConDecl ()] -> C ()
+checkNewtype name cs = do
+  checkSingleElement name cs "Newtype must have exactly one constructor in definition"
+  case head cs of
+    Hs.QualConDecl () _ _ (Hs.ConDecl () cName types) 
+      -> checkSingleElement cName types "Newtype must have exactly one field in constructor"
+
 compileData :: DataTarget -> [Hs.Deriving ()] -> Definition -> C [Hs.Decl ()]
 compileData target ds def = do
   let d = hsName $ prettyShow $ qnameName $ defName def
@@ -37,7 +44,7 @@ compileData target ds def = do
         case target of
           ToData -> return [Hs.DataDecl () (Hs.DataType ()) Nothing hd cs ds]
           ToDataNewType -> do
-            checkSingleField d cs
+            checkNewtype d cs
             return [Hs.DataDecl () (Hs.NewType ()) Nothing hd cs ds]
     _ -> __IMPOSSIBLE__
   where

--- a/src/Agda2Hs/Compile/Data.hs
+++ b/src/Agda2Hs/Compile/Data.hs
@@ -27,7 +27,7 @@ checkNewtype name cs = do
       -> checkSingleElement cName types "Newtype must have exactly one field in constructor"
 
 compileData :: DataTarget -> [Hs.Deriving ()] -> Definition -> C [Hs.Decl ()]
-compileData target ds def = do
+compileData target ds def = setCurrentRange (nameBindingSite $ qnameName $ defName def) $ do
   let d = hsName $ prettyShow $ qnameName $ defName def
   checkValidTypeName d
   case theDef def of

--- a/src/Agda2Hs/Compile/Record.hs
+++ b/src/Agda2Hs/Compile/Record.hs
@@ -111,7 +111,7 @@ compileRecord target def = setCurrentRange (nameBindingSite $ qnameName $ defNam
       ToRecordNewType ds -> do
         checkValidConName cName
         (constraints, fieldDecls) <- compileRecFields fieldDecl recFields fieldTel
-        checkSingleField rName fieldDecls
+        checkSingleElement cName fieldDecls "Newtype must have exactly one field in constructor"
         compileDataRecord constraints fieldDecls (Hs.NewType ()) hd ds
 
   where

--- a/src/Agda2Hs/Compile/Utils.hs
+++ b/src/Agda2Hs/Compile/Utils.hs
@@ -263,9 +263,9 @@ addTyBang Strict ty = tellExtension Hs.BangPatterns >>
   return (Hs.TyBang () (Hs.BangedTy ()) (Hs.NoUnpackPragma ()) ty)
 addTyBang Lazy   ty = return ty
 
-checkSingleField :: Hs.Name () -> [b] -> C ()
-checkSingleField name fs = unless (length fs == 1) $ genericDocError =<< do
-  text "Newtype must have exactly one field in definition: " <+> text (Hs.prettyPrint name)
+checkSingleElement :: Hs.Name () -> [b] -> String -> C ()
+checkSingleElement name fs s = unless (length fs == 1) $ genericDocError =<< do
+  text s <+> text ": " <+> text (Hs.prettyPrint name)
 
 checkingVars :: C a -> C a
 checkingVars = local $ \e -> e { checkVar = True }

--- a/src/Agda2Hs/Compile/Utils.hs
+++ b/src/Agda2Hs/Compile/Utils.hs
@@ -265,7 +265,7 @@ addTyBang Lazy   ty = return ty
 
 checkSingleElement :: Hs.Name () -> [b] -> String -> C ()
 checkSingleElement name fs s = unless (length fs == 1) $ genericDocError =<< do
-  text s <+> text ": " <+> text (Hs.prettyPrint name)
+  text (s ++ ":") <+> text (Hs.prettyPrint name)
 
 checkingVars :: C a -> C a
 checkingVars = local $ \e -> e { checkVar = True }

--- a/test/Fail/NewTypeRecordTwoFields.agda
+++ b/test/Fail/NewTypeRecordTwoFields.agda
@@ -1,0 +1,13 @@
+module Fail.NewTypeRecordTwoFields where
+
+open import Haskell.Prelude
+
+record Duo (a b : Set) : Set where
+    constructor MkDuo
+    field
+        left : a
+        right : b
+open Duo public
+
+{-# COMPILE AGDA2HS Duo newtype #-}
+

--- a/test/Fail/NewTypeTwoConstructors.agda
+++ b/test/Fail/NewTypeTwoConstructors.agda
@@ -1,0 +1,10 @@
+module Fail.NewTypeTwoConstructors where
+
+open import Haskell.Prelude
+
+data Choice (a b  : Set) : Set where
+  A : a → Choice a b
+  B : b → Choice a b
+
+{-# COMPILE AGDA2HS Choice newtype #-}
+

--- a/test/Fail/NewTypeTwoFields.agda
+++ b/test/Fail/NewTypeTwoFields.agda
@@ -1,0 +1,9 @@
+module Fail.NewTypeTwoFields where
+
+open import Haskell.Prelude
+
+data Duo (a b : Set) : Set where
+  MkDuo : a → b → Duo a b
+
+{-# COMPILE AGDA2HS Duo newtype #-}
+

--- a/test/golden/Issue145.err
+++ b/test/golden/Issue145.err
@@ -1,1 +1,2 @@
+test/Fail/Issue145.agda:23,6-8
 Cannot use hidden variable a

--- a/test/golden/NewTypeRecordTwoFields.err
+++ b/test/golden/NewTypeRecordTwoFields.err
@@ -1,2 +1,2 @@
 test/Fail/NewTypeRecordTwoFields.agda:5,8-11
-Newtype must have exactly one field in constructor :  MkDuo
+Newtype must have exactly one field in constructor: MkDuo

--- a/test/golden/NewTypeRecordTwoFields.err
+++ b/test/golden/NewTypeRecordTwoFields.err
@@ -1,0 +1,2 @@
+test/Fail/NewTypeRecordTwoFields.agda:5,8-11
+Newtype must have exactly one field in constructor :  MkDuo

--- a/test/golden/NewTypeTwoConstructors.err
+++ b/test/golden/NewTypeTwoConstructors.err
@@ -1,1 +1,2 @@
+test/Fail/NewTypeTwoConstructors.agda:5,6-12
 Newtype must have exactly one constructor in definition :  Choice

--- a/test/golden/NewTypeTwoConstructors.err
+++ b/test/golden/NewTypeTwoConstructors.err
@@ -1,2 +1,2 @@
 test/Fail/NewTypeTwoConstructors.agda:5,6-12
-Newtype must have exactly one constructor in definition :  Choice
+Newtype must have exactly one constructor in definition: Choice

--- a/test/golden/NewTypeTwoConstructors.err
+++ b/test/golden/NewTypeTwoConstructors.err
@@ -1,0 +1,1 @@
+Newtype must have exactly one constructor in definition :  Choice

--- a/test/golden/NewTypeTwoFields.err
+++ b/test/golden/NewTypeTwoFields.err
@@ -1,1 +1,2 @@
+test/Fail/NewTypeTwoFields.agda:5,6-9
 Newtype must have exactly one field in constructor :  MkDuo

--- a/test/golden/NewTypeTwoFields.err
+++ b/test/golden/NewTypeTwoFields.err
@@ -1,0 +1,1 @@
+Newtype must have exactly one field in constructor :  MkDuo

--- a/test/golden/NewTypeTwoFields.err
+++ b/test/golden/NewTypeTwoFields.err
@@ -1,2 +1,2 @@
 test/Fail/NewTypeTwoFields.agda:5,6-9
-Newtype must have exactly one field in constructor :  MkDuo
+Newtype must have exactly one field in constructor: MkDuo

--- a/test/golden/NonStarDatatypeIndex.err
+++ b/test/golden/NonStarDatatypeIndex.err
@@ -1,1 +1,2 @@
+test/Fail/NonStarDatatypeIndex.agda:5,6-7
 Kind of bound argument not supported: (n : Nat)


### PR DESCRIPTION
This PR adds three tests that should **fail** for the `newtype` pragma:

### Test 1: Worked but wrong error message
This does not have _exactly one constructor_:
```agda
data Choice (a b  : Set) : Set where
  A : a → Choice a b
  B : b → Choice a b

{-# COMPILE AGDA2HS Choice newtype #-}
```

### Test 2: Did not work, fixed in this PR
This does not have _exactly one field_ in the constructor:
```agda
data Duo (a b : Set) : Set where
  MkDuo : a → b → Duo a b

{-# COMPILE AGDA2HS Duo newtype #-}
```
This one *did not work*, since we weren't checking after we established there was only one constructor. This has been added in the code.

### Test 3: Worked
And this record does not have _exactly one field_ in the constructor (records always have exactly one constructor):
```agda
record Duo (a b : Set) : Set where
    constructor MkDuo
    field
        left : a
        right : b
open Duo public

{-# COMPILE AGDA2HS Duo newtype #-}
```
