### PR TITLE
Adding mechanism to compile Haskell.Data.* modules to Data.* modules

### DIFF
--- a/src/Agda2Hs/Compile/Name.hs
+++ b/src/Agda2Hs/Compile/Name.hs
@@ -166,7 +166,7 @@ compileQName f
 
     -- Prefix of modules that correspond to similarly named Haskell modules
     -- (e.g. "Haskell.Data.Map" is "Data.Map").
-    hsModules = ["Haskell.Data"]
+    hsModules = ["Haskell.Data", "Haskell.Control"]
 
     -- Determine whether it is a type operator or an "ordinary" operator.
     -- _getSort is not for that; e. g. a data has the same sort as its constructor.


### PR DESCRIPTION
I've opened a separate PR for this. There is now a list of module prefixes which get compiled to corresponding Haskell modules. E.g. `Haskell.Data.Map` becomes `Data.Map`.

Actually, the test files used depend on maps; so I can only add them after they get merged (I'll include them in the Map PR)