### PR TITLE
Option for user-defined rewrite rules given in a config file

### DIFF
--- a/agda2hs.cabal
+++ b/agda2hs.cabal
@@ -56,7 +56,7 @@ executable agda2hs
                        AgdaInternals
   build-depends:       base >= 4.10 && < 4.18,
                        Agda >= 2.6.3 && < 2.6.4,
-											 bytestring >= 0.11,
+                       bytestring >= 0.11,
                        containers >= 0.6 && < 0.7,
                        unordered-containers >= 0.2,
                        mtl >= 2.2,
@@ -66,7 +66,7 @@ executable agda2hs
                        syb >= 0.7,
                        text >= 1.2.3.0,
                        deepseq >= 1.4.1.1,
-											 yaml-light >= 0.1.4
+                       yaml-light >= 0.1.4
   default-language:    Haskell2010
   default-extensions:  LambdaCase,
                        RecordWildCards,

--- a/agda2hs.cabal
+++ b/agda2hs.cabal
@@ -44,6 +44,7 @@ executable agda2hs
                        Agda2Hs.Compile.Name,
                        Agda2Hs.Compile.Postulate,
                        Agda2Hs.Compile.Record,
+                       Agda2Hs.Compile.Rewrites,
                        Agda2Hs.Compile.Term,
                        Agda2Hs.Compile.Type,
                        Agda2Hs.Compile.TypeDefinition,
@@ -55,6 +56,7 @@ executable agda2hs
                        AgdaInternals
   build-depends:       base >= 4.10 && < 4.18,
                        Agda >= 2.6.3 && < 2.6.4,
+											 bytestring >= 0.11,
                        containers >= 0.6 && < 0.7,
                        unordered-containers >= 0.2,
                        mtl >= 2.2,
@@ -63,7 +65,8 @@ executable agda2hs
                        haskell-src-exts >= 1.23 && < 1.25,
                        syb >= 0.7,
                        text >= 1.2.3.0,
-                       deepseq >= 1.4.1.1
+                       deepseq >= 1.4.1.1,
+											 yaml-light >= 0.1.4
   default-language:    Haskell2010
   default-extensions:  LambdaCase,
                        RecordWildCards,

--- a/rewrite-rules-example.yaml
+++ b/rewrite-rules-example.yaml
@@ -1,0 +1,103 @@
+# An example config file for the '--rewrite-rules' option.
+# Imagine a library which uses the Agda standard library extensively and let's suppose we would like to translate its operators to the Haskell equivalents. The library includes a Haskell.Prim.Num.Num instance.
+
+# We have to include this so that Num is written to the import list of Prelude.
+- from: Haskell.Prim.Num.Num
+  to: Num
+  importing: Prelude
+# And it doesn't see these by default either, if not included in Prelude's import list.
+- from: Haskell.Prim.Num.Num.fromInteger
+  to: fromInteger
+  importing: Prelude
+- from: Haskell.Prim.Num.Num.signum
+  to: signum
+  importing: Prelude
+
+# The rational type.
+- from: Data.Rational.Unnormalised.Base.ℚᵘ
+  to: Rational
+  importing: Data.Ratio
+
+# Arithmetic operators.
+# Note: Prelude has to be specified too!
+- from: Agda.Builtin.Nat._+_
+  to: _+_
+  importing: Prelude
+- from: Agda.Builtin.Nat._*_
+  to: _*_
+  importing: Prelude
+- from: Agda.Builtin.Nat.-_
+  to: negate
+  importing: Prelude
+- from: Agda.Builtin.Nat._-_
+  to: _-_
+  importing: Prelude
+- from: Data.Nat.Base._⊔_
+  to: max
+  importing: Prelude
+
+- from: Agda.Builtin.Integer._+_
+  to: _+_
+  importing: Prelude
+- from: Data.Integer.Base._*_
+  to: _*_
+  importing: Prelude
+- from: Agda.Builtin.Integer.-_
+  to: negate
+  importing: Prelude
+- from: Agda.Builtin.Integer._-_
+  to: _-_
+  importing: Prelude
+
+- from: Data.Rational.Unnormalised.Base._+_
+  to: _+_
+  importing: Prelude
+- from: Data.Rational.Unnormalised.Base._*_
+  to: _*_
+  importing: Prelude
+- from: Data.Rational.Unnormalised.Base.-_
+  to: negate
+  importing: Prelude
+- from: Data.Rational.Unnormalised.Base._-_
+  to: _-_
+  importing: Prelude
+- from: Data.Rational.Unnormalised.Base._/_
+  to: _%_
+  importing: Data.Ratio
+- from: Data.Rational.Unnormalised.Base._⊔_
+  to: max
+  importing: Prelude
+- from: Data.Rational.Unnormalised.Base._⊓_
+  to: min
+  importing: Prelude
+- from: Data.Rational.Unnormalised.Base.∣_∣
+  to: abs
+  importing: Prelude
+- from: Data.Integer.Base.∣_∣
+  to: intAbs
+  importing: Base
+
+# Standard library functions related to naturals and integers.
+- from: Agda.Builtin.Nat.Nat.suc
+  to: suc
+  importing: Base
+- from: Agda.Builtin.Int.Int.pos
+  to: toInteger
+  importing: Prelude
+- from: Data.Integer.DivMod._divℕ_
+  to: divNat
+  importing: Base
+- from: Data.Nat.DivMod._/_
+  to: div
+  importing: Prelude
+
+# Standard library functions related to rationals.
+- from: Data.Rational.Unnormalised.Base.ℚᵘ.numerator
+  to: numerator
+  importing: Data.Ratio
+- from: Data.Rational.Unnormalised.Base.ℚᵘ.denominator
+  to: denominatorNat
+  importing: Base       #the Base version returns a Natural
+- from: Data.Rational.Unnormalised.Base.ℚᵘ.denominator-1
+  to: denominatorMinus1
+  importing: Base

