### PR TITLE
[fix #215] handle automatic projections from let pattern of tuples

### DIFF
--- a/test/Tuples.agda
+++ b/test/Tuples.agda
@@ -33,3 +33,13 @@ t3 : Bool × (Bool × Bool)
 t3 = True , (False , True)
 
 {-# COMPILE AGDA2HS t3 #-}
+
+pair : Int × Int
+pair = (1 , 2)
+
+{-# COMPILE AGDA2HS pair #-}
+
+test : Int
+test = let (x , y) = pair in x + y
+
+{-# COMPILE AGDA2HS test #-}

--- a/test/golden/Tuples.hs
+++ b/test/golden/Tuples.hs
@@ -17,3 +17,9 @@ t2 = ((True, False), True)
 t3 :: (Bool, (Bool, Bool))
 t3 = (True, (False, True))
 
+pair :: (Int, Int)
+pair = (1, 2)
+
+test :: Int
+test = fst pair + snd pair
+


### PR DESCRIPTION
The issue was coming from Agda inlining let bindings. This translation leaked our encoding for tuples.

The example from #215 now gets compiled properly, but:

- n-uples with n > 2 pattern-matched inside `let`s would still get compiled incorrectly because there is in fact no proper way to inline the `let` using projections (unless we also generate projections on the fly, like `\(_, _, x) -> x`).

  So `let (x, y, z) = e in z` would still compile to the incorrect `snd (snd e)`. We probably need a reliable way to prevent such use of pattern-matching on `let` for n-uples, doesn't have to be now.

  We could compute the length of projection chains of `Pair.fst` and `Pair.snd` in the terms we get, the only issue being that the resulting error would not point to the location of the `let`, only the location of the problematic variable.

- The projection `fst` and `snd` of `Pair` probably shouldn't get exported from `Haskell.Prim.Tuple` so as to enforce that the only way they pop up in terms is through inlining of `let` bindings.

Feedback welcome.