### PR TITLE
[ new ] guard, _>>_, and _<$_

### DIFF
--- a/lib/Haskell/Control/Monad.agda
+++ b/lib/Haskell/Control/Monad.agda
@@ -1,0 +1,10 @@
+module Haskell.Control.Monad where
+
+open import Haskell.Prim
+open import Haskell.Prim.Bool
+open import Haskell.Prim.Monad
+open import Haskell.Prim.String
+
+guard : {{ MonadFail m }} → (b : Bool) → m (b ≡ True)
+guard True = return refl
+guard False = fail "Guard was not True"

--- a/lib/Haskell/Prim/Functor.agda
+++ b/lib/Haskell/Prim/Functor.agda
@@ -18,8 +18,8 @@ record Functor (f : Set → Set) : Set₁ where
     fmap : (a → b) → f a → f b
     _<$>_ : (a → b) → f a → f b
     _<&>_ : f a → (a → b) → f b
-    _<$_ : a → f b → f a
-    _$>_ : f a → b → f b
+    _<$_ : (@0 {{ b }} → a) → f b → f a
+    _$>_ : f a → (@0 {{ a }} → b) → f b
     void : f a → f (Tuple [])
 -- ** defaults
 record DefaultFunctor (f : Set → Set) : Set₁ where
@@ -34,10 +34,10 @@ record DefaultFunctor (f : Set → Set) : Set₁ where
   _<&>_ : f a → (a → b) → f b
   m <&> f = fmap f m
 
-  _<$_ : a → f b → f a
-  x <$ m = fmap (const x) m
+  _<$_ : (@0 {{ b }} → a) → f b → f a
+  x <$ m = fmap (λ b → x {{b}}) m
 
-  _$>_ : f a → b → f b
+  _$>_ : f a → (@0 {{ a }} → b) → f b
   m $> x = x <$ m
 
   void : f a → f (Tuple [])

--- a/lib/Haskell/Prim/List.agda
+++ b/lib/Haskell/Prim/List.agda
@@ -2,8 +2,8 @@
 module Haskell.Prim.List where
 
 open import Haskell.Prim
-open import Haskell.Prim.Tuple
 open import Haskell.Prim.Bool
+open import Haskell.Prim.Tuple
 open import Haskell.Prim.Int
 
 

--- a/lib/Haskell/Prim/Monad.agda
+++ b/lib/Haskell/Prim/Monad.agda
@@ -23,7 +23,7 @@ module Do where
       _>>=_ : m a → (a → m b) → m b
       overlap ⦃ super ⦄ : Applicative m
       return : a → m a
-      _>>_ : m a → m b → m b
+      _>>_ : m a → (@0 {{ a }} → m b) → m b
       _=<<_ : (a → m b) → m a → m b
   -- ** defaults
   record DefaultMonad (m : Set → Set) : Set₁ where
@@ -33,8 +33,8 @@ module Do where
     return : a → m a
     return = pure
 
-    _>>_ : m a → m b → m b
-    m >> m₁ = m >>= λ _ → m₁
+    _>>_ : m a → (@0 {{ a }} → m b) → m b
+    m >> m₁ = m >>= λ x → m₁ {{x}}
 
     _=<<_ : (a → m b) → m a → m b
     _=<<_ = flip _>>=_
@@ -51,7 +51,7 @@ module Dont where
   _>>=_ : ⦃ Monad m ⦄ → m a → (a → m b) → m b
   _>>=_ = Do._>>=_
 
-  _>>_ : ⦃ Monad m ⦄ → m a → m b → m b
+  _>>_ : ⦃ Monad m ⦄ → m a → (@0 {{ a }} → m b) → m b
   _>>_ = Do._>>_
 
 open Do public
@@ -60,7 +60,7 @@ mapM₋ : ⦃ Monad m ⦄ → ⦃ Foldable t ⦄ → (a → m b) → t a → m �
 mapM₋ f = foldr (λ x k → f x >> k) (pure tt)
 
 sequence₋ : ⦃ Monad m ⦄ → ⦃ Foldable t ⦄ → t (m a) → m ⊤
-sequence₋ = foldr _>>_ (pure tt)
+sequence₋ = foldr (λ mx my → mx >> my) (pure tt)
 
 -- ** instances
 private

--- a/src/Agda2Hs/Compile/Name.hs
+++ b/src/Agda2Hs/Compile/Name.hs
@@ -45,6 +45,7 @@ isSpecialCon = prettyShow >>> \case
 isSpecialName :: QName -> Maybe (Hs.Name (), Maybe Import)
 isSpecialName = prettyShow >>> \case
     "Agda.Builtin.Nat.Nat"         -> withImport "Numeric.Natural" "Natural"
+    "Haskell.Control.Monad.guard"  -> withImport "Control.Monad" "guard"
     "Agda.Builtin.Int.Int"         -> noImport "Integer"
     "Agda.Builtin.Word.Word64"     -> noImport "Word"
     "Agda.Builtin.Float.Float"     -> noImport "Double"

--- a/test/WitnessedFlows.agda
+++ b/test/WitnessedFlows.agda
@@ -1,4 +1,5 @@
 open import Haskell.Prelude
+open import Haskell.Control.Monad
 
 data Range : Set where
     MkRange : (low high : Int)
@@ -27,3 +28,16 @@ createRangeCase low high =
         False → Nothing
 
 {-# COMPILE AGDA2HS createRangeCase #-}
+
+createRangeGuardSeq : Int → Int → Maybe Range
+createRangeGuardSeq low high =
+  do guard (low <= high)
+     pure (MkRange low high)
+
+{-# COMPILE AGDA2HS createRangeGuardSeq #-}
+
+createRangeGuardFmap : Int → Int → Maybe Range
+createRangeGuardFmap low high
+  = MkRange low high <$ guard (low <= high)
+
+{-# COMPILE AGDA2HS createRangeGuardFmap #-}

--- a/test/golden/WitnessedFlows.hs
+++ b/test/golden/WitnessedFlows.hs
@@ -1,5 +1,7 @@
 module WitnessedFlows where
 
+import Control.Monad (guard)
+
 data Range = MkRange Int Int
 
 createRange :: Int -> Int -> Maybe Range
@@ -17,4 +19,13 @@ createRangeCase low high
   = case low <= high of
         True -> Just (MkRange low high)
         False -> Nothing
+
+createRangeGuardSeq :: Int -> Int -> Maybe Range
+createRangeGuardSeq low high
+  = do guard (low <= high)
+       pure (MkRange low high)
+
+createRangeGuardFmap :: Int -> Int -> Maybe Range
+createRangeGuardFmap low high
+  = MkRange low high <$ guard (low <= high)
 


### PR DESCRIPTION
This is a follow-up from my question this morning.

When we try to write the idiomatic `v <$ guard b` instead of `if b then Just v else Nothing`,
we need the type of `_<$_` to be different so that we propagate the information that the
type we are replacing with a constant value is indeed inhabited.

Similarly the type of `_>>_` also needs to be changed for the equivalent `do`-block to work.

Here `guard` returns a proof `b ≡ True` instead of a value of type unit. I don't know whether
that can potentially be problematic if the users get their hands on it.