### PR TITLE
[ fix #257 ] fix recursive record check

### DIFF
--- a/src/Agda2Hs/Compile/Record.hs
+++ b/src/Agda2Hs/Compile/Record.hs
@@ -170,9 +170,12 @@ compileRecord target def = do
 
 checkUnboxPragma :: Defn -> C ()
 checkUnboxPragma def
-  | Record{recFields} <- def
+  | Record{recFields, recMutual} <- def
   , length (filter keepArg recFields) == 1
-  , not (recRecursive def)
+  -- , not (recRecursive def)
+  --     can be used again after agda 2.6.4.2 is released
+  --     see: agda/agda#7042
+  , all null recMutual -- see agda/agda#7042
   = return ()
 
   | otherwise

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -65,6 +65,7 @@ import ModuleParametersImports
 import Coerce
 import Inlining
 import EraseType
+import Issue257
 
 {-# FOREIGN AGDA2HS
 import Issue14

--- a/test/Issue257.agda
+++ b/test/Issue257.agda
@@ -1,0 +1,7 @@
+module Issue257 where
+
+open import Haskell.Prelude
+
+record Wrap : Set where
+  field int : Integer
+{-# COMPILE AGDA2HS Wrap unboxed #-}


### PR DESCRIPTION
#257 was caused by `recRecursive` being incorrectly implemented upstream.
Added a custom check for now, the old one could be put back once/if agda/agda#7042 is merged and the next version is released.