### PR TITLE
add inlining pragma

### DIFF
--- a/src/Agda2Hs/Compile.hs
+++ b/src/Agda2Hs/Compile.hs
@@ -9,6 +9,7 @@ import qualified Data.Map as M
 import Agda.Compiler.Backend
 import Agda.Syntax.TopLevelModuleName ( TopLevelModuleName )
 import Agda.TypeChecking.Pretty
+import Agda.TypeChecking.Monad.Signature ( isInlineFun )
 import Agda.Utils.Null
 import Agda.Utils.Monad ( whenM )
 
@@ -16,7 +17,7 @@ import qualified Language.Haskell.Exts.Extension as Hs
 
 import Agda2Hs.Compile.ClassInstance ( compileInstance )
 import Agda2Hs.Compile.Data ( compileData )
-import Agda2Hs.Compile.Function ( compileFun, checkTransparentPragma )
+import Agda2Hs.Compile.Function ( compileFun, checkTransparentPragma, checkInlinePragma )
 import Agda2Hs.Compile.Postulate ( compilePostulate )
 import Agda2Hs.Compile.Record ( compileRecord, checkUnboxPragma )
 import Agda2Hs.Compile.Types
@@ -91,6 +92,8 @@ compile opts tlm _ def = withCurrentModule (qnameModule $ defName def) $ runC tl
             tag <$> compileFun True def
           (DefaultPragma ds, _, Record{}) ->
             tag . single <$> compileRecord (ToRecord ds) def
+          (InlinePragma, _, Function{}) -> do
+            checkInlinePragma def >> return []
           _ ->
             genericDocError =<< do
             text "Don't know how to compile" <+> prettyTCM (defName def)

--- a/src/Agda2Hs/Compile/Term.hs
+++ b/src/Agda2Hs/Compile/Term.hs
@@ -300,10 +300,7 @@ compileInlineFunctionApp :: QName -> Elims -> C (Hs.Exp ())
 compileInlineFunctionApp f es = do
   reportSDoc "agda2hs.compile.term" 12 $ text "Compiling application of inline function"
   Function { funClauses = cs } <- theDef <$> getConstInfo f
-  let [ Clause { namedClausePats = pats
-               , clauseBody = Just body
-               , clauseTel
-               } ] = filter (isJust . clauseBody) cs
+  let [ Clause { namedClausePats = pats } ] = filter (isJust . clauseBody) cs
   etaExpand (drop (length es) pats) es >>= compileTerm
   where
     -- inline functions can only have transparent constructor patterns and variable patterns

--- a/src/Agda2Hs/Compile/Type.hs
+++ b/src/Agda2Hs/Compile/Type.hs
@@ -187,10 +187,7 @@ compileInlineType :: QName -> Elims -> C (Hs.Type ())
 compileInlineType f args = do
   Function { funClauses = cs } <- theDef <$> getConstInfo f
 
-  let [ Clause { namedClausePats = pats
-               , clauseBody = Just body
-               , clauseTel
-               } ] = filter (isJust . clauseBody) cs
+  let [ Clause { namedClausePats = pats } ] = filter (isJust . clauseBody) cs
 
   when (length args < length pats) $ genericDocError =<<
     text "Cannot compile inlinable type alias" <+> prettyTCM f <+> text "as it must be fully applied."
@@ -200,7 +197,7 @@ compileInlineType f args = do
 
   case r of
     YesReduction _ t -> compileType t
-    _                -> genericDocError =<< text "Could not reduce inline function" <+> prettyTCM f
+    _                -> genericDocError =<< text "Could not reduce inline type alias " <+> prettyTCM f
 
 compileDom :: ArgName -> Dom Type -> C CompiledDom
 compileDom x a

--- a/src/Agda2Hs/Compile/Utils.hs
+++ b/src/Agda2Hs/Compile/Utils.hs
@@ -191,9 +191,14 @@ isTransparentFunction :: QName -> C Bool
 isTransparentFunction q = do
   getConstInfo q >>= \case
     Defn{defName = r, theDef = Function{}} ->
-      processPragma r <&> \case
-        TransparentPragma -> True
-        _                 -> False
+      (TransparentPragma ==) <$> processPragma r
+    _ -> return False
+
+isInlinedFunction :: QName -> C Bool
+isInlinedFunction q = do
+  getConstInfo q >>= \case
+    Defn{defName = r, theDef = Function{}} ->
+      (InlinePragma ==) <$> processPragma r
     _ -> return False
 
 checkInstance :: Term -> C ()

