### PR TITLE
Only compile Agda instances to a Haskell instance if they target a Haskell class

### DIFF
--- a/lib/Haskell/Prim/Enum.agda
+++ b/lib/Haskell/Prim/Enum.agda
@@ -64,19 +64,19 @@ record Enum (a : Set) : Set₁ where
     maxInt ⦃ _ ⦄ = fromEnum maxBound
 
   field
-    toEnum : (n : Int) → ⦃ TrueIfLB (minInt <= n) ⦄ → ⦃ TrueIfUB (n <= maxInt) ⦄ → a
-    succ   : (x : a) → ⦃ FalseIfUB (fromEnum x == maxInt) ⦄ → a
-    pred   : (x : a) → ⦃ FalseIfLB (fromEnum x == minInt) ⦄ → a
+    toEnum : (n : Int) → @0 ⦃ TrueIfLB (minInt <= n) ⦄ → @0 ⦃ TrueIfUB (n <= maxInt) ⦄ → a
+    succ   : (x : a) → @0 ⦃ FalseIfUB (fromEnum x == maxInt) ⦄ → a
+    pred   : (x : a) → @0 ⦃ FalseIfLB (fromEnum x == minInt) ⦄ → a
 
-    enumFrom       : ⦃ IsBoundedAbove ⦄ → a → List a
+    enumFrom       : @0 ⦃ IsBoundedAbove ⦄ → a → List a
     enumFromTo     : a → a → List a
     -- In the Prelude Enum instances `enumFromThenTo x x y` gives the
     -- infinite list of `x`s. The constraint is a little bit stronger than it needs to be,
     -- since it rules out different x and x₁ that maps to the same Int, but this saves us
     -- requiring an Eq instance for `a`, and it's not a terrible limitation to not be able to
     -- write [0, 2^64 .. 2^66].
-    enumFromThenTo : (x x₁ : a) → ⦃ IsFalse (fromEnum x == fromEnum x₁) ⦄ → a → List a
-    enumFromThen   : ⦃ IsBoundedBelow ⦄ → ⦃ IsBoundedAbove ⦄ → (x x₁ : a) → ⦃ IsFalse (fromEnum x == fromEnum x₁) ⦄ → List a
+    enumFromThenTo : (x x₁ : a) → @0 ⦃ IsFalse (fromEnum x == fromEnum x₁) ⦄ → a → List a
+    enumFromThen   : @0 ⦃ IsBoundedBelow ⦄ → @0 ⦃ IsBoundedAbove ⦄ → (x x₁ : a) → @0 ⦃ IsFalse (fromEnum x == fromEnum x₁) ⦄ → List a
 
 open Enum ⦃...⦄ public
 
@@ -104,7 +104,7 @@ private
   integerFromTo : Integer → Integer → List Integer
   integerFromTo a b = maybe [] (integerFromCount a 1 ∘ suc) (diff b a)
 
-  integerFromThenTo : (a a₁ : Integer) → ⦃ IsFalse (integerToInt a == integerToInt a₁) ⦄ → Integer → List Integer
+  integerFromThenTo : (a a₁ : Integer) → @0 ⦃ IsFalse (integerToInt a == integerToInt a₁) ⦄ → Integer → List Integer
   integerFromThenTo a a₁ b =
     case compare a a₁ of λ where
       LT → maybe [] (λ d → integerFromCount a (a₁ - a) (suc (divNat d (unsafeIntegerToNat (a₁ - a))))) (diff b a)
@@ -127,7 +127,7 @@ module _ (from : a → Integer) (to : Integer → a) where
     fromTo : a → a → List a
     fromTo a b = map to (enumFromTo (from a) (from b))
 
-    fromThenTo : (x x₁ : a) → ⦃ IsFalse (fromEnum (from x) == fromEnum (from x₁)) ⦄ → a → List a
+    fromThenTo : (x x₁ : a) → @0 ⦃ IsFalse (fromEnum (from x) == fromEnum (from x₁)) ⦄ → a → List a
     fromThenTo a a₁ b = map to (enumFromThenTo (from a) (from a₁) (from b))
 
   unboundedEnumViaInteger : Enum a

