### PR TITLE
[ fix #273 ] Add more parenthesis in arguments of operators and sections

### DIFF
--- a/src/Agda2Hs/Compile/Term.hs
+++ b/src/Agda2Hs/Compile/Term.hs
@@ -286,7 +286,9 @@ compileTerm v = do
         body <- compileTerm body
         return $ case body of
           Hs.InfixApp _ a op b
-            | a == hsx -> Hs.RightSection () op b -- System-inserted visible lambdas can only come from sections
+            | a == hsx
+            , pp op /= "-"             -- Jesper: no right section for minus, as Haskell parses this as negation!
+            -> Hs.RightSection () op b -- System-inserted visible lambdas can only come from sections
           _            -> hsLambda x body         -- so we know x is not free in b.
     Lam v b ->
       -- Drop erased lambdas (#65)

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -68,6 +68,7 @@ import Inlining
 import EraseType
 import Issue257
 import Delay
+import Issue273
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -135,4 +136,5 @@ import Coerce
 import Inlining
 import EraseType
 import Delay
+import Issue273
 #-}

--- a/test/Issue273.agda
+++ b/test/Issue273.agda
@@ -1,0 +1,35 @@
+module Issue273 where
+
+open import Haskell.Prelude
+
+test : Int × Int → Int
+test = λ x → snd $ x
+{-# COMPILE AGDA2HS test #-}
+
+mySnd : Int × Int → Int
+mySnd x = snd x
+{-# COMPILE AGDA2HS mySnd #-}
+
+test2 : Int × Int → Int
+test2 = λ x → mySnd $ x
+{-# COMPILE AGDA2HS test2 #-}
+
+test3 : Int × Int → Int
+test3 = λ x → snd x
+{-# COMPILE AGDA2HS test3 #-}
+
+test4 : Int × Int → Int
+test4 = λ x → mySnd x
+{-# COMPILE AGDA2HS test4 #-}
+
+test5 : Int × Int → Int → Int
+test5 = λ x _ → snd $ x
+{-# COMPILE AGDA2HS test5 #-}
+
+test6 : Int → Int
+test6 = _- (1 + 1)
+{-# COMPILE AGDA2HS test6 #-}
+
+test7 : Int → Int
+test7 = _+ (1 - 1)
+{-# COMPILE AGDA2HS test7 #-}

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -65,4 +65,5 @@ import Coerce
 import Inlining
 import EraseType
 import Delay
+import Issue273
 

--- a/test/golden/Issue273.hs
+++ b/test/golden/Issue273.hs
@@ -1,0 +1,26 @@
+module Issue273 where
+
+test :: (Int, Int) -> Int
+test = ((\ r -> snd r) $)
+
+mySnd :: (Int, Int) -> Int
+mySnd x = snd x
+
+test2 :: (Int, Int) -> Int
+test2 = (mySnd $)
+
+test3 :: (Int, Int) -> Int
+test3 = \ x -> snd x
+
+test4 :: (Int, Int) -> Int
+test4 = mySnd
+
+test5 :: (Int, Int) -> Int -> Int
+test5 = \ x _ -> (\ r -> snd r) $ x
+
+test6 :: Int -> Int
+test6 = \ section -> section - (1 + 1)
+
+test7 :: Int -> Int
+test7 = (+ (1 - 1))
+

--- a/test/golden/Issue273.hs
+++ b/test/golden/Issue273.hs
@@ -19,7 +19,7 @@ test5 :: (Int, Int) -> Int -> Int
 test5 = \ x _ -> (\ r -> snd r) $ x
 
 test6 :: Int -> Int
-test6 = \ section -> section - (1 + 1)
+test6 = ((1 + 1) `subtract`)
 
 test7 :: Int -> Int
 test7 = (+ (1 - 1))


### PR DESCRIPTION
Ideally, our pretty-printing library should insert parenthesis where needed. However, hs-src-exts does not insert adequate parenthesis for infix operators so we need to insert some by hand (see issues #54 and #273).

This also disables the printing of `_- u` as a right section `(- u)` in Haskell, as that would be interpreted as a negation instead.