### PR TITLE
Adding mechanism for skipping up-to-date files

### DIFF
--- a/src/Agda2Hs/Compile/Utils.hs
+++ b/src/Agda2Hs/Compile/Utils.hs
@@ -14,7 +14,12 @@ import Data.String ( IsString(..) )
 
 import GHC.Stack (HasCallStack)
 
+import qualified Language.Haskell.Exts as Hs
+
+import System.FilePath ( (</>) )
+
 import Agda.Compiler.Backend hiding ( Args )
+import Agda.Compiler.Common ( compileDir )
 
 import Agda.Syntax.Common
 import qualified Agda.Syntax.Concrete.Name as C
@@ -22,6 +27,7 @@ import Agda.Syntax.Internal
 import Agda.Syntax.Position ( noRange )
 import Agda.Syntax.Scope.Base
 import Agda.Syntax.Scope.Monad ( bindVariable, freshConcreteName, isDatatypeModule )
+import Agda.Syntax.TopLevelModuleName
 import Agda.Syntax.Common.Pretty ( prettyShow )
 import qualified Agda.Syntax.Common.Pretty as P
 
@@ -228,6 +234,12 @@ dropClassModule :: ModuleName -> C ModuleName
 dropClassModule m@(MName ns) = isClassModule m >>= \case
   True  -> dropClassModule $ MName $ init ns
   False -> return m
+
+-- Gets the path of the Haskell file to be generated
+moduleFileName :: Options -> TopLevelModuleName -> TCM FilePath
+moduleFileName opts name = do
+  outDir <- compileDir
+  return $ fromMaybe outDir (optOutDir opts) </> moduleNameToFileName name "hs"
 
 isUnboxRecord :: QName -> C (Maybe Strictness)
 isUnboxRecord q = do

--- a/src/Agda2Hs/Render.hs
+++ b/src/Agda2Hs/Render.hs
@@ -9,11 +9,10 @@ import Data.Maybe ( fromMaybe, isNothing )
 import Data.Set ( Set )
 import qualified Data.Set as Set
 
-import System.FilePath ( takeDirectory, (</>) )
+import System.FilePath ( takeDirectory )
 import System.Directory ( createDirectoryIfMissing )
 
 import Agda.Compiler.Backend
-import Agda.Compiler.Common ( compileDir )
 
 import Agda.TypeChecking.Pretty
 import qualified Agda.Syntax.Concrete.Name as C
@@ -26,7 +25,7 @@ import Agda.Utils.Impossible ( __IMPOSSIBLE__ )
 import Agda2Hs.Compile
 import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Imports
-import Agda2Hs.Compile.Utils ( primModules )
+import Agda2Hs.Compile.Utils ( primModules, moduleFileName )
 import qualified Agda2Hs.Language.Haskell as Hs
 import Agda2Hs.Language.Haskell.Utils
   ( extToName, pp, moveToTop, insertParens )
@@ -64,12 +63,6 @@ codeBlocks code = [(r, [uncurry Hs.exactPrint $ moveToTop $ noPragmas mcs]) | (r
         nonempty _                           = True
 
 -- Generating the files -------------------------------------------------------
-
-moduleFileName :: Options -> TopLevelModuleName -> TCM FilePath
-moduleFileName opts name = do
-  outDir <- compileDir
-  return $ fromMaybe outDir (optOutDir opts) </> moduleNameToFileName name "hs"
-
 
 ensureDirectory :: FilePath -> IO ()
 ensureDirectory = createDirectoryIfMissing True . takeDirectory


### PR DESCRIPTION
Now, agda2hs skips every Agda file for which the corresponding Haskell file is newer _than the `.agdai` file_.

For this, I had to replace the `moduleFileName` function from Render.hs and I chose Compile/Utils.hs; is that OK or should we put it into a different module?

I've also tested it for custom `--compile-dir`-s. I don't know whether test files for this feature could be easily implemented in the current framework (although it's true that I have not thought about it much).