### PR TITLE
Type-based compilation of everything + fix for #264

### DIFF
--- a/src/Agda2Hs/AgdaUtils.hs
+++ b/src/Agda2Hs/AgdaUtils.hs
@@ -20,7 +20,9 @@ import Agda.Syntax.TopLevelModuleName
 
 import Agda.TypeChecking.Monad ( topLevelModuleName )
 import Agda.TypeChecking.Pretty
+import Agda.TypeChecking.Sort
 import Agda.TypeChecking.Substitute
+import Agda.TypeChecking.Telescope
 import Agda.TypeChecking.Reduce ( reduceDefCopy )
 
 import Agda.Utils.Either ( isRight )
@@ -136,3 +138,8 @@ isForcedPat = \case
   ProjP{}       -> False
   IApplyP{}     -> False
   DefP{}        -> False
+
+endsInSort :: (PureTCM m, MonadBlock m) => Type -> m Bool
+endsInSort t = do
+  TelV tel b <- telView t
+  addContext tel $ ifIsSort b (\_ -> return True) (return False)

--- a/src/Agda2Hs/Compile.hs
+++ b/src/Agda2Hs/Compile.hs
@@ -34,6 +34,7 @@ initCompileEnv tlm rewrites = CompileEnv
   { currModule        = tlm
   , minRecordName     = Nothing
   , locals            = []
+  , compilingLocal    = False
   , copatternsEnabled = False
   , rewrites          = rewrites
   }

--- a/src/Agda2Hs/Compile.hs
+++ b/src/Agda2Hs/Compile.hs
@@ -35,7 +35,6 @@ initCompileEnv tlm rewrites = CompileEnv
   , minRecordName     = Nothing
   , locals            = []
   , copatternsEnabled = False
-  , checkVar          = False
   , rewrites          = rewrites
   }
 

--- a/src/Agda2Hs/Compile.hs
+++ b/src/Agda2Hs/Compile.hs
@@ -85,7 +85,7 @@ compile opts tlm _ def =
       case (p , theDef def) of
         (NoPragma            , _         ) -> return []
         (ExistingClassPragma , _         ) -> return []
-        (UnboxPragma s       , defn      ) -> [] <$ checkUnboxPragma defn
+        (UnboxPragma s       , Record{}  ) -> [] <$ checkUnboxPragma def
         (TransparentPragma   , Function{}) -> [] <$ checkTransparentPragma def
         (InlinePragma        , Function{}) -> [] <$ checkInlinePragma def
 

--- a/src/Agda2Hs/Compile/ClassInstance.hs
+++ b/src/Agda2Hs/Compile/ClassInstance.hs
@@ -102,6 +102,7 @@ compileInstRule cs ty = case unSpine1 ty of
     DomConstraint hsA ->
       underAbstraction a b (compileInstRule (cs ++ [hsA]) . unEl)
     DomType _ t -> __IMPOSSIBLE__
+    DomForall _ -> __IMPOSSIBLE__
   _ -> __IMPOSSIBLE__
 
 
@@ -218,7 +219,7 @@ compileInstanceClause' curModule ty (p:ps) c
         reportSDoc "agda2hs.compile.instance" 20 $
           text $ "raw projection:" ++ prettyShow (Def n [])
         d <- chaseDef n
