### PR TITLE
allow erased module arguments

### DIFF
--- a/src/Agda2Hs/Compile/Term.hs
+++ b/src/Agda2Hs/Compile/Term.hs
@@ -208,6 +208,7 @@ compileLiteral (LitString t) = return $ Hs.Lit () $ Hs.String () s s
   where s = Text.unpack t
 compileLiteral l               = genericDocError =<< text "bad term:" <?> prettyTCM (Lit l)
 
+-- | Compile a variable. If the check is enabled, ensures the variable is usable and visible.
 compileVar :: Nat -> C String
 compileVar x = do
   (d, n) <- (fmap snd &&& fst . unDom) <$> lookupBV x

--- a/src/Agda2Hs/Compile/Type.hs
+++ b/src/Agda2Hs/Compile/Type.hs
@@ -149,6 +149,8 @@ compileType' t = do
 compileType :: Term -> C (Hs.Type ())
 compileType t = do
   reportSDoc "agda2hs.compile.type" 12 $ text "Compiling type" <+> prettyTCM t
+  reportSDoc "agda2hs.compile.type" 22 $ text "Compiling type" <+> pretty t
+
   case t of
     Pi a b -> compileDom (absName b) a >>= \case
       DomType _ hsA -> do
@@ -158,7 +160,7 @@ compileType t = do
         hsB <- underAbstraction a b (compileType . unEl)
         return $ constrainType hsA hsB
       DomDropped -> underAbstr a b (compileType . unEl)
-    Def f es -> do
+    Def f es -> maybeUnfoldCopy f es compileType $ \f es -> do
       def <- getConstInfo f
       if | not (usableModality def) ->
             genericDocError

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -61,6 +61,7 @@ import Issue200
 import Issue169
 import Issue210
 import ModuleParameters
+import ModuleParametersImports
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -122,4 +123,5 @@ import Issue200
 import Issue169
 import Issue210
 import ModuleParameters
+import ModuleParametersImports
 #-}

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -60,6 +60,7 @@ import IOInput
 import Issue200
 import Issue169
 import Issue210
+import ModuleParameters
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -120,4 +121,5 @@ import IOInput
 import Issue200
 import Issue169
 import Issue210
+import ModuleParameters
 #-}

