### PR TITLE
Fix for issue #142

### DIFF
--- a/src/Agda2Hs/Compile/Function.hs
+++ b/src/Agda2Hs/Compile/Function.hs
@@ -155,7 +155,7 @@ noAsPatterns = \case
       forM_ ps $ noAsPatterns . namedArg
   where
     checkPatternInfo i = unless (null $ patAsNames i) $
-      genericDocError =<< "not supported by Agda2Hs: as patterns"
+      genericDocError =<< "not supported by agda2hs: as patterns"
 
 compilePats :: NAPs -> C [Hs.Pat ()]
 compilePats ps = mapM (compilePat . namedArg) =<< filterM keepPat ps
@@ -166,7 +166,7 @@ compilePats ps = mapM (compilePat . namedArg) =<< filterM keepPat ps
       when keep $ noAsPatterns $ namedArg p
       -- We do not allow forced (dot) patterns for non-erased arguments (see issue #142).
       when (usableModality p && isForcedPat (namedArg p)) $
-        genericDocError =<< "not supported by Agda2Hs: forced (dot) patterns in non-erased positions"
+        genericDocError =<< "not supported by agda2hs: forced (dot) patterns in non-erased positions"
       return keep
 
     isForcedPat :: DeBruijnPattern -> Bool

--- a/src/Agda2Hs/Compile/Type.hs
+++ b/src/Agda2Hs/Compile/Type.hs
@@ -25,7 +25,7 @@ import Agda.Utils.Impossible ( __IMPOSSIBLE__ )
 import Agda.Utils.Pretty ( prettyShow )
 import Agda.Utils.List ( downFrom )
 import Agda.Utils.Maybe ( ifJustM, fromMaybe )
-import Agda.Utils.Monad ( ifM )
+import Agda.Utils.Monad ( ifM, unlessM )
 import Agda.Utils.Size ( Sized(size) )
 import Agda.Utils.Functor ( ($>) )
 
@@ -134,6 +134,8 @@ compileType t = do
           f <- compileQName f
           return $ tApp (Hs.TyCon () f) vs
     Var x es | Just args <- allApplyElims es -> do
+      unlessM (usableModality <$> lookupBV x) $ genericDocError =<<
+        text "Not supported by agda2hs: erased type variable" <+> prettyTCM (var x)
       vs <- compileTypeArgs args
       x  <- hsName <$> compileVar x
       return $ tApp (Hs.TyVar () x) vs

--- a/test/Fail/Issue142.agda
+++ b/test/Fail/Issue142.agda
@@ -1,0 +1,7 @@
+module Fail.Issue142 where
+
+open import Haskell.Prelude
+
+coerce : @0 a ≡ b → a → b
+coerce refl x = x
+{-# COMPILE AGDA2HS coerce #-}

--- a/test/Fail/Issue145.agda
+++ b/test/Fail/Issue145.agda
@@ -5,7 +5,7 @@ open import Haskell.Prim.Strict
 
 -- ** PASS
 
-module _ {@0 a : Set} where
+module _ {a : Set} where
   it : a → a
   it x = x
   {-# COMPILE AGDA2HS it #-}

--- a/test/HeightMirror.agda
+++ b/test/HeightMirror.agda
@@ -1,8 +1,8 @@
 
 open import Haskell.Prelude hiding (max)
 
-subst : (@0 p : @0 a → Set) {@0 m n : a} → @0 m ≡ n → p m → p n
-subst p refl t = t
+subst : {p : @0 a → Set} {@0 m n : a} → @0 m ≡ n → p m → p n
+subst refl t = t
 
 {-# COMPILE AGDA2HS subst transparent #-}
 
@@ -26,6 +26,6 @@ max-comm (suc l) (suc r) = cong suc (max-comm l r)
 mirror : ∀ {@0 h} → Tree a h → Tree a h
 mirror Tip = Tip
 mirror {a = a} (Bin {l} {r} x lt rt) =
-  subst (Tree a) (cong suc (max-comm r l)) (Bin x (mirror rt) (mirror lt))
+  subst {p = Tree a} (cong suc (max-comm r l)) (Bin x (mirror rt) (mirror lt))
 
 {-# COMPILE AGDA2HS mirror #-}

--- a/test/Issue92.agda
+++ b/test/Issue92.agda
@@ -3,7 +3,7 @@ open import Haskell.Prelude
 postulate Something : Set
 postulate something : Something
 
-module _ {@0 a : Set} where
+module _ {a : Set} where
   foo : a → a
   foo x = bar {something}
     where

--- a/test/golden/ErasedRecordParameter.err
+++ b/test/golden/ErasedRecordParameter.err
@@ -1,2 +1,2 @@
 test/Fail/ErasedRecordParameter.agda:4,8-10
-Cannot use erased variable a
+Not supported by agda2hs: erased type variable a

--- a/test/golden/Issue142.err
+++ b/test/golden/Issue142.err
@@ -1,2 +1,2 @@
 test/Fail/Issue142.agda:5,1-7
-not supported by Agda2Hs: forced (dot) patterns in non-erased positions
+not supported by agda2hs: forced (dot) patterns in non-erased positions

--- a/test/golden/Issue142.err
+++ b/test/golden/Issue142.err
@@ -1,0 +1,2 @@
+test/Fail/Issue142.agda:5,1-7
+not supported by Agda2Hs: forced (dot) patterns in non-erased positions

--- a/test/golden/Issue71.err
+++ b/test/golden/Issue71.err
@@ -1,2 +1,2 @@
 test/Fail/Issue71.agda:8,28-11,4
-not supported by Agda2Hs: as patterns
+not supported by agda2hs: as patterns


### PR DESCRIPTION
This fixes #142 by enforcing that there are no dot patterns in the functions we compile to Haskell, even in implicit (type) arguments. To make this work, I also had to add a check that type parameters that appear in the Haskell code are not marked with `@0` (which was already the case for datatypes, but not yet for functions).