-        fc <- compileFun False d
+        fc <- compileLocal $ compileFun False d
         let hd = hsName $ prettyShow $ nameConcrete $ qnameName $ defName d
         let fc' = {- dropPatterns 1 $ -} replaceName hd uf fc
         return (map (Hs.InsDecl ()) fc', [n])

--- a/src/Agda2Hs/Compile/ClassInstance.hs
+++ b/src/Agda2Hs/Compile/ClassInstance.hs
@@ -84,7 +84,8 @@ compileInstance ToDefinition def@Defn{..} =
 compileInstRule :: [Hs.Asst ()] -> Term -> C (Hs.InstRule ())
 compileInstRule cs ty = case unSpine1 ty of
   Def f es | Just args <- allApplyElims es -> do
-    vs <- mapM (compileType . unArg) $ filter keepArg args
+    fty <- defType <$> getConstInfo f
+    vs <- compileTypeArgs fty args
     f <- compileQName f
     return $
       Hs.IRule () Nothing (ctx cs) $ foldl (Hs.IHApp ()) (Hs.IHCon () f) (map pars vs)

--- a/src/Agda2Hs/Compile/ClassInstance.hs
+++ b/src/Agda2Hs/Compile/ClassInstance.hs
@@ -165,7 +165,11 @@ compileInstanceClause' curModule ty (p:ps) c
 
     -- retrieve the type of the projection
     Just (unEl -> Pi a b) <- getDefType q ty
-    let ty' = absBody b
+    -- We don't really have the information available to reconstruct the instance
+    -- head. However, all dependencies on the instance head are in erased positions, 
+    -- so we can just use a dummy term instead
+    let instanceHead = __DUMMY_TERM__ 
+        ty' = b `absApp` instanceHead
 
     reportSDoc "agda2hs.compile.instance" 15 $
       text "Compiling instance clause for" <+> prettyTCM (Arg arg $ Def q [])

--- a/src/Agda2Hs/Compile/Data.hs
+++ b/src/Agda2Hs/Compile/Data.hs
@@ -52,6 +52,7 @@ compileData newtyp ds def = do
         DomDropped      -> allIndicesErased (unAbs t)
         DomType{}       -> genericDocError =<< text "Not supported: indexed datatypes"
         DomConstraint{} -> genericDocError =<< text "Not supported: constraints in types"
+        DomForall{}     -> genericDocError =<< text "Not supported: indexed datatypes"
       _ -> return ()
 
 compileConstructor :: [Arg Term] -> QName -> C (Hs.QualConDecl ())
@@ -74,3 +75,4 @@ compileConstructorArgs (ExtendTel a tel) = compileDomType (absName tel) a >>= \c
     (ty :) <$> underAbstraction a tel compileConstructorArgs
   DomConstraint hsA -> genericDocError =<< text "Not supported: constructors with class constraints"
   DomDropped        -> underAbstraction a tel compileConstructorArgs
+  DomForall{}       -> __IMPOSSIBLE__

--- a/src/Agda2Hs/Compile/Data.hs
+++ b/src/Agda2Hs/Compile/Data.hs
@@ -55,7 +55,7 @@ compileData newtyp ds def = do
       _ -> return ()
 
 compileConstructor :: [Arg Term] -> QName -> C (Hs.QualConDecl ())
-compileConstructor params c = checkingVars $ do
+compileConstructor params c = do
   reportSDoc "agda2hs.data.con" 15 $ text "compileConstructor" <+> prettyTCM c
   reportSDoc "agda2hs.data.con" 20 $ text "  params = " <+> prettyTCM params
   ty <- (`piApplyM` params) . defType =<< getConstInfo c

--- a/src/Agda2Hs/Compile/Function.hs
+++ b/src/Agda2Hs/Compile/Function.hs
@@ -157,9 +157,6 @@ compileFun' withSig def@Defn{..} = do
     m = qnameModule defName
     n = qnameName defName
     x = hsName $ prettyShow n
-    endsInSort t = do
-      TelV tel b <- telView t
-      addContext tel $ ifIsSort b (\_ -> return True) (return False)
     err = "Not supported: type definition with `where` clauses"
 
 

--- a/src/Agda2Hs/Compile/Function.hs
+++ b/src/Agda2Hs/Compile/Function.hs
@@ -216,16 +216,15 @@ compileClause' curModule projName x ty c@Clause{..} = do
           _                         -> Hs.Match () x ps rhs whereBinds
     return $ Just match
 
-  where
-    keepClause :: Clause -> C Bool
-    keepClause c@Clause{..} = case (clauseBody, clauseType) of
-      (Nothing, _) -> pure False
-      (_, Nothing) -> pure False
-      (Just body, Just cty) -> compileDom (domFromArg cty) >>= \case
-        DODropped  -> pure False
-        DOInstance -> pure False -- not __IMPOSSIBLE__ because of current hacky implementation of `compileInstanceClause`
-        DOType     -> __IMPOSSIBLE__
-        DOTerm     -> pure True
+keepClause :: Clause -> C Bool
+keepClause c@Clause{..} = case (clauseBody, clauseType) of
+  (Nothing, _) -> pure False
+  (_, Nothing) -> pure False
+  (Just body, Just cty) -> compileDom (domFromArg cty) >>= \case
+    DODropped  -> pure False
+    DOInstance -> pure False -- not __IMPOSSIBLE__ because of current hacky implementation of `compileInstanceClause`
+    DOType     -> __IMPOSSIBLE__
+    DOTerm     -> pure True
 
 
 -- TODO(flupe): projection-like definitions are missing the first (variable) patterns

--- a/src/Agda2Hs/Compile/Function.hs
+++ b/src/Agda2Hs/Compile/Function.hs
@@ -213,7 +213,7 @@ compileClause' curModule projName x ty c@Clause{..} = do
 
     let rhs = Hs.UnGuardedRhs () hsBody
         whereBinds | null whereDecls = Nothing
-                  | otherwise       = Just $ Hs.BDecls () (concat whereDecls)
+                   | otherwise       = Just $ Hs.BDecls () (concat whereDecls)
         match = case (x, ps) of
           (Hs.Symbol{}, p : q : ps) -> Hs.InfixMatch () p x (q : ps) rhs whereBinds
           _                         -> Hs.Match () x ps rhs whereBinds
@@ -223,11 +223,11 @@ keepClause :: Clause -> C Bool
 keepClause c@Clause{..} = case (clauseBody, clauseType) of
   (Nothing, _) -> pure False
   (_, Nothing) -> pure False
-  (Just body, Just cty) -> compileDom (domFromArg cty) >>= \case
-    DODropped  -> pure False
-    DOInstance -> pure False -- not __IMPOSSIBLE__ because of current hacky implementation of `compileInstanceClause`
+  (Just body, Just cty) -> compileDom (domFromArg cty) <&> \case
+    DODropped  -> False
+    DOInstance -> False -- not __IMPOSSIBLE__ because of current hacky implementation of `compileInstanceClause`
     DOType     -> __IMPOSSIBLE__
-    DOTerm     -> pure True
+    DOTerm     -> True
 
 
 -- TODO(flupe): projection-like definitions are missing the first (variable) patterns

--- a/src/Agda2Hs/Compile/Function.hs
+++ b/src/Agda2Hs/Compile/Function.hs
@@ -238,11 +238,12 @@ compilePats ty ((namedArg -> pat):ps) = do
   (a, b) <- mustBePi ty
   reportSDoc "agda2hs.compile.pattern" 10 $ text "Compiling pattern:" <+> prettyTCM pat
   let rest = compilePats (absApp b (patternToTerm pat)) ps
+  when (usableDom a) checkForced
   compileDom a >>= \case
     DOInstance -> rest
-    DODropped  -> rest <* when (usableDom a) checkForced
-    DOKept     -> do
-      checkForced
+    DODropped  -> rest
+    DOType     -> rest
+    DOTerm     -> do
       checkNoAsPatterns pat
       (:) <$> compilePat (unDom a) pat <*> rest
   where checkForced  = when (isForcedPat pat) $ genericDocError =<< "not supported by agda2hs: forced (dot) patterns in non-erased positions"

--- a/src/Agda2Hs/Compile/Record.hs
+++ b/src/Agda2Hs/Compile/Record.hs
@@ -48,7 +48,7 @@ compileMinRecord fieldNames m = do
   -- We can't simply compileFun here for two reasons:
   -- * it has an explicit dictionary argument
   -- * it's using the fields and definitions from the minimal record and not the parent record
-  compiled <- withMinRecord m $ addContext (defaultDom rtype) $
+  compiled <- withMinRecord m $ addContext (defaultDom rtype) $ compileLocal $
     fmap concat $ traverse (compileFun False) defaults
   let declMap = Map.fromList [ (definedName c, def) | def@(Hs.FunBind _ (c : _)) <- compiled ]
   return (definedFields, declMap)
@@ -154,6 +154,7 @@ compileRecord target def = do
             ToRecord{} -> genericError $
               "Not supported: record/class with constraint fields"
           DomDropped -> return (hsAssts , hsFields)
+          DomForall{} -> __IMPOSSIBLE__
       (_, _) -> __IMPOSSIBLE__
 
     compileDataRecord

--- a/src/Agda2Hs/Compile/Record.hs
+++ b/src/Agda2Hs/Compile/Record.hs
@@ -93,7 +93,7 @@ compileMinRecords def sls = do
 compileRecord :: RecordTarget -> Definition -> C (Hs.Decl ())
 compileRecord target def = do
   TelV tel _ <- telViewUpTo recPars (defType def)
-  addContext tel $ checkingVars $ do
+  addContext tel $ do
     checkValidTypeName rName
     binds <- compileTeleBinds tel
     let hd = foldl (Hs.DHApp ()) (Hs.DHead () rName) binds

--- a/src/Agda2Hs/Compile/Term.hs
+++ b/src/Agda2Hs/Compile/Term.hs
@@ -523,7 +523,8 @@ compileArgs ty (x:xs) = do
   compileDom a >>= \case
     DODropped  -> rest
     DOInstance -> checkInstance x *> rest
-    DOKept     -> (:) <$> compileTerm (unDom a) x
+    DOType     -> rest
+    DOTerm     -> (:) <$> compileTerm (unDom a) x
                       <*> rest
 
 clauseToAlt :: Hs.Match () -> C (Hs.Alt ())

--- a/src/Agda2Hs/Compile/Term.hs
+++ b/src/Agda2Hs/Compile/Term.hs
@@ -125,7 +125,6 @@ primWord64FromNat ty args = compileArgs ty args >>= \case
   _ -> genericError "primWord64FromNat must be applied to a literal"
 
 
--- should really be named compileVar, TODO: rename compileVar
 compileVar :: Int -> Type -> [Term] -> C (Hs.Exp ())
 compileVar i ty es = do
   reportSDoc "agda2hs.compile.term" 15 $ text "Reached variable"
@@ -145,7 +144,6 @@ compileSpined c tm ty (e@(Proj o q):es) = do
   let t = tm []
   ty' <- shouldBeProjectible t ty o q
   compileSpined (compileProj q ty t ty') (tm . (e:)) ty' es
--- TODO: use mustBePi
 compileSpined c tm ty (e@(Apply (unArg -> x)):es) = do
   (a, b) <- mustBePi ty
   compileSpined (c . (x:)) (tm . (e:)) (absApp b x) es

--- a/src/Agda2Hs/Compile/Term.hs
+++ b/src/Agda2Hs/Compile/Term.hs
@@ -62,7 +62,7 @@ isSpecialDef q = case prettyShow q of
 
 -- | Compile a @\where@ to the equivalent @\case@ expression.
 lambdaCase :: QName -> DefCompileRule
-lambdaCase q ty args = setCurrentRangeQ q $ do
+lambdaCase q ty args = compileLocal $ setCurrentRangeQ q $ do
   Function
     { funClauses = cls
     , funExtLam  = Just ExtLamInfo {extLamModule = mname}

--- a/src/Agda2Hs/Compile/Type.hs
+++ b/src/Agda2Hs/Compile/Type.hs
@@ -173,8 +173,8 @@ compileType t = do
 
     Sort s -> return (Hs.TyStar ())
 
-    Lam argInfo restAbs
-      | not (keepArg argInfo) -> underAbstraction_ restAbs compileType
+    -- This case is only reachable for erased lambdas
+    Lam argInfo restAbs -> underAbstraction_ restAbs compileType
 
     _ -> fail
   where fail = genericDocError =<< text "Bad Haskell type:" <?> prettyTCM t

--- a/src/Agda2Hs/Compile/Type.hs
+++ b/src/Agda2Hs/Compile/Type.hs
@@ -270,7 +270,6 @@ compileTeleBinds (ExtendTel a tel) = do
   compileDom a >>= \case
     DODropped  -> underAbstraction a tel compileTeleBinds
     DOType -> do
-      unless (visible a) $ fail "Hidden type parameter not supported"
       ha <- compileKeptTeleBind (hsName $ absName tel) (unDom a)
       (ha:) <$> underAbstraction a tel compileTeleBinds
     DOInstance -> fail "Constraint in type parameter not supported"

--- a/src/Agda2Hs/Compile/Type.hs
+++ b/src/Agda2Hs/Compile/Type.hs
@@ -4,7 +4,7 @@
 module Agda2Hs.Compile.Type where
 
 import Control.Arrow ( (>>>) )
-import Control.Monad ( forM, when )
+import Control.Monad ( forM, when, unless )
 import Control.Monad.Trans ( lift )
 import Control.Monad.Reader ( asks )
 import Data.List ( find )
@@ -163,6 +163,10 @@ compileType t = do
          | otherwise -> fail
 
     Var x es | Just args <- allApplyElims es -> do
+      xi <- lookupBV x
+      unless (usableModality xi) $ genericDocError
+        =<< text "Cannot use erased variable" <+> prettyTCM (var x)
+        <+> text "in Haskell type"
       vs <- compileTypeArgs args
       x  <- hsName <$> compileDBVar x
       return $ tApp (Hs.TyVar () x) vs

--- a/src/Agda2Hs/Compile/Type.hs
+++ b/src/Agda2Hs/Compile/Type.hs
@@ -125,8 +125,12 @@ compileType t = do
 
     Sort s -> return (Hs.TyStar ())
 
-    -- This case is only reachable for erased lambdas
-    Lam argInfo restAbs -> underAbstraction_ restAbs compileType
+    -- TODO: we should also drop lambdas that can be erased based on their type
+    -- (e.g. argument is of type Level/Size or in a Prop) but currently we do
+    -- not have access to the type of the lambda here.
+    Lam argInfo restAbs 
+      | hasQuantity0 argInfo -> underAbstraction_ restAbs compileType
+      | otherwise -> genericDocError =<< text "Not supported: type-level lambda" <+> prettyTCM t
 
     _ -> fail
   where fail = genericDocError =<< text "Bad Haskell type:" <?> prettyTCM t

--- a/src/Agda2Hs/Compile/Types.hs
+++ b/src/Agda2Hs/Compile/Types.hs
@@ -82,8 +82,6 @@ data CompileEnv = CompileEnv
   -- ^ keeps track of the current clause's where declarations
   , copatternsEnabled :: Bool
   -- ^ whether copatterns should be allowed when compiling patterns
-  , checkVar :: Bool
-  -- ^ whether to ensure compiled variables are usable and visible
   , rewrites :: SpecialRules
   -- ^ Special compilation rules.
   }

--- a/src/Agda2Hs/Compile/Types.hs
+++ b/src/Agda2Hs/Compile/Types.hs
@@ -80,6 +80,8 @@ data CompileEnv = CompileEnv
   -- ^ keeps track of the current minimal record we are compiling
   , locals :: LocalDecls
   -- ^ keeps track of the current clause's where declarations
+  , compilingLocal :: Bool
+  -- ^ whether we are currently compiling a where clause or pattern-matching lambda
   , copatternsEnabled :: Bool
   -- ^ whether copatterns should be allowed when compiling patterns
   , rewrites :: SpecialRules
@@ -181,6 +183,8 @@ data CompiledDom
     -- ^ To a Haskell type (with perhaps a strictness annotation)
   | DomConstraint (Hs.Asst ())
     -- ^ To a typeclass constraint
+  | DomForall (Hs.TyVarBind ())
+    -- ^ To an explicit forall
   | DomDropped
     -- ^ To nothing (e.g. erased proofs)
 

--- a/src/Agda2Hs/Compile/Utils.hs
+++ b/src/Agda2Hs/Compile/Utils.hs
@@ -180,19 +180,6 @@ dropClassModule m@(MName ns) = isClassModule m >>= \case
   True  -> dropClassModule $ MName $ init ns
   False -> return m
 
-moduleParametersToDrop :: ModuleName -> C Telescope
-moduleParametersToDrop mod = do
-   reportSDoc "agda2hs.moduleParameters" 25 $ text "Getting telescope for" <+> prettyTCM mod
-   isDatatypeModule mod >>= \case
-     Just _ -> return EmptyTel
-     Nothing -> do
-       reportSDoc "agda2hs.moduleParameters" 25 $ text "Current context: " <+> (prettyTCM =<< getContext)
-       ctxArgs <- getContextArgs
-       reportSDoc "agda2hs.moduleParameters" 25 $ text "Context arguments: " <+> prettyTCM ctxArgs
-       sec <- lookupSection mod
-       reportSDoc "agda2hs.moduleParameters" 25 $ text "Module section: " <+> prettyTCM sec
-       return $ sec `apply` ctxArgs
-
 isUnboxRecord :: QName -> C (Maybe Strictness)
 isUnboxRecord q = do
   getConstInfo q >>= \case
@@ -251,6 +238,9 @@ checkInstance u@(Con c _ _)
     prettyShow (conName c) == "Haskell.Prim.IsTrue.itsTrue" ||
     prettyShow (conName c) == "Haskell.Prim.IsFalse.itsFalse" = return ()
 checkInstance u = genericDocError =<< text "illegal instance: " <+> prettyTCM u
+
+compileLocal :: C a -> C a
+compileLocal = local $ \e -> e { compilingLocal = True }
 
 modifyLCase :: (Int -> Int) -> CompileState -> CompileState
 modifyLCase f (CompileState {lcaseUsed = n}) = CompileState {lcaseUsed = f n}

--- a/src/Agda2Hs/Compile/Utils.hs
+++ b/src/Agda2Hs/Compile/Utils.hs
@@ -126,13 +126,6 @@ underAbstr = underAbstraction' KeepNames
 underAbstr_ :: Subst a => Abs a -> (a -> C b) -> C b
 underAbstr_ = underAbstr __DUMMY_DOM__
 
--- | Determine whether an argument should be kept or dropped.
--- We drop all arguments that have quantity 0 (= run-time erased).
--- We also drop hidden non-erased arguments (which should all be of
--- type Level or Set l).
-keepArg :: (LensHiding a, LensModality a) => a -> Bool
-keepArg x = usableModality x && visible x
-
 isPropSort :: Sort -> C Bool
 isPropSort s = reduce s <&> \case
   Prop _ -> True

--- a/src/Agda2Hs/Compile/Utils.hs
+++ b/src/Agda2Hs/Compile/Utils.hs
@@ -151,7 +151,6 @@ canErase a = do
   addContext tel $ orM
     [ isLevelType b                       -- Level
     , isJust <$> isSizeType b             -- Size
-    , isJust . isSort <$> reduce (unEl b) -- Set
     , isPropSort (getSort b)              -- _ : Prop
     ]
 

--- a/src/Agda2Hs/Compile/Utils.hs
+++ b/src/Agda2Hs/Compile/Utils.hs
@@ -133,10 +133,6 @@ underAbstr_ = underAbstr __DUMMY_DOM__
 keepArg :: (LensHiding a, LensModality a) => a -> Bool
 keepArg x = usableModality x && visible x
 
-
-keepClause :: Clause -> Bool
-keepClause = any keepArg . clauseType
-
 isPropSort :: Sort -> C Bool
 isPropSort s = reduce s <&> \case
   Prop _ -> True

--- a/src/Agda2Hs/Compile/Utils.hs
+++ b/src/Agda2Hs/Compile/Utils.hs
@@ -320,9 +320,6 @@ checkNewtypeCon :: Hs.Name () -> [b] -> C ()
 checkNewtypeCon name tys =
   checkSingleElement name tys "Newtype must have exactly one field in constructor"
 
-checkingVars :: C a -> C a
-checkingVars = local $ \e -> e { checkVar = True }
-
 checkFixityLevel :: QName -> FixityLevel -> C (Maybe Int)
 checkFixityLevel name Unrelated = pure Nothing
 checkFixityLevel name (Related lvl) =

--- a/src/Agda2Hs/Compile/Var.hs
+++ b/src/Agda2Hs/Compile/Var.hs
@@ -15,15 +15,8 @@ import Agda.TypeChecking.Monad.Context ( lookupBV )
 import Agda.Utils.Monad ( whenM )
 
 
--- | Compile a variable. 
--- If the variable check is enabled, ensure that the variable is usable and visible.
+-- | Compile a variable.
 compileDBVar :: Nat -> C String
 compileDBVar x = do
   (d, n) <- (fmap snd &&& fst . unDom) <$> lookupBV x
-  let cn = prettyShow $ nameConcrete n
-  let b | notVisible d   = "hidden"
-        | hasQuantity0 d = "erased"
-        | otherwise      = ""
-  whenM (asks checkVar) $ unless (null b) $ genericDocError =<<
-    text ("Cannot use " <> b <> " variable " <> cn)
-  return cn
+  return $ prettyShow $ nameConcrete n

--- a/src/Agda2Hs/HsUtils.hs
+++ b/src/Agda2Hs/HsUtils.hs
@@ -297,12 +297,10 @@ constrainType c = \case
 
 -- | Add explicit quantification over a variable to a Haskell type.
 qualifyType
-  :: String  -- ^ Name of the variable.
+  :: TyVarBind ()  -- ^ Name of the variable.
   -> Type () -- ^ Type to quantify.
   -> Type ()
-qualifyType s = \case
+qualifyType a = \case
     TyForall _ (Just as) cs t -> TyForall () (Just (a:as)) cs      t
     TyForall _ Nothing   cs t -> TyForall () (Just [a]   ) cs      t
     t                         -> TyForall () (Just [a]   ) Nothing t
-  where
-    a = UnkindedVar () $ Ident () s

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -77,6 +77,7 @@ import Issue218
 import Issue251
 import TypeBasedUnboxing
 import Issue145
+import Issue264
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -153,4 +154,5 @@ import Issue218
 import Issue251
 import TypeBasedUnboxing
 import Issue145
+import Issue264
 #-}

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -78,6 +78,7 @@ import Issue251
 import TypeBasedUnboxing
 import Issue145
 import Issue264
+import Issue301
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -155,4 +156,5 @@ import Issue251
 import TypeBasedUnboxing
 import Issue145
 import Issue264
+import Issue301
 #-}

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -75,6 +75,7 @@ import Issue286
 import NonClassInstance
 import Issue218
 import Issue251
+import TypeBasedUnboxing
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -149,4 +150,5 @@ import Issue286
 import NonClassInstance
 import Issue218
 import Issue251
+import TypeBasedUnboxing
 #-}

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -76,6 +76,7 @@ import NonClassInstance
 import Issue218
 import Issue251
 import TypeBasedUnboxing
+import Issue145
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -151,4 +152,5 @@ import NonClassInstance
 import Issue218
 import Issue251
 import TypeBasedUnboxing
+import Issue145
 #-}

--- a/test/Fail/TypeLambda.agda
+++ b/test/Fail/TypeLambda.agda
@@ -1,0 +1,9 @@
+
+module Fail.TypeLambda where
+
+open import Haskell.Prelude
+
+foo : (f : (Set → Set) → Set) (x : f (λ y → Nat)) (y : f List) → Nat
+foo f x y = 42
+
+{-# COMPILE AGDA2HS foo #-}

--- a/test/Issue145.agda
+++ b/test/Issue145.agda
@@ -1,4 +1,4 @@
-module Fail.Issue145 where
+module Issue145 where
 
 open import Haskell.Prelude
 open import Haskell.Prim.Strict

--- a/test/Issue264.agda
+++ b/test/Issue264.agda
@@ -1,0 +1,15 @@
+
+module Issue264 (@0 name : Set) where
+
+data Term : @0 Set → Set where
+  Dummy : Term name
+
+{-# COMPILE AGDA2HS Term #-}
+
+reduce : Term name → Term name
+reduce v = go v
+  where
+    go : Term name → Term name
+    go v = v
+
+{-# COMPILE AGDA2HS reduce #-}

--- a/test/Issue301.agda
+++ b/test/Issue301.agda
@@ -1,0 +1,36 @@
+
+open import Haskell.Prelude
+open import Haskell.Prim.Monoid
+open import Haskell.Prim.Foldable
+
+data MyData (a : Set) : Set where
+  Nuttin' : MyData a
+{-# COMPILE AGDA2HS MyData #-}
+
+-- notice this does not occur with other classes such as Foldable
+myDataDefaultFoldable : DefaultFoldable MyData
+DefaultFoldable.foldMap myDataDefaultFoldable _ _ = mempty
+
+instance
+  MyDataFoldable : Foldable MyData
+  MyDataFoldable = record {DefaultFoldable myDataDefaultFoldable}
+{-# COMPILE AGDA2HS MyDataFoldable #-}
+
+-- need to create instance for semigroup first
+-- (requires explicitly typed function AFAICT)
+_><_ : {a : Set} -> MyData a -> MyData a -> MyData a
+_ >< _ = Nuttin'
+{-# COMPILE AGDA2HS _><_ #-}
+
+instance
+  MyDataSemigroup : Semigroup (MyData a)
+  MyDataSemigroup ._<>_ = _><_
+{-# COMPILE AGDA2HS MyDataSemigroup #-}
+
+myDataDefaultMonoid : DefaultMonoid (MyData a)
+DefaultMonoid.mempty myDataDefaultMonoid = Nuttin'
+
+instance
+  MyDataMonoid : Monoid (MyData a)
+  MyDataMonoid = record {DefaultMonoid myDataDefaultMonoid}
+{-# COMPILE AGDA2HS MyDataMonoid #-}

--- a/test/TypeBasedUnboxing.agda
+++ b/test/TypeBasedUnboxing.agda
@@ -1,0 +1,23 @@
+{-# OPTIONS --prop --sized-types #-}
+
+open import Agda.Primitive
+open import Agda.Builtin.Size
+open import Haskell.Prelude
+
+data P : Prop where
+
+record R : Set where
+  field
+    @0 anErasedThing : Bool
+    aRealThing : Int
+    aLevel : Level
+    aProp : P
+    aSize : Size
+open R public
+
+{-# COMPILE AGDA2HS R unboxed #-}
+
+foo : R → Int
+foo = aRealThing
+
+{-# COMPILE AGDA2HS foo #-}

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -72,4 +72,5 @@ import Issue286
 import NonClassInstance
 import Issue218
 import Issue251
+import TypeBasedUnboxing
 

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -74,4 +74,5 @@ import Issue218
 import Issue251
 import TypeBasedUnboxing
 import Issue145
+import Issue264
 

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -75,4 +75,5 @@ import Issue251
 import TypeBasedUnboxing
 import Issue145
 import Issue264
+import Issue301
 

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -73,4 +73,5 @@ import NonClassInstance
 import Issue218
 import Issue251
 import TypeBasedUnboxing
+import Issue145
 

--- a/test/golden/ErasedRecordParameter.err
+++ b/test/golden/ErasedRecordParameter.err
@@ -1,2 +1,2 @@
 test/Fail/ErasedRecordParameter.agda:4,8-10
-Cannot use erased variable a
+Cannot use erased variable a in Haskell type

--- a/test/golden/Issue113a.err
+++ b/test/golden/Issue113a.err
@@ -1,3 +1,2 @@
 test/Fail/Issue113a.agda:5,8-12
-An unboxed type must be a non-recursive record type with exactly
-one non-erased field.
+Unboxed record Loop cannot be recursive

--- a/test/golden/Issue113b.err
+++ b/test/golden/Issue113b.err
@@ -1,3 +1,2 @@
 test/Fail/Issue113b.agda:7,8-12
-An unboxed type must be a non-recursive record type with exactly
-one non-erased field.
+Unboxed record Loop cannot be recursive

--- a/test/golden/Issue145.err
+++ b/test/golden/Issue145.err
@@ -1,2 +1,2 @@
 test/Fail/Issue145.agda:23,6-8
-Cannot use hidden variable a
+Hidden type parameter not supported: (a : Set)

--- a/test/golden/Issue145.err
+++ b/test/golden/Issue145.err
@@ -1,2 +1,0 @@
-test/Fail/Issue145.agda:23,6-8
-Hidden type parameter not supported: (a : Set)

--- a/test/golden/Issue145.hs
+++ b/test/golden/Issue145.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE ScopedTypeVariables, BangPatterns #-}
+module Issue145 where
+
+it :: forall a . a -> a
+it x = x
+
+it' :: Monoid a => a -> a
+it' x = x
+
+data Ok' a = Thing' !a
+
+data Ok a = Thing a
+
+test :: Ok String
+test = Thing "ok"
+

--- a/test/golden/Issue264.hs
+++ b/test/golden/Issue264.hs
@@ -1,0 +1,10 @@
+module Issue264 where
+
+data Term = Dummy
+
+reduce :: Term -> Term
+reduce v = go v
+  where
+    go :: Term -> Term
+    go v = v
+

--- a/test/golden/Issue301.hs
+++ b/test/golden/Issue301.hs
@@ -1,0 +1,16 @@
+module Issue301 where
+
+data MyData a = Nuttin'
+
+instance Foldable MyData where
+    foldMap _ _ = mempty
+
+(><) :: MyData a -> MyData a -> MyData a
+_ >< _ = Nuttin'
+
+instance Semigroup (MyData a) where
+    (<>) = (><)
+
+instance Monoid (MyData a) where
+    mempty = Nuttin'
+

--- a/test/golden/ModuleParameters.hs
+++ b/test/golden/ModuleParameters.hs
@@ -4,7 +4,7 @@ module ModuleParameters where
 data Scope p = Empty
              | Bind p (Scope p)
 
-unbind :: Scope p -> Scope p
+unbind :: forall p . Scope p -> Scope p
 unbind Empty = Empty
 unbind (Bind _ s) = s
 

--- a/test/golden/NonStarDatatypeIndex.err
+++ b/test/golden/NonStarDatatypeIndex.err
@@ -1,2 +1,2 @@
 test/Fail/NonStarDatatypeIndex.agda:5,6-7
-Kind of bound argument not supported: (n : Nat)
+Term variable in type parameter not supported: (n : Nat)

--- a/test/golden/NonStarRecordIndex.err
+++ b/test/golden/NonStarRecordIndex.err
@@ -1,2 +1,2 @@
 test/Fail/NonStarRecordIndex.agda:5,8-9
-Kind of bound argument not supported: (n : Nat)
+Term variable in type parameter not supported: (n : Nat)

--- a/test/golden/TypeBasedUnboxing.hs
+++ b/test/golden/TypeBasedUnboxing.hs
@@ -1,0 +1,5 @@
+module TypeBasedUnboxing where
+
+foo :: Int -> Int
+foo = \ r -> r
+

--- a/test/golden/TypeLambda.err
+++ b/test/golden/TypeLambda.err
@@ -1,0 +1,2 @@
+test/Fail/TypeLambda.agda:6,1-4
+Not supported: type-level lambda λ y → Nat


### PR DESCRIPTION
This PR continues on the path that @flupe has started with https://github.com/agda/agda2hs/pull/270 and pushes type-based compilation to every corner of `agda2hs`. It also fixes #264 by removing the horrible `compileTopLevelType` function and introducing a better way to handle explicit `forall`s.

Ignoring a number of refactorings, this PR makes the following semantic changes to `agda2hs`:
- Parameters of data and record types and of type aliases are now compiled according to their type rather than their hiding/quantity annotations. In particular, hidden data parameters are now supported.
- Instance declarations are now also compiled according to their type, so non-erased hidden fields are now supported.
- The check that unboxed records have a single non-erased field is now type-based, so in particular (visible) fields of type `Level`, `Size`, and any type in `Prop` are now allowed (and dropped during compilation).
- Non-erased module parameters are now allowed. Type parameters are turned into explicit `forall`s to each top-level function in the module, while other parameters are compiled as normal arguments.

The test suite passes and I have added some minimal extra tests, but it could definitely still use some more testing, so please let me know if you have any examples you'd like me to try.