### PR TITLE
Update to Agda 2.6.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
     # Takes care of ghc and cabal. See https://github.com/haskell/actions.
-    - uses: haskell/actions/setup@v2
+    - uses: haskell-actions/setup@v2
       id: setup-haskell-cabal
       name: Setup Haskell
       with:

--- a/agda2hs.agda-lib
+++ b/agda2hs.agda-lib
@@ -1,4 +1,4 @@
 name: agda2hs
 depend:
 include: lib
-flags: -W noUnsupportedIndexedMatch
+flags: -W noUnsupportedIndexedMatch --erasure

--- a/agda2hs.cabal
+++ b/agda2hs.cabal
@@ -58,7 +58,7 @@ executable agda2hs
                        Agda2Hs.Render
                        AgdaInternals
   build-depends:       base >= 4.10 && < 4.18,
-                       Agda >= 2.6.4 && < 2.6.5,
+                       Agda >= 2.6.3.20230805 && < 2.6.5,
                        bytestring >= 0.11,
                        containers >= 0.6 && < 0.7,
                        unordered-containers >= 0.2,

--- a/agda2hs.cabal
+++ b/agda2hs.cabal
@@ -58,7 +58,7 @@ executable agda2hs
                        Agda2Hs.Render
                        AgdaInternals
   build-depends:       base >= 4.10 && < 4.18,
-                       Agda >= 2.6.3.20230805 && < 2.6.5,
+                       Agda >= 2.6.4 && < 2.6.5,
                        bytestring >= 0.11,
                        containers >= 0.6 && < 0.7,
                        unordered-containers >= 0.2,

--- a/agda2hs.cabal
+++ b/agda2hs.cabal
@@ -58,7 +58,7 @@ executable agda2hs
                        Agda2Hs.Render
                        AgdaInternals
   build-depends:       base >= 4.10 && < 4.18,
-                       Agda >= 2.6.3 && < 2.6.4,
+                       Agda >= 2.6.4 && < 2.6.5,
                        bytestring >= 0.11,
                        containers >= 0.6 && < 0.7,
                        unordered-containers >= 0.2,

--- a/agda2hs.cabal
+++ b/agda2hs.cabal
@@ -85,7 +85,7 @@ executable agda2hs-mode
   main-is:             Main.hs
   other-modules:       Paths_agda2hs
   build-depends:       base >= 4.10 && < 4.18,
-                       Agda >= 2.6.3 && < 2.6.4,
+                       Agda >= 2.6.4 && < 2.6.5,
                        bytestring >= 0.11,
                        containers >= 0.6 && < 0.7,
                        unordered-containers >= 0.2,

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,6 @@
 packages: ./agda2hs.cabal
+
+source-repository-package
+  type: git
+  location: https://github.com/agda/agda
+  tag: v2.6.3.20230805

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,1 @@
 packages: ./agda2hs.cabal
-
-source-repository-package
-  type: git
-  location: https://github.com/agda/agda
-  tag: v2.6.3.20230805

