### PR TITLE
Fix for issue #305 + some related problems

### DIFF
--- a/src/Agda2Hs/Compile.hs
+++ b/src/Agda2Hs/Compile.hs
@@ -82,6 +82,8 @@ compile opts tlm _ def =
 
       isInstance <- anyM (defInstance def) isClassName 
 
+      reportSDoc "agda2hs.compile" 15  $ text "Is instance?" <+> prettyTCM isInstance
+
       case (p , theDef def) of
         (NoPragma            , _         ) -> return []
         (ExistingClassPragma , _         ) -> return []

--- a/src/Agda2Hs/Compile/ClassInstance.hs
+++ b/src/Agda2Hs/Compile/ClassInstance.hs
@@ -217,7 +217,9 @@ compileInstanceClause' curModule ty (p:ps) c
           body <- case clauseBody c' of
             Nothing -> genericDocError =<< text "not allowed: absurd clause for superclass"
             Just b  -> return b
-          checkInstance body
+          addContext (clauseTel c) $ do
+            liftTCM $ setModuleCheckpoint curModule
+            checkInstance body
           reportSDoc "agda2hs.compile.instance" 20 $ vcat
             [ text "compileInstanceClause dropping clause"
             , nest 2 $ prettyTCM c

--- a/src/Agda2Hs/Compile/ClassInstance.hs
+++ b/src/Agda2Hs/Compile/ClassInstance.hs
@@ -235,13 +235,13 @@ compileInstanceClause' curModule ty (p:ps) c
         reportSDoc "agda2hs.compile.instance" 20 $
           text $ "raw projection:" ++ prettyShow (Def n [])
         d <- chaseDef n
-        fc <- compileLocal $ compileFun False d
+        Hs.InstDecl _ _ _ (Just fc) <- compileLocal $ compileInstance ToDefinition d
         let hd = hsName $ prettyShow $ nameConcrete $ qnameName $ defName d
         let fc' = {- dropPatterns 1 $ -} replaceName hd uf fc
         reportSDoc "agda2hs.compile.instance" 6 $ vcat $
           text "compileInstanceClause compiled clause: " :
           map (nest 2 . text . pp) fc'
-        return (map (Hs.InsDecl ()) fc', [n])
+        return (fc', [n])
 
        -- Projection of a default implementation: drop while making sure these are drawn from the
        -- same (minimal) dictionary as the primitive fields.

--- a/src/Agda2Hs/Compile/Function.hs
+++ b/src/Agda2Hs/Compile/Function.hs
@@ -178,6 +178,11 @@ compileClause' curModule projName x ty c@Clause{..} = do
     reportSDoc "agda2hs.compile" 17 $ "Function type:    " <+> prettyTCM ty
     reportSDoc "agda2hs.compile" 17 $ "Clause patterns:  " <+> text (prettyShow namedClausePats)
 
+    -- Jesper: we need to set the checkpoint for the current module so that
+    -- the canonicity check for typeclass instances picks up the
+    -- module parameters (see https://github.com/agda/agda2hs/issues/305).
+    liftTCM $ setModuleCheckpoint curModule
+
     toDrop <- case projName of
       Nothing -> pure 0
       Just q  -> maybe 0 (pred . projIndex) <$> isProjection q

--- a/src/Agda2Hs/Compile/Function.hs
+++ b/src/Agda2Hs/Compile/Function.hs
@@ -230,7 +230,7 @@ keepClause c@Clause{..} = case (clauseBody, clauseType) of
   (_, Nothing) -> pure False
   (Just body, Just cty) -> compileDom (domFromArg cty) <&> \case
     DODropped  -> False
-    DOInstance -> False -- not __IMPOSSIBLE__ because of current hacky implementation of `compileInstanceClause`
+    DOInstance -> True
     DOType     -> __IMPOSSIBLE__
     DOTerm     -> True
 

--- a/src/Agda2Hs/Compile/Function.hs
+++ b/src/Agda2Hs/Compile/Function.hs
@@ -177,6 +177,9 @@ compileClause' curModule projName x ty c@Clause{..} = do
     reportSDoc "agda2hs.compile" 17 $ "Clause type:      " <+> prettyTCM clauseType
     reportSDoc "agda2hs.compile" 17 $ "Function type:    " <+> prettyTCM ty
     reportSDoc "agda2hs.compile" 17 $ "Clause patterns:  " <+> text (prettyShow namedClausePats)
+    reportSDoc "agda2hs.compile" 18 $ "Clause module:" <+> prettyTCM curModule
+    ls <- asks locals
+    reportSDoc "agda2hs.compile" 18 $ "Clause locals:" <+> prettyTCM ls
 
     -- Jesper: we need to set the checkpoint for the current module so that
     -- the canonicity check for typeclass instances picks up the

--- a/src/Agda2Hs/Compile/Term.hs
+++ b/src/Agda2Hs/Compile/Term.hs
@@ -75,7 +75,7 @@ lambdaCase q ty args = compileLocal $ setCurrentRangeQ q $ do
 
   ty' <- piApplyM ty pars
 
-  cs <- mapMaybeM (compileClause' (qnameModule q) (Just q) (hsName "(lambdaCase)") ty') cs
+  cs <- mapMaybeM (compileClause' mname (Just q) (hsName "(lambdaCase)") ty') cs
 
   case cs of
     -- If there is a single clause and all patterns got erased, we

--- a/src/Agda2Hs/Compile/Term.hs
+++ b/src/Agda2Hs/Compile/Term.hs
@@ -23,7 +23,7 @@ import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Records ( shouldBeProjectible )
 import Agda.TypeChecking.Datatypes ( getConType )
-import Agda.TypeChecking.Reduce ( unfoldDefinitionStep )
+import Agda.TypeChecking.Reduce ( unfoldDefinitionStep, instantiate )
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Telescope ( telView, mustBePi, piApplyM )
 import Agda.TypeChecking.ProjectionLike ( reduceProjectionLike )
@@ -382,6 +382,8 @@ compileTerm :: Type -> Term -> C (Hs.Exp ())
 compileTerm ty v = do
 
   reportSDoc "agda2hs.compile.term" 10  $ text "compiling term:" <+> prettyTCM v
+
+  v <- instantiate v
 
   let bad s t = genericDocError =<< vcat
         [ text "agda2hs: cannot compile" <+> text (s ++ ":")

--- a/test/AllFailTests.agda
+++ b/test/AllFailTests.agda
@@ -35,3 +35,4 @@ import Fail.PartialCaseNoLambda
 import Fail.NonStarDatatypeIndex
 import Fail.NonCanonicalSpecialFunction
 import Fail.TypeLambda
+import Fail.NonCanonicalSuperclass

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -81,6 +81,7 @@ import TypeBasedUnboxing
 import Issue145
 import Issue264
 import Issue301
+import Issue305
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -159,4 +160,5 @@ import TypeBasedUnboxing
 import Issue145
 import Issue264
 import Issue301
+import Issue305
 #-}

--- a/test/Fail/NonCanonicalSuperclass.agda
+++ b/test/Fail/NonCanonicalSuperclass.agda
@@ -1,0 +1,32 @@
+
+module Fail.NonCanonicalSuperclass where
+
+open import Haskell.Prelude
+
+record Class (a : Set) : Set where
+  field
+    foo : a → a
+open Class {{...}} public
+
+{-# COMPILE AGDA2HS Class class #-}
+
+instance
+  ClassBool : Class Bool
+  ClassBool .foo = not
+
+{-# COMPILE AGDA2HS ClassBool #-}
+
+record Subclass (a : Set) : Set where
+  field
+    overlap {{super}} : Class a
+    bar : a
+open Subclass {{...}} public
+
+{-# COMPILE AGDA2HS Subclass class #-}
+
+instance 
+  SubclassBool : Subclass Bool
+  SubclassBool .super = record { foo = id }
+  SubclassBool .bar = False
+
+{-# COMPILE AGDA2HS SubclassBool #-}

--- a/test/Issue305.agda
+++ b/test/Issue305.agda
@@ -15,7 +15,33 @@ instance
 
 {-# COMPILE AGDA2HS ClassInt #-}
 
+instance
+  ClassBool : Class Bool
+  ClassBool .foo = not
+
+{-# COMPILE AGDA2HS ClassBool #-}
+
 test : Int
 test = foo 41
 
 {-# COMPILE AGDA2HS test #-}
+
+anotherTest : Int
+anotherTest = test
+
+{-# COMPILE AGDA2HS anotherTest #-}
+
+record Subclass (a : Set) : Set where
+  field
+    overlap {{super}} : Class a
+    bar : a
+open Subclass {{...}} public
+
+{-# COMPILE AGDA2HS Subclass class #-}
+
+instance 
+  SubclassBool : Subclass Bool
+  SubclassBool .super = ClassBool
+  SubclassBool .bar = False
+
+{-# COMPILE AGDA2HS SubclassBool #-}

--- a/test/Issue305.agda
+++ b/test/Issue305.agda
@@ -1,0 +1,21 @@
+open import Haskell.Prelude
+
+module Issue305 (@0 X : Set) where
+
+record Class (a : Set) : Set where
+  field
+    foo : a → a
+open Class {{...}} public
+
+{-# COMPILE AGDA2HS Class class #-}
+
+instance
+  ClassInt : Class Int
+  ClassInt .foo = _+ 1
+
+{-# COMPILE AGDA2HS ClassInt #-}
+
+test : Int
+test = foo 41
+
+{-# COMPILE AGDA2HS test #-}

--- a/test/Issue305.agda
+++ b/test/Issue305.agda
@@ -31,6 +31,16 @@ anotherTest = test
 
 {-# COMPILE AGDA2HS anotherTest #-}
 
+yetAnotherTest : Int
+yetAnotherTest = case Just True of λ where
+  Nothing → error "unreachable"
+  (Just y) → foo 5
+{-# COMPILE AGDA2HS yetAnotherTest #-}
+
+andOneMoreTest : Int → Int
+andOneMoreTest x = foo 5
+{-# COMPILE AGDA2HS andOneMoreTest #-}
+
 record Subclass (a : Set) : Set where
   field
     overlap {{super}} : Class a

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -76,4 +76,5 @@ import TypeBasedUnboxing
 import Issue145
 import Issue264
 import Issue301
+import Issue305
 

--- a/test/golden/DefaultMethods.hs
+++ b/test/golden/DefaultMethods.hs
@@ -13,14 +13,14 @@ class Ord a where
     x > y = y < x
 
 instance Ord Bool where
-    (<) False b = b
-    (<) True _ = False
+    False < b = b
+    True < _ = False
 
 data Bool1 = Mk1 Bool
 
 instance Ord Bool1 where
-    (<) (Mk1 False) (Mk1 b) = b
-    (<) (Mk1 True) _ = False
+    Mk1 False < Mk1 b = b
+    Mk1 True < _ = False
 
 data Bool2 = Mk2 Bool
 
@@ -39,8 +39,11 @@ instance Ord Bool2 where
 data Bool3 = Mk3 Bool
 
 instance Ord Bool3 where
-    Mk3 False < Mk3 b = b
-    Mk3 True < _ = False
+    (<) = (<:)
+      where
+        (<:) :: Bool3 -> Bool3 -> Bool
+        Mk3 False <: Mk3 b = b
+        Mk3 True <: _ = False
 
 data Bool4 = Mk4 Bool
 
@@ -53,8 +56,11 @@ instance Ord Bool4 where
 data Bool5 = Mk5 Bool
 
 instance Ord Bool5 where
-    Mk5 False > _ = False
-    Mk5 True > Mk5 b = not b
+    (>) = (>:)
+      where
+        (>:) :: Bool5 -> Bool5 -> Bool
+        Mk5 False >: _ = False
+        Mk5 True >: Mk5 b = not b
 
 data Bool6 = Mk6 Bool
 
@@ -64,8 +70,11 @@ instance Ord Bool6 where
         (>:) :: Bool6 -> Bool6 -> Bool
         Mk6 False >: _ = False
         Mk6 True >: Mk6 b = not b
-    Mk6 False > _ = False
-    Mk6 True > Mk6 b = not b
+    (>) = (>:)
+      where
+        (>:) :: Bool6 -> Bool6 -> Bool
+        Mk6 False >: _ = False
+        Mk6 True >: Mk6 b = not b
 
 defaultShowList :: (a -> ShowS) -> [a] -> ShowS
 defaultShowList _ [] = showString "[]"

--- a/test/golden/Issue305.hs
+++ b/test/golden/Issue305.hs
@@ -1,0 +1,11 @@
+module Issue305 where
+
+class Class a where
+    foo :: a -> a
+
+instance Class Int where
+    foo = (+ 1)
+
+test :: Int
+test = foo 41
+

--- a/test/golden/Issue305.hs
+++ b/test/golden/Issue305.hs
@@ -15,6 +15,15 @@ test = foo 41
 anotherTest :: Int
 anotherTest = test
 
+yetAnotherTest :: Int
+yetAnotherTest
+  = case Just True of
+        Nothing -> error "unreachable"
+        Just y -> foo 5
+
+andOneMoreTest :: Int -> Int
+andOneMoreTest x = foo 5
+
 class Class a => Subclass a where
     bar :: a
 

--- a/test/golden/Issue305.hs
+++ b/test/golden/Issue305.hs
@@ -6,6 +6,18 @@ class Class a where
 instance Class Int where
     foo = (+ 1)
 
+instance Class Bool where
+    foo = not
+
 test :: Int
 test = foo 41
+
+anotherTest :: Int
+anotherTest = test
+
+class Class a => Subclass a where
+    bar :: a
+
+instance Subclass Bool where
+    bar = False
 

--- a/test/golden/NonCanonicalSuperclass.err
+++ b/test/golden/NonCanonicalSuperclass.err
@@ -1,0 +1,2 @@
+test/Fail/NonCanonicalSuperclass.agda:28,3-15
+illegal instance:  record { foo = id }


### PR DESCRIPTION
This fixes #305 by setting the right checkpoint for Agda so that when we call instance search for checking canonicity, the instances are correctly applied to the module parameters.

I also found and fixed a related regression introduced in my PR https://github.com/agda/agda2hs/pull/304 that caused us to no longer check the canonicity of superclass instances when defining a subclass instance.

When I run the test suite locally on this branch, there is something weird that happens with the golden files for two modules:

- `NonCanonicalSuperclass.agda` produces an unexpected success despite producing the correct error when running `agda2hs` on it directly
- `StreamFusion.agda` I did not touch in any way, but suddenly appears in a different location

I feel like our test suite is getting increasingly flaky and hard to manage, so perhaps we should look into improving it soon (https://github.com/agda/agda2hs/issues/153)