### PR TITLE
Adding "type" prefix before type operator imports

### DIFF
--- a/src/Agda2Hs/Compile/Name.hs
+++ b/src/Agda2Hs/Compile/Name.hs
@@ -160,22 +160,17 @@ compileQName f
     getNamespace :: QName -> C (Hs.Namespace ())
     getNamespace qName = do
       definition <- getConstInfo qName
-      let isQNameSet = isSet $ getResultType $ defType definition
-      reportSDoc "agda2hs.name" 25 $ text $ "Checking whether " ++ (prettyShow $ nameCanonical $ qnameName f)
-                                              ++ "is a type operator: " ++ show isQNameSet
-      if isQNameSet then return (Hs.TypeNamespace ()) else return (Hs.NoNamespace ())
+      case isSort $ unEl $ getResultType $ defType definition of
+        Just _         -> (reportSDoc "agda2hs.name" 25 $ text $ (prettyShow $ nameCanonical $ qnameName f)
+                                              ++ " is a type operator; will add \"type\" prefix before it") >>
+                          return (Hs.TypeNamespace ())
+        _              -> return (Hs.NoNamespace ())
 
     -- Gets the type of the result of the function (the type after the last "->").
     getResultType :: Type -> Type
     getResultType typ = case (unEl typ) of
       (Pi _ absType) -> getResultType $ unAbs absType
       _              -> typ
-
-    -- I'm not sure whether this is the correct way to determine whether it's a Set/Prop;
-    -- but this is my best bet.
-    isSet :: Type -> Bool
-    isSet (El _ (Sort _)) = True
-    isSet _               = False
 
     mkImport mod qual par hf maybeIsType
       -- make sure the Prelude is properly qualified

--- a/src/Agda2Hs/Compile/Types.hs
+++ b/src/Agda2Hs/Compile/Types.hs
@@ -88,9 +88,9 @@ data Import = Import
   , importQualified :: Qualifier
   , importParent    :: Maybe (Hs.Name ())
   , importName      :: Hs.Name ()
-  , importNamespace :: Maybe (Hs.Namespace ())
+  , importNamespace :: Hs.Namespace ()
                     -- ^^ if this is a type or something like that, we can add a namespace qualifier to the import spec
-                    -- now it's only useful for differentiating type operators; hence the "Maybe"
+                    -- now it's only useful for differentiating type operators; so for others we always put Hs.NoNamespace () here
                     -- (we don't calculate it if it's not necessary)
   }
 type Imports = [Import]

--- a/src/Agda2Hs/Compile/Types.hs
+++ b/src/Agda2Hs/Compile/Types.hs
@@ -88,6 +88,10 @@ data Import = Import
   , importQualified :: Qualifier
   , importParent    :: Maybe (Hs.Name ())
   , importName      :: Hs.Name ()
+  , importNamespace :: Maybe (Hs.Namespace ())
+                    -- ^^ if this is a type or something like that, we can add a namespace qualifier to the import spec
+                    -- now it's only useful for differentiating type operators; hence the "Maybe"
+                    -- (we don't calculate it if it's not necessary)
   }
 type Imports = [Import]
 

--- a/src/Agda2Hs/Compile/Types.hs
+++ b/src/Agda2Hs/Compile/Types.hs
@@ -134,3 +134,9 @@ data DataTarget = ToData | ToDataNewType
 data RecordTarget = ToRecord [Hs.Deriving ()] | ToRecordNewType [Hs.Deriving ()] | ToClass [String]
 
 data InstanceTarget = ToDefinition | ToDerivation (Maybe (Hs.DerivStrategy ()))
+
+-- Used when compiling imports. If there is a type operator, we can append a "type" namespace here.
+data NamespacedName = NamespacedName { nnNamespace :: Hs.Namespace (),
+                                       nnName      :: Hs.Name ()
+                                     }
+                      deriving (Eq, Ord)

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -104,4 +104,8 @@ import WitnessedFlows
 import Kinds
 import LawfulOrd
 import Deriving
+import ErasedLocalDefinitions
+import TypeOperators
+import TypeOperatorExport
+import TypeOperatorImport
 #-}

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -52,6 +52,8 @@ import LawfulOrd
 import Deriving
 import ErasedLocalDefinitions
 import TypeOperators
