### PR TITLE
Translating "zero" constructor of Nat to "0" literal

### DIFF
--- a/src/Agda2Hs/Compile/Function.hs
+++ b/src/Agda2Hs/Compile/Function.hs
@@ -43,13 +43,14 @@ isSpecialPat qn = case prettyShow qn of
   "Haskell.Prim.Tuple._;_" -> Just tuplePat
   "Agda.Builtin.Int.Int.pos" -> Just posIntPat
   "Agda.Builtin.Int.Int.negsuc" -> Just negSucIntPat
+  "Agda.Builtin.Nat.Nat.zero" -> Just $ \ _ _ _ -> return $ Hs.PLit () (Hs.Signless ()) (Hs.Int () 0 "0")
   s | s `elem` badConstructors -> Just $ \ _ _ _ -> genericDocError =<<
     "constructor `" <> prettyTCM qn <> "` not supported in patterns"
   _ -> Nothing
   where
     badConstructors =
-      [ "Agda.Builtin.Nat.Nat.zero"
-      , "Agda.Builtin.Nat.Nat.suc"
+      [
+        "Agda.Builtin.Nat.Nat.suc"
       ]
 
 isUnboxCopattern :: DeBruijnPattern -> C Bool

--- a/test/golden/Issue154.err
+++ b/test/golden/Issue154.err
@@ -1,2 +1,2 @@
 test/Fail/Issue154.agda:5,1-4
-constructor `zero` not supported in patterns
+constructor `suc` not supported in patterns


### PR DESCRIPTION
I've found @uncle-betty's workaround for natural pattern matching at #117 quite useful. To be more precise, this one, when we make an equivalent version where we only pattern-match for zero:

```agda
module Test where

open import Haskell.Prelude
open import Haskell.Prim using (monusNat)

fac3 : Nat → Nat
fac3 0       = 1
fac3 (suc n) = suc n * fac3 n

{-# TERMINATING #-}
fac3' : Nat → Nat
fac3' 0 = 1
fac3' n = n * fac3' (monusNat n 1)

{-# COMPILE AGDA2HS fac3' #-}

fac3'≡fac3 : ∀ n → fac3' n ≡ fac3 n
fac3'≡fac3 zero = refl
fac3'≡fac3 (suc n) rewrite fac3'≡fac3 n = refl
```

However, this is not supported anymore per #154. I consider it to be useful; so I've rewritten `Function.hs` so that it always rewrites `Agda.Builtin.Nat.Nat.zero` to a `0` literal. Pattern matching to `suc` would still be rejected.

I don't know whether it would require a broader consensus; but I think we wouldn't lose anything by adding this feature. Thanks in advance for looking at it:)
