### PR TITLE
iLawfulEq Double postulate removal

### DIFF
--- a/lib/Haskell/Law/Eq/Def.agda
+++ b/lib/Haskell/Law/Eq/Def.agda
@@ -66,5 +66,3 @@ eqNegation : ⦃ iEq : Eq e ⦄ → ⦃ IsLawfulEq e ⦄
            → ∀ { x y : e } → (x /= y) ≡ not (x == y)
 eqNegation = refl
 
-postulate instance
-  iLawfulEqDouble : IsLawfulEq Double


### PR DESCRIPTION
Because of floating-point error, Doubles/Floats can't, in general, have lawful equality. Therefore, it is proposed to remove the postulate from the library. 