### PR TITLE
Bring docs agda version in sync with .cabal file

### DIFF
--- a/docs/source/introduction.md
+++ b/docs/source/introduction.md
@@ -7,7 +7,7 @@
 - [Haskell programming language](https://www.haskell.org)
 - [Haskell Cabal](https://www.haskell.org/cabal/)
 - [Agda programming language](https://github.com/agda/agda)
-  - version >= 2.6.3 && < 2.6.4
+  - version >= 2.6.4 && < 2.6.5
 - [Agda standard library](https://github.com/agda/agda-stdlib)
 - Agda library `agda2hs`
   - this Agda library is include in the `agda2hs` repository; see


### PR DESCRIPTION
Docs say you need 2.6.3, cabal file says you need 2.6.4.

https://github.com/agda/agda2hs/blob/b269164e15da03b74cf43b51c522f4f052b4af80/agda2hs.cabal#L49-L50

(the code above is from v1.2 tag, but github refuses to render it if it's not a permalink)