--- a/src/Agda2Hs/Compile.hs
+++ b/src/Agda2Hs/Compile.hs
@@ -15,7 +15,7 @@ import Agda.Syntax.Common.Pretty ( prettyShow )
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Monad.Signature ( isInlineFun )
 import Agda.Utils.Null
-import Agda.Utils.Monad ( whenM )
+import Agda.Utils.Monad ( whenM, anyM )
 
 import qualified Language.Haskell.Exts.Extension as Hs
 
@@ -80,9 +80,7 @@ compile opts tlm _ def =
       reportSDoc "agda2hs.compile" 45 $ text "Pragma:" <+> text (show p)
       reportSDoc "agda2hs.compile" 45 $ text "Compiling definition:" <+> pretty (theDef def)
 
-      isInstance <- case defInstance def of
-        Just cl -> isClassName cl
-        Nothing -> return False
+      isInstance <- anyM (defInstance def) isClassName 
 
       case (p , theDef def) of
         (NoPragma            , _         ) -> return []

--- a/src/Agda2Hs/Compile/Term.hs
+++ b/src/Agda2Hs/Compile/Term.hs
@@ -280,7 +280,7 @@ specialClassFunction3 v f = specialClassFunction $ \case
   es               -> v `eApp` es
 
 fromNat :: ProjCompileRule
-fromNat = specialClassFunction1 (hsVar "fromIntegral") $ \case
+fromNat = specialClassFunction2 (hsVar "fromIntegral") $ \v _ -> case v of
   n@Hs.Lit{} -> n
   v          -> hsVar "fromIntegral" `eApp` [v]
 
@@ -297,7 +297,7 @@ mkEnumFromThenTo :: ProjCompileRule
 mkEnumFromThenTo = specialClassFunction3 (hsVar "enumFromThenTo") $ Hs.EnumFromThenTo ()
 
 fromNeg :: ProjCompileRule
-fromNeg = specialClassFunction1 negFromIntegral $ \case
+fromNeg = specialClassFunction2 negFromIntegral $ \v _ -> case v of
   n@Hs.Lit{} -> Hs.NegApp () n
   v          -> negFromIntegral `eApp` [v]
   where
@@ -306,7 +306,7 @@ fromNeg = specialClassFunction1 negFromIntegral $ \case
     f `o` g = Hs.InfixApp () f (Hs.QVarOp () $ hsUnqualName "_._") g
 
 fromString :: ProjCompileRule
-fromString = specialClassFunction1 (hsVar "fromString") $ \case
+fromString = specialClassFunction2 (hsVar "fromString") $ \v _ -> case v of
   s@Hs.Lit{} -> s
   v          -> hsVar "fromString" `eApp` [v]
 

--- a/src/Agda2Hs/Compile/Term.hs
+++ b/src/Agda2Hs/Compile/Term.hs
@@ -279,6 +279,9 @@ specialClassFunction3 v f = specialClassFunction $ \case
   (a : b : c : es) -> f a b c `eApp` es
   es               -> v `eApp` es
 
+-- Note: currently the second (instance) argument {{_ : Constraint n}}
+-- is compiled and then dropped here, ideally it would not be compiled
+-- at all.
 fromNat :: ProjCompileRule
 fromNat = specialClassFunction2 (hsVar "fromIntegral") $ \v _ -> case v of
   n@Hs.Lit{} -> n
@@ -296,6 +299,7 @@ mkEnumFromThen = specialClassFunction2 (hsVar "enumFromThen") $ Hs.EnumFromThen 
 mkEnumFromThenTo :: ProjCompileRule
 mkEnumFromThenTo = specialClassFunction3 (hsVar "enumFromThenTo") $ Hs.EnumFromThenTo ()
 
+-- Same comment as for fromNat
 fromNeg :: ProjCompileRule
 fromNeg = specialClassFunction2 negFromIntegral $ \v _ -> case v of
   n@Hs.Lit{} -> Hs.NegApp () n
@@ -305,6 +309,7 @@ fromNeg = specialClassFunction2 negFromIntegral $ \v _ -> case v of
     -- TODO: move this to HsUtils
     f `o` g = Hs.InfixApp () f (Hs.QVarOp () $ hsUnqualName "_._") g
 