--- a/src/Agda2Hs/Compile/Rewrites.hs
+++ b/src/Agda2Hs/Compile/Rewrites.hs
@@ -1,0 +1,63 @@
+-- Reads custom rewrite rules of the user from a YAML config file.
+module Agda2Hs.Compile.Rewrites where
+
+import Data.Yaml.YamlLight
+import qualified Data.Map as Map
+import qualified Data.Text as Text
+import Data.Text.Encoding (decodeUtf8, encodeUtf8)
+import qualified Data.ByteString as ByteString
+
+-- There is already a RewriteRule identifier in Agda internals, hence the name.
+-- Elements:
+  -- the identifier to rewrite ("from")
+  -- the identifier with which we replace it ("to")
+  -- the import to use, if any ("importing")
+data Rewrite = Rewrite {from :: String, to :: String, importing :: Maybe String}
+
+type Rewrites = [Rewrite]
+
+-- Read rewrite rules from a given file. Fail if the format is incorrect (necessary fields are absent).
+readRewritesFromFile :: FilePath -> IO Rewrites
+readRewritesFromFile fname = rulesFromYaml <$> parseYamlFile fname
+
+-- Read rewrite rules from a YamlLight object. Fail if the format is incorrect.
+rulesFromYaml :: YamlLight -> Rewrites
+rulesFromYaml y = case y of
+  YNil -> []
+  YSeq ls -> map ruleFromElement ls
+  otherYaml -> error $ "Incorrect format for the rewrite rules file: must be a list of elements – " ++ show otherYaml
+  where
+    -- parsing a single element
+    ruleFromElement :: YamlLight -> Rewrite
+    ruleFromElement (YMap dmap) = case (safeRuleFromMap dmap) of
+      Right rule -> rule
+      Left e     -> error e
+    ruleFromElement otherYaml   = error $ "Not a map: " ++ show otherYaml
+    
+    safeRuleFromMap :: Map.Map YamlLight YamlLight -> Either String Rewrite
+    safeRuleFromMap yamlMap = do
+      let dmap = Map.mapKeys unpackString $ Map.map unpackString yamlMap
+      from <- safeLookup (pure "from") dmap
+      to   <- safeLookup (pure "to") dmap
+      case Map.lookup (Right "importing") dmap of
+        Just (Right lib) -> Right $ Rewrite from to (Just lib)
+        Just (Left e)    -> Left e
+        Nothing          -> Right $ Rewrite from to Nothing
+
+    -- not too pretty... but Map.Map is not Traversable
+    safeLookup :: Either String String -> Map.Map (Either String String) (Either String String) -> Either String String
+    safeLookup key dmap = case Map.lookup key dmap of
+      Just val -> val
+      Nothing  -> Left $ "Key not found: " ++ show key
+
+    unpackString :: YamlLight -> Either String String
+    unpackString yaml = case (unStr yaml) of
+      Just bytestr -> Right $ byteStringToString $ bytestr
+      Nothing      -> Left $ "Not a string element: " ++ show yaml
+
+-- Conversions from String to ByteString and vice versa.
+-- We assume UTF-8.
+stringToByteString :: String -> ByteString.ByteString
+stringToByteString = encodeUtf8 . Text.pack
+byteStringToString :: ByteString.ByteString -> String
+byteStringToString = Text.unpack . decodeUtf8

--- a/src/Agda2Hs/Compile/Types.hs
+++ b/src/Agda2Hs/Compile/Types.hs
@@ -20,6 +20,7 @@ import Agda.Syntax.Position ( Range )
 import Agda.Syntax.TopLevelModuleName ( TopLevelModuleName )
 
 import Agda2Hs.HsUtils ( Strictness )
+import Agda2Hs.Compile.Rewrites
 
 type ModuleEnv   = TopLevelModuleName
 type ModuleRes   = ()
@@ -29,7 +30,9 @@ type Ranged a    = (Range, a)
 type Code = (Hs.Module Hs.SrcSpanInfo, [Hs.Comment])
 
 data Options = Options { optOutDir     :: Maybe FilePath,
-                         optExtensions :: [Hs.Extension] }
+                         optExtensions :: [Hs.Extension],
+                         rewriteRules  :: Rewrites }
+                      -- ^ the rewrite rules read from user-provided config files
 
 -- Required by Agda-2.6.2, but we don't really care.
 instance NFData Options where