--- a/test/Fail/Issue223.agda
+++ b/test/Fail/Issue223.agda
@@ -1,0 +1,8 @@
+module Fail.Issue223 where
+
+data Void : Set where
+{-# COMPILE AGDA2HS Void #-}
+
+test : {a : Set} → Void → a
+test ()
+{-# COMPILE AGDA2HS test #-}

--- a/test/ModuleParameters.agda
+++ b/test/ModuleParameters.agda
@@ -1,0 +1,33 @@
+open import Haskell.Prelude hiding (a)
+
+module ModuleParameters
+  (@0 name : Set)
+  (p : @0 name → Set) where
+
+data Scope : Set where
+  Empty : Scope
+  Bind  : (@0 x : name) → p x → Scope → Scope
+{-# COMPILE AGDA2HS Scope #-}
+
+unbind : Scope → Scope
+unbind Empty = Empty
+unbind (Bind _ _ s) = s
+{-# COMPILE AGDA2HS unbind #-}
+
+module _ {a : Set} where
+  thing : a → a
+  thing x = y
+    where y : a
+          y = x
+  {-# COMPILE AGDA2HS thing #-}
+
+  stuff : a → Scope → a
+  stuff x Empty = x
+  stuff x (Bind _ _ _) = x
+  {-# COMPILE AGDA2HS stuff #-}
+
+  module _ {b : Set} where
+    more : b → a → Scope → Scope
+    more _ _ Empty = Empty
+    more _ _ (Bind _ _ s) = s
+    {-# COMPILE AGDA2HS more #-}

--- a/test/ModuleParametersImports.agda
+++ b/test/ModuleParametersImports.agda
@@ -1,0 +1,10 @@
+module ModuleParametersImports where
+
+open import Haskell.Prelude
+open import ModuleParameters Bool (λ _ → Nat)
+
+scope : Scope
+scope = unbind (Bind True 3 (Bind False 2 Empty))
+{-# COMPILE AGDA2HS scope #-}
+
+

--- a/test/ScopedTypeVariables.agda
+++ b/test/ScopedTypeVariables.agda
@@ -1,6 +1,6 @@
-module ScopedTypeVariables where
-
 open import Haskell.Prelude
+
+module ScopedTypeVariables (@0 x : Bool) where
 
 -- We can encode explicit `forall` quantification by module parameters in Agda.
 module _ {a : Set} {{_ : Eq a}} where
@@ -19,3 +19,11 @@ module _ {a b : Set} where
       baz : b → b
       baz z = f (f z)
 {-# COMPILE AGDA2HS bar #-}
+
+data D : Set where
+  MakeD : (y : Bool) → @0 x ≡ y → D
+{-# COMPILE AGDA2HS D #-}
+
+mybool : Bool
+mybool = False
+{-# COMPILE AGDA2HS mybool #-}

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -58,4 +58,5 @@ import IOInput
 import Issue200
 import Issue169
 import Issue210
+import ModuleParameters
 

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -59,4 +59,5 @@ import Issue200
 import Issue169
 import Issue210
 import ModuleParameters
+import ModuleParametersImports
 

--- a/test/golden/ErasedRecordParameter.err
+++ b/test/golden/ErasedRecordParameter.err
@@ -1,2 +1,2 @@
 test/Fail/ErasedRecordParameter.agda:4,8-10
-Not supported by agda2hs: erased type variable a
+Cannot use erased variable a

--- a/test/golden/Issue223.err
+++ b/test/golden/Issue223.err
@@ -1,0 +1,2 @@
+test/Fail/Issue223.agda:6,1-5
+Functions defined with absurd patterns exclusively are not supported. Use function `error` from the Haskell.Prelude instead.

--- a/test/golden/ModuleParameters.hs
+++ b/test/golden/ModuleParameters.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+module ModuleParameters where
+
+data Scope p = Empty
+             | Bind p (Scope p)
+
+unbind :: Scope p -> Scope p
+unbind Empty = Empty
+unbind (Bind _ s) = s
+
+thing :: forall p a . a -> a
+thing x = y
+  where
+    y :: a
+    y = x
+
+stuff :: forall p a . a -> Scope p -> a
+stuff x Empty = x
+stuff x (Bind _ _) = x
+
+more :: forall p a b . b -> a -> Scope p -> Scope p
+more _ _ Empty = Empty
+more _ _ (Bind _ s) = s
+

--- a/test/golden/ModuleParametersImports.hs
+++ b/test/golden/ModuleParametersImports.hs
@@ -1,0 +1,11 @@
+module ModuleParametersImports where
+
+import qualified ModuleParameters (Scope(Bind, Empty), unbind)
+import Numeric.Natural (Natural)
+
+scope :: ModuleParameters.Scope Natural
+scope
+  = ModuleParameters.unbind
+      (ModuleParameters.Bind 3
+         (ModuleParameters.Bind 2 ModuleParameters.Empty))
+

--- a/test/golden/ScopedTypeVariables.hs
+++ b/test/golden/ScopedTypeVariables.hs
@@ -13,3 +13,8 @@ bar x y f = baz y
     baz :: b -> b
     baz z = f (f z)
 
+data D = MakeD Bool
+
+mybool :: Bool
+mybool = False
+


### PR DESCRIPTION
Closes #222.

Also fixes #223 by throwing a hard error when a function gets no compiled clauses.

We now only add scoped type variables for definitions in modules that are not top-level, but they still get quantified over the parameters of the top-level module. Could be convenient, could be annoying, remains to be seen which behavior is the one we want.

This PR only officially supports erased parameters, or explicit sort parameters. Some other may be allowed but we don't have special checks I think (yet).