+-- Same comment as for fromNat
 fromString :: ProjCompileRule
 fromString = specialClassFunction2 (hsVar "fromString") $ \v _ -> case v of
   s@Hs.Lit{} -> s

--- a/src/Agda2Hs/Compile/Utils.hs
+++ b/src/Agda2Hs/Compile/Utils.hs
@@ -177,6 +177,13 @@ isClassName q = getConstInfo' q >>= \case
       _                   -> False
   _                       -> return False
 
+isClassType :: Type -> C Bool
+isClassType a = do
+  TelV _ t <- telView a
+  case unEl t of
+    Def cl _ -> isClassName cl
+    _        -> return False
+
 -- Drops the last (record) module for typeclass methods
 dropClassModule :: ModuleName -> C ModuleName
 dropClassModule m@(MName ns) = isClassModule m >>= \case

--- a/src/Agda2Hs/Compile/Utils.hs
+++ b/src/Agda2Hs/Compile/Utils.hs
@@ -167,6 +167,7 @@ isClassModule m
     minRec <- asks minRecordName
     if Just m == minRec then return True else isClassName (mnameToQName m)
 
+-- | Check if the given name corresponds to a type class in Haskell.
 isClassName :: QName -> C Bool
 isClassName q = getConstInfo' q >>= \case
   Right Defn{defName = r, theDef = Record{}} ->
@@ -177,6 +178,7 @@ isClassName q = getConstInfo' q >>= \case
       _                   -> False
   _                       -> return False
 
+-- | Check if the given type corresponds to a class constraint in Haskell.
 isClassType :: Type -> C Bool
 isClassType a = do
   TelV _ t <- telView a

--- a/src/Agda2Hs/Compile/Utils.hs
+++ b/src/Agda2Hs/Compile/Utils.hs
@@ -165,15 +165,17 @@ isClassModule m
   | null $ mnameToList m = return False
   | otherwise            = do
     minRec <- asks minRecordName
-    getConstInfo' (mnameToQName m) >>= \case
-      _ | Just m == minRec -> return True
-      Right Defn{defName = r, theDef = Record{}} ->
-        -- It would be nicer if we remembered this from when we looked at the record the first time.
-        processPragma r <&> \case
-          ClassPragma _       -> True
-          ExistingClassPragma -> True
-          _                   -> False
-      _                       -> return False
+    if Just m == minRec then return True else isClassName (mnameToQName m)
+
+isClassName :: QName -> C Bool
+isClassName q = getConstInfo' q >>= \case
+  Right Defn{defName = r, theDef = Record{}} ->
+    -- It would be nicer if we remembered this from when we looked at the record the first time.
+    processPragma r <&> \case
+      ClassPragma _       -> True
+      ExistingClassPragma -> True
+      _                   -> False
+  _                       -> return False
 
 -- Drops the last (record) module for typeclass methods
 dropClassModule :: ModuleName -> C ModuleName

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -73,6 +73,8 @@ import TypeDirected
 import ProjLike
 import Issue286
 import NonClassInstance
+import Issue218
+import Issue251
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -145,4 +147,6 @@ import TypeDirected
 import ProjLike
 import Issue286
 import NonClassInstance
+import Issue218
+import Issue251
 #-}

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -72,6 +72,7 @@ import Issue273
 import TypeDirected
 import ProjLike
 import Issue286
+import NonClassInstance
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -143,4 +144,5 @@ import Issue273
 import TypeDirected
 import ProjLike
 import Issue286
+import NonClassInstance
 #-}

