### PR TITLE
Fix #286: drop `int64` and `primWord64FromNat` when applied to literals

### DIFF
--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -71,6 +71,7 @@ import Delay
 import Issue273
 import TypeDirected
 import ProjLike
+import Issue286
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -141,4 +142,5 @@ import Delay
 import Issue273
 import TypeDirected
 import ProjLike
+import Issue286
 #-}

--- a/test/Issue286.agda
+++ b/test/Issue286.agda
@@ -1,0 +1,14 @@
+open import Haskell.Prelude
+
+instance
+  favoriteNumber : Int
+  favoriteNumber = 42
+{-# COMPILE AGDA2HS favoriteNumber inline #-}
+
+get : {{Int}} → Int
+get {{x}} = x
+{-# COMPILE AGDA2HS get inline #-}
+
+test : Int
+test = get
+{-# COMPILE AGDA2HS test #-}

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -68,4 +68,5 @@ import Delay
 import Issue273
 import TypeDirected
 import ProjLike
+import Issue286
 

--- a/test/golden/Issue286.hs
+++ b/test/golden/Issue286.hs
@@ -1,0 +1,5 @@
+module Issue286 where
+
+test :: Int
+test = 42
+


### PR DESCRIPTION
As stated in the title. The reason why these two pop up in the first place is because Agda needlessly reduces terms that are produced by instance search, see https://github.com/agda/agda/issues/7143.