### PR TITLE
Allowing type operators not starting with a colon

### DIFF
--- a/src/Agda2Hs/Compile/Utils.hs
+++ b/src/Agda2Hs/Compile/Utils.hs
@@ -240,7 +240,7 @@ checkValidFunName x = unless (validVarName x) $ genericDocError =<< do
   text "Invalid name for Haskell function: " <+> text (Hs.prettyPrint x)
 
 checkValidTypeName :: Hs.Name () -> C ()
-checkValidTypeName x = unless (validConName x) $ genericDocError =<< do
+checkValidTypeName x = unless (validTypeName x) $ genericDocError =<< do
   text "Invalid name for Haskell type: " <+> text (Hs.prettyPrint x)
 
 checkValidConName :: Hs.Name () -> C ()

--- a/src/Agda2Hs/HsUtils.hs
+++ b/src/Agda2Hs/HsUtils.hs
@@ -45,6 +45,10 @@ validVarName :: Name () -> Bool
 validVarName (Ident _ s)  = validVarId s
 validVarName (Symbol _ s) = validVarSym s
 
+validTypeName :: Name () -> Bool
+validTypeName (Ident _ s) = validConId s
+validTypeName (Symbol _ s) = validVarSym s || validConSym s -- type operators need not start with a colon
+
 validConName :: Name () -> Bool
 validConName (Ident _ s)  = validConId s
 validConName (Symbol _ s) = validConSym s

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -50,6 +50,7 @@ import WitnessedFlows
 import Kinds
 import LawfulOrd
 import Deriving
+import TypeOperators
 
 {-# FOREIGN AGDA2HS
 import Issue14

--- a/test/TypeOperators.agda
+++ b/test/TypeOperators.agda
@@ -1,0 +1,32 @@
+module TypeOperators where
+
+{-# FOREIGN AGDA2HS {-# LANGUAGE TypeOperators #-} #-}
+
+open import Haskell.Prim.Either
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Bool
+
+_:++:_ : Set → Set → Set
+_:++:_ = Either
+{-# COMPILE AGDA2HS _:++:_ #-}
+
+mx : Bool :++: Nat
+mx = Left true
+{-# COMPILE AGDA2HS mx #-}
+
+_++++_ : Set → Set → Set
+_++++_ = Either
+{-# COMPILE AGDA2HS _++++_ #-}
+
+mx' : Bool ++++ Nat
+mx' = Left true
+{-# COMPILE AGDA2HS mx' #-}
+
+data _****_ (a b : Set): Set where
+  _:****_ : a → b → a **** b
+{-# COMPILE AGDA2HS _****_ #-}
+
+cross : Bool **** Nat
+cross = true :**** 1
+{-# COMPILE AGDA2HS cross #-}

--- a/test/golden/TypeOperators.hs
+++ b/test/golden/TypeOperators.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE TypeOperators #-}
+
+module TypeOperators where
+
+import Numeric.Natural (Natural)
+
+type (:++:) = Either
+
+mx :: (:++:) Bool Natural
+mx = Left True
+
+type (++++) = Either
+
+mx' :: (++++) Bool Natural
+mx' = Left True
+
+data (****) a b = (:****) a b
+
+cross :: (****) Bool Natural
+cross = True :**** 1
+


### PR DESCRIPTION
Type operators were only accepted if they started with a colon, like constructors. Hopefully this will fix this.