--- a/test/Issue218.agda
+++ b/test/Issue218.agda
@@ -1,0 +1,18 @@
+
+module Issue218 where
+
+open import Haskell.Prelude
+open import Haskell.Extra.Erase
+open import Haskell.Extra.Refinement
+
+module _ (@0 n : Int) where
+
+  foo : {{Rezz _ n}} → ∃ Int (_≡ n)
+  foo {{rezz n}} = n ⟨ refl ⟩
+
+  {-# COMPILE AGDA2HS foo #-}
+
+bar : ∃ Int (_≡ 42)
+bar = foo _
+
+{-# COMPILE AGDA2HS bar #-}

--- a/test/Issue251.agda
+++ b/test/Issue251.agda
@@ -1,0 +1,10 @@
+open import Haskell.Prelude
+
+instance
+  favoriteNumber : Int
+  favoriteNumber = 42
+{-# INLINE favoriteNumber #-}
+
+test : {{Int}} → Int
+test {{x}} = x
+{-# COMPILE AGDA2HS test #-}

--- a/test/Issue251.agda
+++ b/test/Issue251.agda
@@ -3,8 +3,12 @@ open import Haskell.Prelude
 instance
   favoriteNumber : Int
   favoriteNumber = 42
-{-# INLINE favoriteNumber #-}
+{-# COMPILE AGDA2HS favoriteNumber inline #-}
 
-test : {{Int}} → Int
-test {{x}} = x
+get : {{Int}} → Int
+get {{x}} = x
+{-# COMPILE AGDA2HS get #-}
+
+test : Int
+test = get
 {-# COMPILE AGDA2HS test #-}

--- a/test/NonClassInstance.agda
+++ b/test/NonClassInstance.agda
@@ -1,0 +1,11 @@
+
+open import Haskell.Prelude
+open import Haskell.Extra.Dec
+open import Haskell.Extra.Refinement
+
+instance
+  iDecIsTrue : {b : Bool} → Dec (IsTrue b)
+  iDecIsTrue {False} = False ⟨ (λ ()) ⟩
+  iDecIsTrue {True}  = True  ⟨ IsTrue.itsTrue ⟩
+
+{-# COMPILE AGDA2HS iDecIsTrue #-}

--- a/test/NonClassInstance.agda
+++ b/test/NonClassInstance.agda
@@ -9,3 +9,13 @@ instance
   iDecIsTrue {True}  = True  ⟨ IsTrue.itsTrue ⟩
 
 {-# COMPILE AGDA2HS iDecIsTrue #-}
+
+foo : (b : Bool) → {{Dec (IsTrue b)}} → Bool
+foo _ {{b ⟨ _ ⟩}} = not b
+
+{-# COMPILE AGDA2HS foo #-}
+
+bar : Bool → Bool
+bar b = foo b
+
+{-# COMPILE AGDA2HS bar #-}

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -70,4 +70,6 @@ import TypeDirected
 import ProjLike
 import Issue286
 import NonClassInstance
+import Issue218
+import Issue251
 

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -69,4 +69,5 @@ import Issue273
 import TypeDirected
 import ProjLike
 import Issue286
+import NonClassInstance
 

--- a/test/golden/Issue218.hs
+++ b/test/golden/Issue218.hs
@@ -1,0 +1,8 @@
+module Issue218 where
+
+foo :: Int -> Int
+foo n = n
+
+bar :: Int
+bar = foo 42
+

--- a/test/golden/Issue251.hs
+++ b/test/golden/Issue251.hs
@@ -1,5 +1,8 @@
 module Issue251 where
 
-test :: Int -> Int
-test x = x
+get :: Int -> Int
+get x = x
+
+test :: Int
+test = get 42
 

--- a/test/golden/Issue251.hs
+++ b/test/golden/Issue251.hs
@@ -1,0 +1,5 @@
+module Issue251 where
+
+test :: Int -> Int
+test x = x
+

--- a/test/golden/NonClassInstance.hs
+++ b/test/golden/NonClassInstance.hs
@@ -4,3 +4,9 @@ iDecIsTrue :: Bool -> Bool
 iDecIsTrue False = False
 iDecIsTrue True = True
 
+foo :: Bool -> Bool -> Bool
+foo _ b = not b
+
+bar :: Bool -> Bool
+bar b = foo b (iDecIsTrue b)
+

--- a/test/golden/NonClassInstance.hs
+++ b/test/golden/NonClassInstance.hs
@@ -1,0 +1,6 @@
+module NonClassInstance where
+
+iDecIsTrue :: Bool -> Bool
+iDecIsTrue False = False
+iDecIsTrue True = True
+


### PR DESCRIPTION
This is a little gift for @jakobn-ai , who asked in https://github.com/agda/agda2hs/pull/270#issuecomment-1948366775 if we could have instances on the Agda side that compile to regular functions in Haskell. I thought this should be easy since we can just check whether a given instance actually targets a type that is compiled to a Haskell class, and it turns out I was right :)