### PR TITLE
[fix #219] always qualify unopened imports

### DIFF
--- a/src/Agda2Hs/Compile/Name.hs
+++ b/src/Agda2Hs/Compile/Name.hs
@@ -150,10 +150,10 @@ compileQName f
         (C.Qual as C.QName{} : _) -> liftTCM $ do
           let qual = hsModuleName $ prettyShow as
           lookupModuleInCurrentModule as >>= \case
-            (x:_) | qual /= mod -> isDatatypeModule (amodName x) >>= \case
-              Just{} -> return $ QualifiedAs Nothing
-              Nothing -> return $ QualifiedAs $ Just qual
-            _ -> return Nothing
+            (x:_) | qual /= mod -> do
+              isDataMod <- isJust <$> isDatatypeModule (amodName x)
+              return $ QualifiedAs (if isDataMod then Nothing else Just qual)
+            _ -> return $ QualifiedAs Nothing
           `catchError` \_ -> return $ QualifiedAs Nothing
         _ -> return $ QualifiedAs Nothing
 

--- a/test/QualifiedImports.agda
+++ b/test/QualifiedImports.agda
@@ -35,3 +35,7 @@ qualFooable = Qually.doTheFoo
 qualDefaultBar : Qually.Foo
 qualDefaultBar = Qually.defaultFoo
 {-# COMPILE AGDA2HS qualDefaultBar #-}
+
+Foo : Set
+Foo = Importee.Foo
+{-# COMPILE AGDA2HS Foo #-}

--- a/test/golden/QualifiedImports.hs
+++ b/test/golden/QualifiedImports.hs
@@ -1,15 +1,15 @@
 module QualifiedImports where
 
-import Importee (Foo(MkFoo), foo)
+import qualified Importee (Foo(MkFoo), foo)
 import qualified QualifiedImportee as Qually (Foo, Fooable(defaultFoo, doTheFoo), foo, (!#))
 
 -- ** simple qualification
 
 simpqualBar :: Int
-simpqualBar = foo
+simpqualBar = Importee.foo
 
-simpfoo :: Foo
-simpfoo = MkFoo
+simpfoo :: Importee.Foo
+simpfoo = Importee.MkFoo
 
 -- ** qualified imports
 
@@ -24,4 +24,6 @@ qualFooable = Qually.doTheFoo
 
 qualDefaultBar :: Qually.Foo
 qualDefaultBar = Qually.defaultFoo
+
+type Foo = Importee.Foo
 


### PR DESCRIPTION
The fix was easy enough, one branch for qualified imports (without a name) started returned `Nothing` after #202.

I changed a few lines that I found very hard to read, but can revert if it isn't to your taste. Also, can the lookup ever fail? I tried removing the `catchError` line locally and nothing happened on the test suite.