--- a/src/Agda2Hs/HsUtils.hs
+++ b/src/Agda2Hs/HsUtils.hs
@@ -267,4 +267,4 @@ patToExp = \case
   _                   -> Nothing
 
 data Strictness = Lazy | Strict
-  deriving Show
+  deriving (Eq, Show)

--- a/src/Agda2Hs/Pragma.hs
+++ b/src/Agda2Hs/Pragma.hs
@@ -48,6 +48,7 @@ getForeignPragmas exts = do
 
 data ParsedPragma
   = NoPragma
+  | InlinePragma
   | DefaultPragma [Hs.Deriving ()]
   | ClassPragma [String]
   | ExistingClassPragma
@@ -55,7 +56,7 @@ data ParsedPragma
   | TransparentPragma
   | NewTypePragma [Hs.Deriving ()]
   | DerivePragma (Maybe (Hs.DerivStrategy ()))
-  deriving Show
+  deriving (Eq, Show)
 
 derivePragma :: String
 derivePragma = "derive"
@@ -85,6 +86,7 @@ processPragma qn = liftTCM (getUniqueCompilerPragma pragmaName qn) >>= \case
   Nothing -> return NoPragma
   Just (CompilerPragma _ s)
     | "class" `isPrefixOf` s      -> return $ ClassPragma (words $ drop 5 s)
+    | s == "inline"               -> return InlinePragma
     | s == "existing-class"       -> return ExistingClassPragma
     | s == "unboxed"              -> return $ UnboxPragma Lazy
     | s == "unboxed-strict"       -> return $ UnboxPragma Strict

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -63,6 +63,7 @@ import Issue210
 import ModuleParameters
 import ModuleParametersImports
 import Coerce
+import Inlining
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -126,4 +127,5 @@ import Issue210
 import ModuleParameters
 import ModuleParametersImports
 import Coerce
+import Inlining
 #-}