--- a/src/Agda2Hs/AgdaUtils.hs
+++ b/src/Agda2Hs/AgdaUtils.hs
@@ -9,18 +9,18 @@ import Agda.Compiler.Backend hiding ( Args )
 import Agda.Interaction.FindFile ( findFile' )
 
 import Agda.Syntax.Common ( Arg, defaultArg )
+import Agda.Syntax.Common.Pretty ( prettyShow )
 import Agda.Syntax.Internal
 import Agda.Syntax.Internal.Names
 import Agda.Syntax.TopLevelModuleName
 
 import Agda.TypeChecking.Monad ( topLevelModuleName )
-import Agda.TypeChecking.Pretty 
+import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Substitute
 
 import Agda.Utils.Either ( isRight )
 import Agda.Utils.List ( initMaybe )
 import Agda.Utils.Monad ( ifM )
-import Agda.Utils.Pretty ( prettyShow )
 import Agda.Utils.Impossible ( __IMPOSSIBLE__ )
 
 import AgdaInternals

--- a/src/Agda2Hs/Compile/ClassInstance.hs
+++ b/src/Agda2Hs/Compile/ClassInstance.hs
@@ -21,13 +21,13 @@ import Agda.Syntax.Internal
 import Agda.Syntax.Position ( noRange )
 import Agda.Syntax.Scope.Base
 import Agda.Syntax.Scope.Monad ( resolveName )
+import Agda.Syntax.Common.Pretty ( prettyShow )
 
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Substitute ( Apply(applyE) )
 import Agda.TypeChecking.Records
 
 import Agda.Utils.Lens
-import Agda.Utils.Pretty ( prettyShow )
 import Agda.Utils.Impossible ( __IMPOSSIBLE__ )
 
 import Agda2Hs.AgdaUtils

--- a/src/Agda2Hs/Compile/Data.hs
+++ b/src/Agda2Hs/Compile/Data.hs
@@ -5,13 +5,13 @@ import qualified Language.Haskell.Exts.Syntax as Hs
 import Agda.Compiler.Backend
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
+import Agda.Syntax.Common.Pretty ( prettyShow )
 
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Telescope
 
-import Agda.Utils.Pretty ( prettyShow )
 import Agda.Utils.Impossible ( __IMPOSSIBLE__ )
 
 import Agda2Hs.Compile.Type ( compileDom, compileTeleBinds )
@@ -23,7 +23,7 @@ checkNewtype :: Hs.Name () -> [Hs.QualConDecl ()] -> C ()
 checkNewtype name cs = do
   checkSingleElement name cs "Newtype must have exactly one constructor in definition"
   case head cs of
-    Hs.QualConDecl () _ _ (Hs.ConDecl () cName types) 
+    Hs.QualConDecl () _ _ (Hs.ConDecl () cName types)
       -> checkSingleElement cName types "Newtype must have exactly one field in constructor"
 
 compileData :: DataTarget -> [Hs.Deriving ()] -> Definition -> C [Hs.Decl ()]

--- a/src/Agda2Hs/Compile/Function.hs
+++ b/src/Agda2Hs/Compile/Function.hs
@@ -18,6 +18,7 @@ import Agda.Compiler.Common
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
 import Agda.Syntax.Literal
+import Agda.Syntax.Common.Pretty ( prettyShow )
 
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Substitute
@@ -26,7 +27,6 @@ import Agda.TypeChecking.Sort ( ifIsSort )
 
 import Agda.Utils.Functor ( (<&>) )
 import Agda.Utils.Impossible ( __IMPOSSIBLE__ )
-import Agda.Utils.Pretty ( prettyShow )
 import Agda.Utils.Monad
 
 import Agda2Hs.AgdaUtils

--- a/src/Agda2Hs/Compile/Imports.hs
+++ b/src/Agda2Hs/Compile/Imports.hs
@@ -12,7 +12,7 @@ import qualified Language.Haskell.Exts as Hs
 
 import Agda.Compiler.Backend
 import Agda.TypeChecking.Pretty ( text )
-import Agda.Utils.Pretty ( prettyShow )
+import Agda.Syntax.Common.Pretty ( prettyShow )
 
 import Agda2Hs.AgdaUtils
 import Agda2Hs.Compile.Name

--- a/src/Agda2Hs/Compile/Name.hs
+++ b/src/Agda2Hs/Compile/Name.hs
@@ -19,14 +19,14 @@ import Agda.Syntax.Position
 import qualified Agda.Syntax.Concrete as C
 import Agda.Syntax.Scope.Base ( inverseScopeLookupName )
 import Agda.Syntax.TopLevelModuleName
+import Agda.Syntax.Common.Pretty ( prettyShow )
+import qualified Agda.Syntax.Common.Pretty as P
 
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Records ( isRecordConstructor )
 
 import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Maybe ( isJust, whenJust, fromMaybe, caseMaybeM )
-import Agda.Utils.Pretty ( prettyShow )
-import qualified Agda.Utils.Pretty as P ( Pretty(pretty) )
 
 import Agda2Hs.AgdaUtils
 import Agda2Hs.Compile.Rewrites

--- a/src/Agda2Hs/Compile/Postulate.hs
+++ b/src/Agda2Hs/Compile/Postulate.hs
@@ -5,8 +5,7 @@ import qualified Language.Haskell.Exts.Syntax as Hs
 import Agda.Compiler.Backend
 
 import Agda.Syntax.Internal
-
-import Agda.Utils.Pretty ( prettyShow )
+import Agda.Syntax.Common.Pretty ( prettyShow )
 
 import Agda2Hs.Compile.Type ( compileType )
 import Agda2Hs.Compile.Types

--- a/src/Agda2Hs/Compile/Record.hs
+++ b/src/Agda2Hs/Compile/Record.hs
@@ -14,12 +14,12 @@ import Agda.Compiler.Backend
 
 import Agda.Syntax.Common ( Arg(unArg), defaultArg )
 import Agda.Syntax.Internal
+import Agda.Syntax.Common.Pretty ( prettyShow )
 
 import Agda.TypeChecking.Pretty ( ($$), (<+>), text, vcat )
 import Agda.TypeChecking.Substitute ( TelV(TelV), Apply(apply) )
 import Agda.TypeChecking.Telescope
 
-import Agda.Utils.Pretty ( prettyShow )
 import Agda.Utils.Impossible ( __IMPOSSIBLE__ )
 
 import Agda2Hs.AgdaUtils

--- a/src/Agda2Hs/Compile/Term.hs
+++ b/src/Agda2Hs/Compile/Term.hs
@@ -10,6 +10,8 @@ import qualified Data.Text as Text ( unpack )
 
 import qualified Language.Haskell.Exts as Hs
 
+import Agda.Syntax.Common.Pretty ( prettyShow )
+import qualified Agda.Syntax.Common.Pretty as P
 import Agda.Syntax.Common
 import Agda.Syntax.Literal
 import Agda.Syntax.Internal
@@ -20,8 +22,6 @@ import Agda.TypeChecking.Reduce ( instantiate )
 import Agda.TypeChecking.Substitute ( Apply(applyE) )
 
 import Agda.Utils.Lens
-import Agda.Utils.Pretty ( prettyShow )
-import qualified Agda.Utils.Pretty as P
 
 import Agda.Utils.Impossible ( __IMPOSSIBLE__ )
 import Agda.Utils.Monad

--- a/src/Agda2Hs/Compile/Type.hs
+++ b/src/Agda2Hs/Compile/Type.hs
@@ -15,6 +15,7 @@ import Agda.Compiler.Backend hiding ( Args )
 
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
+import Agda.Syntax.Common.Pretty ( prettyShow )
 
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Reduce ( reduce )
@@ -22,7 +23,6 @@ import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Telescope
 
 import Agda.Utils.Impossible ( __IMPOSSIBLE__ )
-import Agda.Utils.Pretty ( prettyShow )
 import Agda.Utils.List ( downFrom )
 import Agda.Utils.Maybe ( ifJustM, fromMaybe )
 import Agda.Utils.Monad ( ifM, unlessM )

--- a/src/Agda2Hs/Compile/Utils.hs
+++ b/src/Agda2Hs/Compile/Utils.hs
@@ -19,6 +19,8 @@ import Agda.Syntax.Internal
 import Agda.Syntax.Position ( noRange )
 import Agda.Syntax.Scope.Base
 import Agda.Syntax.Scope.Monad ( bindVariable, freshConcreteName )
+import Agda.Syntax.Common.Pretty ( prettyShow )
+import qualified Agda.Syntax.Common.Pretty as P
 
 import Agda.TypeChecking.CheckInternal ( infer )
 import Agda.TypeChecking.Constraints ( noConstraints )
@@ -34,8 +36,6 @@ import Agda.TypeChecking.Substitute ( Subst, TelV(TelV) )
 import Agda.TypeChecking.Telescope ( telView )
 
 import Agda.Utils.Lens ( (<&>) )
-import Agda.Utils.Pretty ( prettyShow )
-import qualified Agda.Utils.Pretty as P
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Singleton

--- a/src/Agda2Hs/Pragma.hs
+++ b/src/Agda2Hs/Pragma.hs
@@ -29,7 +29,7 @@ languagePragmas _ = []
 
 getForeignPragmas :: [Hs.Extension] -> TCM [(Range, Code)]
 getForeignPragmas exts = do
-  pragmas <- fromMaybe [] . Map.lookup pragmaName . iForeignCode <$> curIF
+  pragmas <- fromMaybe [] . fmap getForeignCodeStack . Map.lookup pragmaName . iForeignCode <$> curIF
   getCode exts $ reverse pragmas
   where
     getCode :: [Hs.Extension] -> [ForeignCode] -> TCM [(Range, Code)]

--- a/src/Agda2Hs/Render.hs
+++ b/src/Agda2Hs/Render.hs
@@ -25,8 +25,8 @@ import Agda.TypeChecking.Pretty
 import qualified Agda.Syntax.Concrete.Name as C
 import Agda.Syntax.Position
 import Agda.Syntax.TopLevelModuleName
+import Agda.Syntax.Common.Pretty ( prettyShow )
 
-import Agda.Utils.Pretty ( prettyShow )
 import Agda.Utils.Impossible ( __IMPOSSIBLE__ )
 
 import Agda2Hs.Compile

--- a/test/agda2hs-test.agda-lib
+++ b/test/agda2hs-test.agda-lib
@@ -1,4 +1,4 @@
 name: agda2hs-test
 depend:
 include: . ../lib
-flags: --sized-types
+flags: --sized-types --erasure


### PR DESCRIPTION
On the Haskell side, other than me having moved `Agda.Utils.Pretty` (possibly the most breaking a trivial change could be), the values in `iForeignCode` are now also wrapped in a newtype.
On the Agda side, `--erasure` is now a flag; I added it to the agda-lib files rather than adding it by hand everywhere.