+import TypeOperatorExport
+import TypeOperatorImport
 
 {-# FOREIGN AGDA2HS
 import Issue14

--- a/test/TypeOperatorExport.agda
+++ b/test/TypeOperatorExport.agda
@@ -1,0 +1,21 @@
+module TypeOperatorExport where
+
+{-# FOREIGN AGDA2HS {-# LANGUAGE TypeOperators #-} #-}
+
+open import Agda.Primitive
+
+_<_ : Set -> Set -> Set
+a < b = a
+{-# COMPILE AGDA2HS _<_ #-}
+
+data _***_ {i j : Level} (a : Set i) (b : Set j) : Set (i ⊔ j) where
+  _:*:_ : a -> b -> a *** b
+open _***_ public
+{-# COMPILE AGDA2HS _***_ #-}
+
+open import Agda.Builtin.Bool
+
+_&&&_ : Bool -> Bool -> Bool
+false &&& _  = false
+_     &&& b2 = b2
+{-# COMPILE AGDA2HS _&&&_ #-}

--- a/test/TypeOperatorImport.agda
+++ b/test/TypeOperatorImport.agda
@@ -1,0 +1,15 @@
+module TypeOperatorImport where
+
+{-# FOREIGN AGDA2HS {-# LANGUAGE TypeOperators #-} #-}
+
+open import Agda.Builtin.Unit
+open import Agda.Builtin.Bool
+open import TypeOperatorExport
+
+test1 : ⊤ < Bool
+test1 = tt
+{-# COMPILE AGDA2HS test1 #-}
+
+test2 : Bool -> Bool -> ⊤ *** Bool
+test2 b1 b2 = tt :*: (b1 &&& b2)
+{-# COMPILE AGDA2HS test2 #-}

--- a/test/TypeOperatorImport.agda
+++ b/test/TypeOperatorImport.agda
@@ -4,12 +4,17 @@ module TypeOperatorImport where
 
 open import Agda.Builtin.Unit
 open import Agda.Builtin.Bool
+open import Haskell.Prelude using (_∘_)
 open import TypeOperatorExport
+
+not : Bool → Bool
+not true  = false
+not false = true
 
 test1 : ⊤ < Bool
 test1 = tt
 {-# COMPILE AGDA2HS test1 #-}
 
 test2 : Bool -> Bool -> ⊤ *** Bool
-test2 b1 b2 = tt :*: (b1 &&& b2)
+test2 b1 b2 = ((tt :*:_) ∘ not) (b1 &&& b2)
 {-# COMPILE AGDA2HS test2 #-}

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -48,4 +48,8 @@ import WitnessedFlows
 import Kinds
 import LawfulOrd
 import Deriving
+import ErasedLocalDefinitions
+import TypeOperators
+import TypeOperatorExport
+import TypeOperatorImport
 

--- a/test/golden/Importer.hs
+++ b/test/golden/Importer.hs
@@ -1,7 +1,6 @@
 module Importer where
 
-import Importee
-       (Foo(MkFoo), Fooable(defaultFoo, doTheFoo), foo, (!#))
+import Importee (Foo(MkFoo), Fooable(defaultFoo, doTheFoo), foo, (!#))
 import Numeric.Natural (Natural)
 import SecondImportee (anotherFoo)
 

--- a/test/golden/QualifiedImports.hs
+++ b/test/golden/QualifiedImports.hs
@@ -1,8 +1,7 @@
 module QualifiedImports where
 
 import qualified Importee (Foo(MkFoo), foo)
-import qualified QualifiedImportee as Qually
-       (Foo, Fooable(defaultFoo, doTheFoo), foo, (!#))
+import qualified QualifiedImportee as Qually (Foo, Fooable(defaultFoo, doTheFoo), foo, (!#))
 
 -- ** simple qualification
 

--- a/test/golden/RequalifiedImports.hs
+++ b/test/golden/RequalifiedImports.hs
@@ -1,8 +1,7 @@
 module RequalifiedImports where
 
 import OtherImportee (OtherFoo(MkFoo))
-import qualified QualifiedImportee as A
-       (Foo, Fooable(defaultFoo, doTheFoo), foo, (!#))
+import qualified QualifiedImportee as A (Foo, Fooable(defaultFoo, doTheFoo), foo, (!#))
 
 -- ** conflicting imports are all replaced with the "smallest" qualifier
 --   * the characters are ordered based on their ASCII value (i.e. capitals first)

--- a/test/golden/TypeOperatorExport.hs
+++ b/test/golden/TypeOperatorExport.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE TypeOperators #-}
+
+module TypeOperatorExport where
+
+type (<) a b = a
+
+data (***) a b = (:*:) a b
+
+(&&&) :: Bool -> Bool -> Bool
+False &&& _ = False
+_ &&& b2 = b2
+

--- a/test/golden/TypeOperatorImport.hs
+++ b/test/golden/TypeOperatorImport.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE TypeOperators #-}
+
+module TypeOperatorImport where
+
+import TypeOperatorExport ((&&&), type (***)((:*:)), type (<))
+
+test1 :: (<) () Bool
+test1 = ()
+
+test2 :: Bool -> Bool -> (***) () Bool
+test2 b1 b2 = ((() :*:) . not) (b1 &&& b2)
+


### PR DESCRIPTION
GHC expects that when importing type operators, the `type` prefix is provided before the identifier in the import specs. This PR fixes that. It only calculates this for operators; since for other identifiers it would only be needed when having a "normal" function with the same name, and Agda doesn't allow that.

Unfortunately, when type operators have "children" imports (see `(***)` in `TypeOperatorImport.hs`), you have to specify it too, but the Haskell Language Extensions' pretty printer does not do it. So I had to circumvent this; which has the side effect of it not being able to break long import lines anymore. (But see [PR 475](https://github.com/haskell-suite/haskell-src-exts/pull/475) there.)