### PR TITLE
Lawful proofs

### DIFF
--- a/lib/Haskell/Law/Applicative/List.agda
+++ b/lib/Haskell/Law/Applicative/List.agda
@@ -22,7 +22,11 @@ private
   compositionList : {a b c : Set} → (u : List (b → c)) (v : List (a → b)) (w : List a)
     → ((((pure _∘_) <*> u) <*> v) <*> w) ≡ (u <*> (v <*> w))
   compositionList [] _  _  = refl
-  compositionList us vs ws = trustMe -- TODO
+  compositionList (u ∷ us) v w
+    rewrite sym $ concatMap-++-distr (map (u ∘_) v) (((pure _∘_) <*> us) <*> v) (λ f → map f w)
+      | sym $ map-<*>-recomp v w u
+      | compositionList us v w
+    = refl 
 
   interchangeList : {a b : Set} → (u : List (a → b)) → (y : a)
     → (u <*> (pure y)) ≡ (pure (_$ y) <*> u)

--- a/lib/Haskell/Law/List.agda
+++ b/lib/Haskell/Law/List.agda
@@ -98,6 +98,14 @@ lengthNat-++ (x ∷ xs) = cong suc (lengthNat-++ xs)
 ∷-not-identity : ∀ x (xs ys : List a) → (x ∷ xs) ++ ys ≡ ys → ⊥
 ∷-not-identity x xs ys eq = []≠∷ x xs (sym $ ++-identity-left-unique (x ∷ xs) (sym eq))
 
+concatMap-++-distr : ∀ (xs ys : List a) (f : a → List b) → 
+  ((concatMap f xs) ++ (concatMap f ys)) ≡ (concatMap f (xs ++ ys))
+concatMap-++-distr [] ys f = refl
+concatMap-++-distr (x ∷ xs) ys f
+  rewrite ++-assoc (f x) (concatMap f xs) (concatMap f ys)
+  | concatMap-++-distr xs ys f
+ = refl
+
 --------------------------------------------------
 -- foldr
 

