### PR TITLE
gitignore agda2hs-mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist
 dist-newstyle
 test/build
 test/agda2hs
+test/agda2hs-mode
 *~
 docs/build/
 test/*.hs


### PR DESCRIPTION
`make test` also installs agda2hs into `test` at this point