### PR TITLE
Fix #169

### DIFF
--- a/src/Agda2Hs/AgdaUtils.hs
+++ b/src/Agda2Hs/AgdaUtils.hs
@@ -2,6 +2,7 @@ module Agda2Hs.AgdaUtils where
 
 import Data.Data
 import Data.Monoid ( Any(..) )
+import qualified Data.Map as Map
 import Data.Maybe ( fromMaybe )
 
 import Agda.Compiler.Backend hiding ( Args )
@@ -9,8 +10,11 @@ import Agda.Compiler.Backend hiding ( Args )
 import Agda.Interaction.FindFile ( findFile' )
 
 import Agda.Syntax.Common ( Arg, defaultArg )
+import qualified Agda.Syntax.Concrete as C
 import Agda.Syntax.Internal
 import Agda.Syntax.Internal.Names
+import Agda.Syntax.Scope.Base
+import Agda.Syntax.Scope.Monad
 import Agda.Syntax.TopLevelModuleName
 
 import Agda.TypeChecking.Monad ( topLevelModuleName )
@@ -92,3 +96,7 @@ getTopLevelModuleForModuleName = loop . mnameToList
 
 getTopLevelModuleForQName :: QName -> TCM (Maybe TopLevelModuleName)
 getTopLevelModuleForQName = getTopLevelModuleForModuleName . qnameModule
+
+lookupModuleInCurrentModule :: C.Name -> TCM [AbstractModule]
+lookupModuleInCurrentModule x =
+  fromMaybe [] . Map.lookup x . nsModules . thingsInScope [PublicNS, PrivateNS] <$> getCurrentScope

--- a/src/Agda2Hs/Compile/ClassInstance.hs
+++ b/src/Agda2Hs/Compile/ClassInstance.hs
@@ -137,6 +137,10 @@ compileInstanceClause curModule c = withClauseLocals curModule c $ do
       -- We want the actual field name, not the instance-opened projection.
       (q, _, _) <- origProjection q
       arg <- fieldArgInfo q
+
+      reportSDoc "agda2hs.compile.instance" 15 $
+        text "Compiling instance clause for" <+> prettyTCM (Arg arg $ Def q [])
+
       let uf = hsName $ prettyShow $ nameConcrete $ qnameName q
 
       let
@@ -168,25 +172,37 @@ compileInstanceClause curModule c = withClauseLocals curModule c $ do
         -- Projection of a primitive field: chase down definition and inline as instance clause.
         | Clause {namedClausePats = [], clauseBody = Just (Def n es)} <- c'
         , [(_, f)] <- mapMaybe isProjElim es
-        , f .~ q
-        -> do d <- chaseDef n
-              fc <- compileFun False d
-              let hd = hsName $ prettyShow $ nameConcrete $ qnameName $ defName d
-              let fc' = dropPatterns 1 $ replaceName hd uf fc
-              return (map (Hs.InsDecl ()) fc', [n])
+        , f .~ q -> do
+          reportSDoc "agda2hs.compile.instance" 20 $
+            text "Instance clause is projected from" <+> prettyTCM (Def n [])
+          reportSDoc "agda2hs.compile.instance" 20 $
+            text $ "raw projection:" ++ prettyShow (Def n [])
+          d <- chaseDef n
+          fc <- compileFun False d
+          let hd = hsName $ prettyShow $ nameConcrete $ qnameName $ defName d
+          let fc' = dropPatterns 1 $ replaceName hd uf fc
+          return (map (Hs.InsDecl ()) fc', [n])
 
          -- Projection of a default implementation: drop while making sure these are drawn from the
          -- same (minimal) dictionary as the primitive fields.
-         | Clause {namedClausePats = [], clauseBody = Just (Def n es)} <- c'
-         , n .~ q
-         , Just [ Def n' _ ] <- map unArg . filter keepArg <$> allApplyElims es
-         -> do n' <- resolveExtendedLambda n'
-               return ([], [n'])
+        | Clause {namedClausePats = [], clauseBody = Just (Def n es)} <- c'
+        , n .~ q -> do
+          case map unArg . filter keepArg <$> allApplyElims es of
+            Just [ Def f _ ] -> do
+              reportSDoc "agda2hs.compile.instance" 20 $ vcat
+                  [ text "Dropping default instance clause" <+> prettyTCM c'
+                  , text "with minimal dictionary" <+> prettyTCM f
+                  ]
+              reportSDoc "agda2hs.compile.instance" 40 $
+                  text $ "raw dictionary:" ++ prettyShow f
+              return ([], [f])
+            _ -> genericDocError =<< text "illegal instance declaration: instances using default methods should use a named definition or an anonymous `λ where`."
 
-         -- No minimal dictionary used, proceed with compiling as a regular clause.
-         | otherwise
-         -> do ms <- disableCopatterns $ compileClause curModule uf c'
-               return ([Hs.InsDecl () (Hs.FunBind () [ms]) | keepArg arg], [])
+        -- No minimal dictionary used, proceed with compiling as a regular clause.
+        | otherwise -> do
+          reportSDoc "agda2hs.compile.instance" 20 $ text "Compiling instance clause" <+> prettyTCM c'
+          ms <- disableCopatterns $ compileClause curModule uf c'
+          return ([Hs.InsDecl () (Hs.FunBind () [ms])], [])
 
 fieldArgInfo :: QName -> C ArgInfo
 fieldArgInfo f = do

--- a/src/Agda2Hs/Compile/Name.hs
+++ b/src/Agda2Hs/Compile/Name.hs
@@ -3,8 +3,10 @@ module Agda2Hs.Compile.Name where
 import Control.Arrow ( (>>>) )
 import Control.Applicative ( (<|>) )
 import Control.Monad
+import Control.Monad.Except ( catchError )
 import Control.Monad.Reader
 
+import Data.Functor ( (<&>) )
 import Data.List ( intercalate, isPrefixOf )
 import Data.Text ( unpack )
 
@@ -13,18 +15,21 @@ import qualified Language.Haskell.Exts as Hs
 import Agda.Compiler.Backend hiding ( topLevelModuleName )
 import Agda.Compiler.Common ( topLevelModuleName )
 
+import qualified Agda.Syntax.Abstract as A
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
 import Agda.Syntax.Position
 import qualified Agda.Syntax.Concrete as C
-import Agda.Syntax.Scope.Base ( inverseScopeLookupName )
+import Agda.Syntax.Scope.Base ( inverseScopeLookupName, amodName )
+import Agda.Syntax.Scope.Monad ( resolveName, isDatatypeModule )
 import Agda.Syntax.TopLevelModuleName
 
+import Agda.TypeChecking.Datatypes ( isDataOrRecordType )
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Records ( isRecordConstructor )
 
 import qualified Agda.Utils.List1 as List1
-import Agda.Utils.Maybe ( isJust, whenJust, fromMaybe, caseMaybeM )
+import Agda.Utils.Maybe ( isJust, isNothing, whenJust, fromMaybe, caseMaybeM )
 import Agda.Utils.Pretty ( prettyShow )
 import qualified Agda.Utils.Pretty as P ( Pretty(pretty) )
 
@@ -140,12 +145,17 @@ compileQName f
 
     getQualifier :: QName -> Hs.ModuleName () -> C Qualifier
     getQualifier f mod =
-      (inverseScopeLookupName f <$> getScope) >>= return . \case
-        (C.Qual as C.QName{} : _)
-          | qual <- hsModuleName $ prettyShow as, qual /= mod
-          -> QualifiedAs (Just qual)
-        (C.Qual{} : _) -> QualifiedAs Nothing
-        _ -> Unqualified
+      (inverseScopeLookupName f <$> getScope) >>= \case
+        (C.QName{} : _) -> return Unqualified
+        (C.Qual as C.QName{} : _) -> liftTCM $ do
+          let qual = hsModuleName $ prettyShow as
+          lookupModuleInCurrentModule as >>= \case
+            (x:_) | qual /= mod -> isDatatypeModule (amodName x) >>= \case
+              Just{} -> return $ QualifiedAs Nothing
+              Nothing -> return $ QualifiedAs $ Just qual
+            _ -> return Nothing
+          `catchError` \_ -> return $ QualifiedAs Nothing
+        _ -> return $ QualifiedAs Nothing
 
     qualify :: Hs.ModuleName () -> Hs.Name () -> Qualifier -> Hs.QName ()
     qualify mod n = \case

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -55,6 +55,7 @@ import TypeOperators
 import ErasedTypeArguments
 import TypeOperatorExport
 import TypeOperatorImport
+import Issue169
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -110,4 +111,5 @@ import TypeOperators
 import ErasedTypeArguments
 import TypeOperatorExport
 import TypeOperatorImport
+import Issue169
 #-}

--- a/test/Fail/Issue169-record.agda
+++ b/test/Fail/Issue169-record.agda
@@ -1,3 +1,9 @@
+-- Using a default method implementation for an instance declaration currently
+-- requires a named definition or an anonymous `λ where` on the Agda side, so a
+-- record is not allowed.
+
+module Fail.Issue169-record where
+
 open import Haskell.Prelude
 
 record Identity (a : Set) : Set where
@@ -14,6 +20,6 @@ showIdentity record { runIdentity = id } = "Id < " ++ show id ++ " >"
 
 instance
   iIdentityShow : ⦃ Show a ⦄ → Show (Identity a)
-  iIdentityShow = record {Show₂ (λ where .Show₂.show → showIdentity)}
+  iIdentityShow = record {Show₂ record {show = showIdentity}}
 
 {-# COMPILE AGDA2HS iIdentityShow #-}

--- a/test/Issue169.agda
+++ b/test/Issue169.agda
@@ -1,0 +1,19 @@
+open import Haskell.Prelude
+
+record Identity (a : Set) : Set where
+    field
+        runIdentity : a
+open Identity public
+
+{-# COMPILE AGDA2HS Identity newtype #-}
+
+showIdentity : ⦃ Show a ⦄ → Identity a → String
+showIdentity record { runIdentity = id } = "Id < " ++ show id ++ " >"
+
+{-# COMPILE AGDA2HS showIdentity #-}
+
+instance
+  iIdentityShow : ⦃ Show a ⦄ → Show (Identity a)
+  iIdentityShow = record {Show₂ record {show = showIdentity}}
+
+{-# COMPILE AGDA2HS iIdentityShow #-}

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -53,4 +53,5 @@ import TypeOperators
 import ErasedTypeArguments
 import TypeOperatorExport
 import TypeOperatorImport
+import Issue169
 

--- a/test/golden/Issue169-record.err
+++ b/test/golden/Issue169-record.err
@@ -1,0 +1,2 @@
+test/Fail/Issue169-record.agda:22,3-16
+illegal instance declaration: instances using default methods should use a named definition or an anonymous `λ where`.

--- a/test/golden/Issue169.hs
+++ b/test/golden/Issue169.hs
@@ -1,0 +1,12 @@
+module Issue169 where
+
+newtype Identity a = Identity{runIdentity :: a}
+
+showIdentity :: Show a => Identity a -> String
+showIdentity (Identity id) = "Id < " ++ show id ++ " >"
+
+instance (Show a) => Show (Identity a) where
+    showsPrec = showsPrec
+    showList = showList
+    show = showIdentity
+

--- a/test/golden/Issue169.hs
+++ b/test/golden/Issue169.hs
@@ -6,7 +6,5 @@ showIdentity :: Show a => Identity a -> String
 showIdentity (Identity id) = "Id < " ++ show id ++ " >"
 
 instance (Show a) => Show (Identity a) where
-    showsPrec = showsPrec
-    showList = showList
     show = showIdentity
 

--- a/test/golden/QualifiedImports.hs
+++ b/test/golden/QualifiedImports.hs
@@ -1,15 +1,15 @@
 module QualifiedImports where
 
-import qualified Importee (Foo(MkFoo), foo)
+import Importee (Foo(MkFoo), foo)
 import qualified QualifiedImportee as Qually (Foo, Fooable(defaultFoo, doTheFoo), foo, (!#))
 
 -- ** simple qualification
 
 simpqualBar :: Int
-simpqualBar = Importee.foo
+simpqualBar = foo
 
-simpfoo :: Importee.Foo
-simpfoo = Importee.MkFoo
+simpfoo :: Foo
+simpfoo = MkFoo
 
 -- ** qualified imports
 


### PR DESCRIPTION
This PR addresses the two first points of my comment https://github.com/agda/agda2hs/issues/169#issuecomment-1750868186:

* Names of data and record modules are no longer considered for `as` names in qualified imports
* We now throw an error when the contents of a minimal record used to create an instance are not a named definition or a `\where` (which we never supported in the first place).

With these two changes, I'm not sure if there is anything left to fix for the third point since there doesn't seem to be any way to reproduce that problem. If it does happen again, it probably deserves its own issue.