@@ -46,6 +49,8 @@ data CompileEnv = CompileEnv
   -- ^ whether copatterns should be allowed when compiling patterns
   , checkVar :: Bool
   -- ^ whether to ensure compiled variables are usable and visible
+  , rewrites :: Rewrites
+  -- ^ the user-defined rewrite rules read from a config file
   }
 
 type Qualifier = Maybe (Maybe (Hs.ModuleName ()))

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -11,17 +11,27 @@ import Agda.Main
 import Agda.Compiler.Backend
 
 import Agda2Hs.Compile
+import Agda2Hs.Compile.Rewrites
 import Agda2Hs.Compile.Types
 import Agda2Hs.Render
 
+import qualified System.IO.Unsafe as UNSAFE (unsafePerformIO)
+
 defaultOptions :: Options
-defaultOptions = Options{ optOutDir = Nothing, optExtensions = [] }
+defaultOptions = Options{ optOutDir = Nothing, optExtensions = [], rewriteRules = [] }
 
 outdirOpt :: Monad m => FilePath -> Options -> m Options
 outdirOpt dir opts = return opts{ optOutDir = Just dir }
 
 extensionOpt :: Monad m => String -> Options -> m Options
 extensionOpt ext opts = return opts{ optExtensions = Hs.parseExtension ext : optExtensions opts }
+
+-- Here we use unsafePerformIO to read the rewrite rules from the files.
+rewriteOpt :: Monad m => FilePath -> Options -> m Options
+rewriteOpt file opts = return opts{
+                         rewriteRules = UNSAFE.unsafePerformIO (readRewritesFromFile file)
+                                          ++ rewriteRules opts}
+{-# NOINLINE rewriteOpt #-}
 
 backend :: Backend' Options Options ModuleEnv ModuleRes (CompiledDef, CompileOutput)
 backend = Backend'
@@ -33,6 +43,8 @@ backend = Backend'
         "Write Haskell code to DIR. (default: project root)"
       , Option ['X'] [] (ReqArg extensionOpt "EXTENSION")
         "Enable Haskell language EXTENSION. Affects parsing of Haskell code in FOREIGN blocks."
+      , Option [] ["rewrite-rules"] (ReqArg rewriteOpt "FILE")
+        "Provide custom rewrite rules in a YAML configuration file. Identifiers contained here will be replaced with the one given, with an appropriate import added if requested. See rewrite-example.yaml for the format."
       ]
   , isEnabled             = \ _ -> True
   , preCompile            = return

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -44,7 +44,7 @@ backend = Backend'
       , Option ['X'] [] (ReqArg extensionOpt "EXTENSION")
         "Enable Haskell language EXTENSION. Affects parsing of Haskell code in FOREIGN blocks."
       , Option [] ["rewrite-rules"] (ReqArg rewriteOpt "FILE")
-        "Provide custom rewrite rules in a YAML configuration file. Identifiers contained here will be replaced with the one given, with an appropriate import added if requested. See rewrite-example.yaml for the format."
+        "Provide custom rewrite rules in a YAML configuration file. Identifiers contained here will be replaced with the one given, with an appropriate import added if requested. See rewrite-rules-example.yaml for the format."
       ]
   , isEnabled             = \ _ -> True
   , preCompile            = return


### PR DESCRIPTION
The rewriting mechanism used in `isSpecialName` in `Name.hs` has been opened for users. For this, you have to use the `--rewrite-rules` option and provide a YAML file with the format of `rewrite-rules-example.yaml`.

Why is this useful? Imagine you have a project which uses the Agda standard library quite extensively. You don't want to rewrite the entire standard library to an agda2hs-compatible version, but you need the theorems contained in it for your proofs. With this option, you can translate the operators of the standard library to the corresponding Haskell functions, or to your predefined functions (I used a file called `Base.hs` for that in my project).

Of course, that compromises the mathematically proven correctness of your library a bit. But if you trust that the Haskell Prelude operators do the same thing as the Agda standard library functions, this might not be something to worry about. If you want, you can even write proofs for the equivalence of the two. Besides that, the feature would remain optional.

Known issues:
- If you import something from Prelude, you have to state this explicitly.
- Then, it will add an import like `import Prelude (...)`, which shadows all the other functions in Prelude. I think this is not necessarily a problem; as we will probably not modify the generated Haskell files by hand, and so we won't add any new Prelude functions.
- But this only works for things you do use, not for those that you only define. For example, if you write an instance of the `Num` class and define `signum` but don't use it, it won't get into Prelude's import list, and so GHC will complain.
- You cannot change to a version with arguments of different modality without getting rubbish code. So if you rewrite a function to a version which has some of its parameters erased, the parameters remain there; probably because rewriting happens only after compiling the type signature.

Further development:
- I would like to add a flag which gives a warning for all names defined neither in the project nor in a rewrite rule. This would make purging invalid references easier.
- Maybe an implicit import of Prelude functions. But with that, you could get into trouble if you reuse a name already defined in Prelude.