--- a/lib/Haskell/Law/List.agda
+++ b/lib/Haskell/Law/List.agda
@@ -37,6 +37,12 @@ map-∘ : ∀ (g : b → c) (f : a → b) xs → map (g ∘ f) xs ≡ (map g ∘
 map-∘ g f []       = refl
 map-∘ g f (x ∷ xs) = cong (_ ∷_) (map-∘ g f xs)
 
+map-concatMap : ∀ (f : a → b) (xs : List a) → (map f xs) ≡ concatMap (λ x2 → f x2 ∷ []) xs
+map-concatMap f [] = refl
+map-concatMap f (x ∷ xs) 
+  rewrite map-concatMap f xs
+  = refl
+
 --------------------------------------------------
 -- _++_
 
@@ -125,5 +131,5 @@ foldr-fusion : (h : b → c) {f : a → b → b} {g : a → c → c} (e : b) →
                (∀ x y → h (f x y) ≡ g x (h y)) →
                ∀ (xs : List a) → h (foldr f e xs) ≡ foldr g (h e) xs
 foldr-fusion h {f} {g} e fuse =
-  foldr-universal (h ∘ foldr f e) g (h e) refl
+  foldr-universal (h ∘ foldr f e) g (h e) refl 
                   (λ x xs → fuse x (foldr f e xs))

--- a/lib/Haskell/Law/Monad/List.agda
+++ b/lib/Haskell/Law/Monad/List.agda
@@ -45,4 +45,4 @@ instance
     rewrite rSequence2rBind ma mb 
       | map-id mb 
     = refl
- 
+

--- a/lib/Haskell/Law/Monad/List.agda
+++ b/lib/Haskell/Law/Monad/List.agda
@@ -1,18 +1,31 @@
 module Haskell.Law.Monad.List where
 
 open import Haskell.Prim
+open import Haskell.Prim.Foldable
 open import Haskell.Prim.List
+open import Haskell.Prim.Monoid
 
 open import Haskell.Prim.Monad
 
 open import Haskell.Law.Monad.Def
+open import Haskell.Law.List
 
 open import Haskell.Law.Applicative.List
 open import Haskell.Law.Equality
 
+concatMap-distr : ∀ (xs ys : List a) (f : a → List b ) → 
+  ((concatMap f xs) ++ (concatMap f ys)) ≡ (concatMap f (xs ++ ys))
+concatMap-distr [] ys f = refl
+concatMap-distr (x ∷ xs) ys f
+  rewrite ++-assoc (f x) (concatMap f xs) (concatMap f ys)
+  | concatMap-distr xs ys f
+ = refl
+
 instance
-  iLawfulMonadList : IsLawfulMonad List
-  iLawfulMonadList .leftIdentity a k = trustMe
+  iLawfulMonadList :  IsLawfulMonad List
+  iLawfulMonadList .leftIdentity a k 
+    rewrite ++-[] (k a)
+    = refl
 
   iLawfulMonadList .rightIdentity [] = refl
   iLawfulMonadList .rightIdentity (_ ∷ xs)
@@ -20,13 +33,14 @@ instance
     = refl
 
   iLawfulMonadList .associativity [] f g = refl
-  iLawfulMonadList .associativity (_ ∷ xs) f g
+  iLawfulMonadList .associativity (x ∷ []) f g 
+    rewrite ++-[] (concatMap g (f x))
+     |  ++-[] (f x)
+    = refl
+  iLawfulMonadList .associativity (x ∷ xs) f g
     rewrite associativity xs f g
-    = trustMe
-
-    -- foldMapList g (f x) ++ foldMapList g (foldMapList f xs)
-    -- ≡
-    -- foldMapList g (f x ++ foldMapList f xs)
+    | concatMap-distr (f x) (concatMap f xs) g
+    = refl  
 
   iLawfulMonadList .pureIsReturn _ = refl
 
@@ -41,3 +55,4 @@ instance
 
   iLawfulMonadList .rSequence2rBind [] mb = refl
   iLawfulMonadList .rSequence2rBind (x ∷ ma) mb = trustMe
+ 

--- a/lib/Haskell/Law/Monad/List.agda
+++ b/lib/Haskell/Law/Monad/List.agda
@@ -1,7 +1,6 @@
 module Haskell.Law.Monad.List where
 
 open import Haskell.Prim
-open import Haskell.Prim.Foldable
 open import Haskell.Prim.List
 
 open import Haskell.Prim.Monad
@@ -10,15 +9,6 @@ open import Haskell.Law.Monad.Def
 open import Haskell.Law.List
 
 open import Haskell.Law.Applicative.List
-open import Haskell.Law.Equality
-
-concatMap-distr : ∀ (xs ys : List a) (f : a → List b ) → 
-  ((concatMap f xs) ++ (concatMap f ys)) ≡ (concatMap f (xs ++ ys))
-concatMap-distr [] ys f = refl
-concatMap-distr (x ∷ xs) ys f
-  rewrite ++-assoc (f x) (concatMap f xs) (concatMap f ys)
-  | concatMap-distr xs ys f
- = refl
 
 instance
   iLawfulMonadList :  IsLawfulMonad List
@@ -32,20 +22,18 @@ instance
     = refl
 
   iLawfulMonadList .associativity [] f g = refl
-  iLawfulMonadList .associativity (x ∷ []) f g 
-    rewrite ++-[] (concatMap g (f x))
-     |  ++-[] (f x)
-    = refl
   iLawfulMonadList .associativity (x ∷ xs) f g
     rewrite associativity xs f g
-    | concatMap-++-distr (f x) (concatMap f xs) g
+      | concatMap-++-distr (f x) (xs >>= f) g
     = refl  
 
   iLawfulMonadList .pureIsReturn _ = refl
 
   iLawfulMonadList .sequence2bind [] _ = refl
-  iLawfulMonadList .sequence2bind (_ ∷ _) [] = refl
-  iLawfulMonadList .sequence2bind (f ∷ fs) (x ∷ xs) = trustMe
+  iLawfulMonadList .sequence2bind (f ∷ fs) xs 
+    rewrite sequence2bind fs xs
+      | map-concatMap f xs
+    = refl
 
   iLawfulMonadList .fmap2bind f [] = refl
   iLawfulMonadList .fmap2bind f (_ ∷ xs)
@@ -53,5 +41,8 @@ instance
     = refl
 
   iLawfulMonadList .rSequence2rBind [] mb = refl
-  iLawfulMonadList .rSequence2rBind (x ∷ ma) mb = trustMe
+  iLawfulMonadList .rSequence2rBind (x ∷ ma) mb
+    rewrite rSequence2rBind ma mb 
+      | map-id mb 
+    = refl
  

--- a/lib/Haskell/Law/Monad/List.agda
+++ b/lib/Haskell/Law/Monad/List.agda
@@ -3,7 +3,6 @@ module Haskell.Law.Monad.List where
 open import Haskell.Prim
 open import Haskell.Prim.Foldable
 open import Haskell.Prim.List
-open import Haskell.Prim.Monoid
 
 open import Haskell.Prim.Monad
 
@@ -39,7 +38,7 @@ instance
     = refl
   iLawfulMonadList .associativity (x ∷ xs) f g
     rewrite associativity xs f g
-    | concatMap-distr (f x) (concatMap f xs) g
+    | concatMap-++-distr (f x) (concatMap f xs) g
     = refl  
 
   iLawfulMonadList .pureIsReturn _ = refl

--- a/lib/Haskell/Law/Monoid/List.agda
+++ b/lib/Haskell/Law/Monoid/List.agda
@@ -25,6 +25,9 @@ instance
     = refl
 
   iLawfulMonoidList .concatenation [] = refl
-  iLawfulMonoidList .concatenation (x ∷ xs)
-    rewrite ++-[] x
-    = trustMe -- TODO
+  iLawfulMonoidList .concatenation ([] ∷ xs) = begin
+    mconcat xs              ≡⟨  concatenation xs  ⟩
+    foldr _<>_ [] (xs) ∎
+  iLawfulMonoidList .concatenation ((y ∷ ys) ∷ xs) = begin
+    (y ∷ ys) <> mconcat (xs)             ≡⟨ cong ( (y ∷ ys) <>_) (concatenation xs)⟩
+    (y ∷ ys) <> (foldr _<>_ [] xs) ∎

--- a/lib/Haskell/Law/Monoid/List.agda
+++ b/lib/Haskell/Law/Monoid/List.agda
@@ -1,12 +1,10 @@
 module Haskell.Law.Monoid.List where
 
 open import Haskell.Prim
-open import Haskell.Prim.Foldable
 open import Haskell.Prim.List
 
 open import Haskell.Prim.Monoid
 
-open import Haskell.Law.Equality
 open import Haskell.Law.List
 open import Haskell.Law.Monoid.Def
 open import Haskell.Law.Semigroup.Def

--- a/lib/Haskell/Law/Monoid/List.agda
+++ b/lib/Haskell/Law/Monoid/List.agda
@@ -25,9 +25,7 @@ instance
     = refl
 
   iLawfulMonoidList .concatenation [] = refl
-  iLawfulMonoidList .concatenation ([] ∷ xs) = begin
-    mconcat xs              ≡⟨  concatenation xs  ⟩
-    foldr _<>_ [] (xs) ∎
-  iLawfulMonoidList .concatenation ((y ∷ ys) ∷ xs) = begin
-    (y ∷ ys) <> mconcat (xs)             ≡⟨ cong ( (y ∷ ys) <>_) (concatenation xs)⟩
-    (y ∷ ys) <> (foldr _<>_ [] xs) ∎
+  iLawfulMonoidList .concatenation (x ∷ xs) 
+    rewrite ++-[] (x ∷ xs)
+      | concatenation xs
+    = refl

--- a/lib/Haskell/Law/Monoid/Maybe.agda
+++ b/lib/Haskell/Law/Monoid/Maybe.agda
@@ -17,11 +17,7 @@ instance
 
   iLawfulMonoidMaybe .leftIdentity = λ { Nothing → refl; (Just _) → refl }
 
-  iLawfulMonoidMaybe .concatenation []              = refl
-  iLawfulMonoidMaybe .concatenation (Nothing ∷  xs) = begin
-    mconcat xs              ≡⟨  concatenation xs  ⟩
-    foldr _<>_ Nothing (xs) ∎
-  iLawfulMonoidMaybe .concatenation (Just x ∷ xs)   = begin
-    Just x <> mconcat (xs)             ≡⟨ cong ( Just x <>_) (concatenation xs)⟩
-    Just x <> (foldr _<>_ Nothing xs) ∎
-
+  iLawfulMonoidMaybe .concatenation [] = refl
+  iLawfulMonoidMaybe .concatenation (x ∷ xs) 
+    rewrite (concatenation xs)
+    = refl

--- a/lib/Haskell/Law/Monoid/Maybe.agda
+++ b/lib/Haskell/Law/Monoid/Maybe.agda
@@ -1,12 +1,10 @@
 module Haskell.Law.Monoid.Maybe where
 
 open import Haskell.Prim
-open import Haskell.Prim.Foldable
 open import Haskell.Prim.Maybe
 
 open import Haskell.Prim.Monoid
 
-open import Haskell.Law.Equality
 open import Haskell.Law.Monoid.Def
 open import Haskell.Law.Semigroup.Def
 open import Haskell.Law.Semigroup.Maybe

--- a/lib/Haskell/Law/Monoid/Maybe.agda
+++ b/lib/Haskell/Law/Monoid/Maybe.agda
@@ -1,6 +1,7 @@
 module Haskell.Law.Monoid.Maybe where
 
 open import Haskell.Prim
+open import Haskell.Prim.Foldable
 open import Haskell.Prim.Maybe
 
 open import Haskell.Prim.Monoid
@@ -16,6 +17,11 @@ instance
 
   iLawfulMonoidMaybe .leftIdentity = λ { Nothing → refl; (Just _) → refl }
 
-  iLawfulMonoidMaybe .concatenation [] = refl
-  iLawfulMonoidMaybe .concatenation (x ∷ xs) = trustMe -- TODO
+  iLawfulMonoidMaybe .concatenation []              = refl
+  iLawfulMonoidMaybe .concatenation (Nothing ∷  xs) = begin
+    mconcat xs              ≡⟨  concatenation xs  ⟩
+    foldr _<>_ Nothing (xs) ∎
+  iLawfulMonoidMaybe .concatenation (Just x ∷ xs)   = begin
+    Just x <> mconcat (xs)             ≡⟨ cong ( Just x <>_) (concatenation xs)⟩
+    Just x <> (foldr _<>_ Nothing xs) ∎
 

--- a/lib/Haskell/Prim.agda
+++ b/lib/Haskell/Prim.agda
@@ -99,6 +99,11 @@ data ⊥ : Set where
 magic : {A : Set} → ⊥ → A
 magic ()
 
+--principle of explosion
+exFalso : {x : Bool} → (x ≡ True) → (x ≡ False) → ⊥
+exFalso {False} () b 
+exFalso {True} a ()
+
 -- Use to bundle up constraints
 data All {a b} {A : Set a} (B : A → Set b) : List A → Set (a ⊔ b) where
   instance


### PR DESCRIPTION
Proofs completed:
 - Lawful ordering: `gte2GtEq`, `lte2LtEq', 'gte2nlt', 'lte2ngt'
 - Lawful Monoid: composition instance for `List` and `Maybe`
- added principle of explosion (`exFalso`) in `lib/Haskell/Prim` (not sure if the right file to put it)