### PR TITLE
CI: generate HTML for Haskell.Prelude lib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]   # macOS-latest, windows-latest
         cabal: ["3.8"]
-        ghc:
-          - "8.8.4"
-          - "8.10.7"
-          - "9.2.5"
-          - "9.4.3"
-          - "9.6.3"
-
+        ghc: [8.8.4, 8.10.7, 9.2.5, 9.4.3, 9.6.3]
     steps:
     - uses: actions/checkout@v3
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
@@ -58,7 +52,18 @@ jobs:
         key:          ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
         restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
 
-    # The actual job.
-    - name: Test
+    - name: Run test suite
       run: make test
+
+    - name: Generate Prelude HTML
+      if: ${{ matrix.ghc == '9.6.3' }}
+      run: make libHtml
+
+    - name: Deploy Prelude HTML
+      if: ${{ matrix.ghc == '9.6.3' }}
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: html
+        destination_dir: lib
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,16 +4,10 @@ name: Docs
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["master", "docs"]
+    branches: [master]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
 
 # Allow one concurrent deployment
 concurrency:
@@ -27,9 +21,6 @@ jobs:
       matrix:
         python-version: ["3.10.8"]
 
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     env:
       DOCS_DIR: docs
       DOCS_BUILD_DIR: docs/build
@@ -50,12 +41,8 @@ jobs:
         run: |
           cd ${{ env.DOCS_DIR }}
           make html
-      - name: Setup Pages
-        uses: actions/configure-pages@v2
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
-        with:
-          path: ${{ env.DOCS_BUILD_HTML_DIR }}
       - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v1
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ${{ env.DOCS_BUILD_HTML_DIR }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,10 @@ test/build
 test/agda2hs
 test/agda2hs-mode
 *~
+html/
 docs/build/
 test/*.hs
 test/Haskell
 *.hi
 *.o
+

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,21 @@
 .PHONY : test install repl agda
 
 install :
-	cabal new-install --overwrite-policy=always
+	cabal install --overwrite-policy=always
 
 agda :
-	cabal new-install Agda --program-suffix=-erased --overwrite-policy=always
+	cabal install Agda --program-suffix=-erased --overwrite-policy=always
 
 repl :
-	cabal new-repl # e.g. `:set args -itest -otest/build test/AllTests.agda ... main ... :r ... main`
+	cabal repl # e.g. `:set args -itest -otest/build test/AllTests.agda ... main ... :r ... main`
 
 test :
-	cabal new-install agda2hs --overwrite-policy=always --installdir=test --install-method=copy
+	cabal install agda2hs --overwrite-policy=always --installdir=test --install-method=copy
 	make -C test
+
+libHtml :
+	cabal run agda2hs -- --html lib/Haskell/Prelude.agda
+	cp html/Haskell.Prelude.html html/index.html
 
 golden :
 	make -C test golden

--- a/docs/source/introduction.md
+++ b/docs/source/introduction.md
@@ -10,8 +10,9 @@
   - version >= 2.6.4 && < 2.6.5
 - [Agda standard library](https://github.com/agda/agda-stdlib)
 - Agda library `agda2hs`
-  - this Agda library is include in the `agda2hs` repository; see
+  - this Agda library is included in the `agda2hs` repository; see
     [`agda2hs.agda-lib`](https://github.com/agda/agda2hs/blob/master/agda2hs.agda-lib)
+  - you can navigate the library in [HTML format](https://agda.github.io/agda2hs/lib/)
 
 ### Installation
 


### PR DESCRIPTION
*ACTION REQUIRED*

Change Github Pages setting `Source` to `Deploy from a branch: gh-pages`.


See deployed instance in a fork: https://omelkonian.github.io/agda2hs/lib/