### PR TITLE
Some extra proofs + NewType constructor docs

### DIFF
--- a/docs/source/features.md
+++ b/docs/source/features.md
@@ -140,7 +140,29 @@ newtype Identity a = MkIdentity{runIdentity :: a}
 newtype Equal a = MkEqual{pair :: (a, a)}
 ```
 
-_Note: Unfortunately, Agda does not allow the constructor name to be the same as the data/record name._
+Unfortunately, Agda does not allow the constructor name to be the same as the data/record name.
+However, it _is_ possible to achieve this with Agda2HS if you do not explicitly add a constructor name to a record definition (this requires the use of `record { ... }` syntax on the Agda side):
+
+```agda
+record Duo (a : Set) : Set where
+    field
+        duo : a × a
+open Duo public
+
+{-# COMPILE AGDA2HS Duo newtype #-}
+
+createDuo : a → a → Duo a
+createDuo a b = record { duo = a , b }
+
+{-# COMPILE AGDA2HS createDuo #-}
+```
+
+```hs
+newtype Duo a = Duo{duo :: (a, a)}
+
+createDuo :: a -> a -> Duo a
+createDuo a b = Duo (a, b)
+```
 
 ## Pattern Matching on Datatype Values
 

--- a/lib/Haskell/Law.agda
+++ b/lib/Haskell/Law.agda
@@ -6,3 +6,9 @@ open import Haskell.Prim.Bool
 ifFlip : ∀ (b) (t e : a) → (if b then t else e) ≡ (if not b then e else t)
 ifFlip False _ _ = refl
 ifFlip True  _ _ = refl
+
+ifTrueEqThen : ∀ (b : Bool) {thn els : a} → b ≡ True → (if b then thn else els) ≡ thn
+ifTrueEqThen .True refl = refl
+
+ifFalseEqElse : ∀ (b : Bool) {thn els : a} → b ≡ False → (if b then thn else els) ≡ els
+ifFalseEqElse .False refl = refl

--- a/lib/Haskell/Law/Bool.agda
+++ b/lib/Haskell/Law/Bool.agda
@@ -45,6 +45,13 @@ open import Haskell.Law.Equality
 ||-excludedMiddle False _ = refl
 ||-excludedMiddle True  _ = refl
 
+||-leftTrue : ∀ (a b : Bool) → a ≡ True → (a || b) ≡ True
+||-leftTrue .True b refl = refl
+
+||-rightTrue : ∀ (a b : Bool) → b ≡ True → (a || b) ≡ True
+||-rightTrue False .True refl = refl
+||-rightTrue True  .True refl = refl
+
 --------------------------------------------------
 -- not
 

--- a/lib/Haskell/Law/List.agda
+++ b/lib/Haskell/Law/List.agda
@@ -10,7 +10,7 @@ open import Haskell.Prim.List
 ++-[] [] = refl
 ++-[] (x ∷ xs) rewrite ++-[] xs = refl
 
-[]-++ : ∀ (xs : List a) → xs ++ [] ≡ xs
+[]-++ : ∀ (xs : List a) → [] ++ xs ≡ xs
 []-++ [] = refl
 []-++ (x ∷ xs) rewrite []-++ xs = refl
 

--- a/lib/Haskell/Prelude.agda
+++ b/lib/Haskell/Prelude.agda
@@ -38,11 +38,13 @@ open import Haskell.Prim.Traversable public
 open import Haskell.Prim.Tuple       public hiding (first; second; _***_)
 open import Haskell.Prim.Word        public
 
+open import Haskell.Law              public
 open import Haskell.Law.Applicative  public
 open import Haskell.Law.Bool         public
 open import Haskell.Law.Eq           public
 open import Haskell.Law.Equality     public
 open import Haskell.Law.Functor      public
+open import Haskell.Law.List         public
 open import Haskell.Law.Maybe        public
 open import Haskell.Law.Monad        public
 open import Haskell.Law.Monoid       public

--- a/test/NewTypePragma.agda
+++ b/test/NewTypePragma.agda
@@ -1,6 +1,8 @@
 open import Haskell.Prelude using ( Int ; fst ; snd
                                   ; a ; b
-                                  ; _×_ ; _≡_
+                                  ; _×_ ; _,_
+                                  ; _≡_; refl
+                                  ; List; map
                                   )
 
 {-# FOREIGN AGDA2HS
@@ -50,3 +52,19 @@ record Equal (a : Set) : Set where
 open Equal public
 
 {-# COMPILE AGDA2HS Equal newtype #-}
+
+{-# FOREIGN AGDA2HS
+-- record newtype with same name
+#-}
+
+record Duo (a : Set) : Set where
+    field
+        duo : a × a
+open Duo public
+
+{-# COMPILE AGDA2HS Duo newtype #-}
+
+createDuo : a → a → Duo a
+createDuo a b = record { duo = a , b }
+
+{-# COMPILE AGDA2HS createDuo #-}

--- a/test/golden/NewTypePragma.hs
+++ b/test/golden/NewTypePragma.hs
@@ -20,3 +20,10 @@ newtype Identity a = MkIdentity{runIdentity :: a}
 
 newtype Equal a = MkEqual{pair :: (a, a)}
 
+-- record newtype with same name
+
+newtype Duo a = Duo{duo :: (a, a)}
+
+createDuo :: a -> a -> Duo a
+createDuo a b = Duo (a, b)
+


### PR DESCRIPTION
This is a sort of random PR with things that I added while working with Agda2HS, but I thought they might be useful to include.

It includes:

* Documentation (and a test) on how to get the same constructor name in `newtype` as the type name
* A few proofs about `if_then_else_`,  `++` and `||`
* Exports of proofs that were already there but weren't available