--- a/test/Fail/Inline.agda
+++ b/test/Fail/Inline.agda
@@ -1,0 +1,8 @@
+module Fail.Inline where
+
+open import Haskell.Prelude
+
+tail' : List a → List a
+tail' (x ∷ xs) = xs
+tail' [] = []
+{-# COMPILE AGDA2HS tail' inline #-}

--- a/test/Fail/Inline2.agda
+++ b/test/Fail/Inline2.agda
@@ -1,0 +1,7 @@
+module Fail.Inline2 where
+
+open import Haskell.Prelude
+
+tail' : (xs : List a) → @0 {{ NonEmpty xs }}  → List a
+tail' (x ∷ xs) = xs
+{-# COMPILE AGDA2HS tail' inline #-}

--- a/test/Inlining.agda
+++ b/test/Inlining.agda
@@ -1,0 +1,35 @@
+module Inlining where
+
+open import Haskell.Prelude
+
+record Wrap (a : Set) : Set where
+  constructor Wrapped
+  field
+    unwrap : a
+open Wrap public
+{-# COMPILE AGDA2HS Wrap unboxed #-}
+
+mapWrap : (f : a → b) → Wrap a → Wrap b
+mapWrap f (Wrapped x) = Wrapped (f x)
+{-# COMPILE AGDA2HS mapWrap inline #-}
+
+mapWrap2 : (f : a → b → c) → Wrap a → Wrap b → Wrap c
+mapWrap2 f (Wrapped x) (Wrapped y) = Wrapped (f x y)
+{-# COMPILE AGDA2HS mapWrap2 inline #-}
+
+test1 : Wrap Int → Wrap Int
+test1 x = mapWrap (1 +_) x
+{-# COMPILE AGDA2HS test1 #-}
+
+test2 : Wrap Int → Wrap Int → Wrap Int
+test2 x y = mapWrap2 _+_ x y
+{-# COMPILE AGDA2HS test2 #-}
+
+-- partial application of inline function
+test3 : Wrap Int → Wrap Int → Wrap Int
+test3 x = mapWrap2 _+_ x
+{-# COMPILE AGDA2HS test3 #-}
+
+test4 : Wrap Int → Wrap Int → Wrap Int
+test4 = mapWrap2 _+_
+{-# COMPILE AGDA2HS test4 #-}

--- a/test/Inlining.agda
+++ b/test/Inlining.agda
@@ -2,6 +2,14 @@ module Inlining where
 
 open import Haskell.Prelude
 
+Alias : Set
+Alias = Bool
+{-# COMPILE AGDA2HS Alias inline #-}
+
+aliased : Alias
+aliased = True
+{-# COMPILE AGDA2HS aliased #-}
+
 record Wrap (a : Set) : Set where
   constructor Wrapped
   field

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -61,4 +61,5 @@ import Issue210
 import ModuleParameters
 import ModuleParametersImports
 import Coerce
+import Inlining
 

--- a/test/golden/Haskell/Extra/Dec.hs
+++ b/test/golden/Haskell/Extra/Dec.hs
@@ -1,4 +1,0 @@
-module Haskell.Extra.Dec where
-
-type Dec = Bool
-

--- a/test/golden/Inline.err
+++ b/test/golden/Inline.err
@@ -1,0 +1,2 @@
+test/Fail/Inline.agda:5,1-6
+Cannot make function tail' inlinable. An inline function must have exactly one clause.

--- a/test/golden/Inline2.err
+++ b/test/golden/Inline2.err
@@ -1,2 +1,2 @@
 test/Fail/Inline2.agda:5,1-6
-Cannot make function tail' inlinable. Inline functions can only use variable patterns, dot patterns, or transparent record constructor patterns.
+Cannot make function tail' inlinable. Inline functions can only use variable patterns or transparent record constructor patterns.

--- a/test/golden/Inline2.err
+++ b/test/golden/Inline2.err
@@ -1,0 +1,2 @@
+test/Fail/Inline2.agda:5,1-6
+Cannot make function tail' inlinable. Inline functions can only use variable patterns, dot patterns, or transparent record constructor patterns.

--- a/test/golden/Inlining.hs
+++ b/test/golden/Inlining.hs
@@ -1,0 +1,14 @@
+module Inlining where
+
+test1 :: Int -> Int
+test1 x = 1 + x
+
+test2 :: Int -> Int -> Int
+test2 x y = x + y
+
+test3 :: Int -> Int -> Int
+test3 x = \ y -> x + y
+
+test4 :: Int -> Int -> Int
+test4 = \ x y -> x + y
+

--- a/test/golden/Inlining.hs
+++ b/test/golden/Inlining.hs
@@ -1,5 +1,8 @@
 module Inlining where
 
+aliased :: Bool
+aliased = True
+
 test1 :: Int -> Int
 test1 x = 1 + x
 


### PR DESCRIPTION
Unboxed records lead to the definition of many functions (on the Agda side) that lift functionality to unboxed records by wrapping and unwrapping accordingly. However, once compiled this overhead disappears and the resulting output could be inlined.

This PR introduces the `{-# COMPILE AGDA2HS name inline #-}` pragma that tells agda2hs to do the inlining automatically. Underapplied inline functions will be eta-expanded so that the substitution still happens.

---

```agda
record Wrap (a : Set) : Set where
  constructor Wrapped
  field
    unwrap : a
open Wrap public
{-# COMPILE AGDA2HS Wrap unboxed #-}

mapWrap : (f : a → b) → Wrap a → Wrap b
mapWrap f (Wrapped x) = Wrapped (f x)
{-# COMPILE AGDA2HS mapWrap inline #-}

mapWrap2 : (f : a → b → c) → Wrap a → Wrap b → Wrap c
mapWrap2 f (Wrapped x) (Wrapped y) = Wrapped (f x y)
{-# COMPILE AGDA2HS mapWrap2 inline #-}

test1 : Wrap Int → Wrap Int
test1 x = mapWrap (1 +_) x
{-# COMPILE AGDA2HS test1 #-}

test2 : Wrap Int → Wrap Int → Wrap Int
test2 x y = mapWrap2 _+_ x y
{-# COMPILE AGDA2HS test2 #-}

-- partial application of inline function
test3 : Wrap Int → Wrap Int → Wrap Int
test3 x = mapWrap2 _+_ x
{-# COMPILE AGDA2HS test3 #-}
```
compiles to:
```haskell
test1 :: Int -> Int
test1 x = 1 + x

test2 :: Int -> Int -> Int
test2 x y = x + y

test3 :: Int -> Int -> Int
test3 x = \ y -> x + y
```

---

Right now the names of the inserted lambdas come from the names given to the patterns in the inlined function. I suspect these could shadow names outside of where the inlined function is being used. Suggestions welcomed for making it more robust.