### PR TITLE
Add a flake for agda2hs

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -1,0 +1,35 @@
+name: Nix CI
+
+# Trigger the workflow on push or pull request, but only for the master branch
+on:
+  pull_request:
+  push:
+    paths:
+      - 'lib/**'
+      - 'src/**'
+      - 'test/**'
+      - 'agda2hs.agda-lib'
+      - 'agda2hs.cabal'
+      - 'cabal.project'
+      - 'Makefile'
+      - '.github/workflows/**.yml'
+    branches: [master]
+
+jobs:
+  nix-build:
+    name: ${{ matrix.pretty }} with nix (${{ matrix.derivation }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        derivation: [agda2hs, agda2hs-lib]
+        include:
+          - pretty: "Compile agda2hs"
+            derivation: agda2hs
+          - pretty: "Typecheck with Agda"
+            derivation: agda2hs-lib
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v22
+    - uses: DeterminateSystems/magic-nix-cache-action@v2
+    - run: nix build .#${{ matrix.derivation }} --print-build-logs

--- a/agda2hs.nix
+++ b/agda2hs.nix
@@ -1,0 +1,29 @@
+{stdenv, lib, self, agda2hs, runCommandNoCC, makeWrapper, writeText, mkShell, ghcWithPackages}:
+with lib.strings;
+let
+  withPackages' = {
+      pkgs,
+      ghc ? ghcWithPackages (p: with p; [ ieee754 ])
+  }: let
+    pkgs' = if builtins.isList pkgs then pkgs else pkgs self;
+    library-file = writeText "libraries" ''
+      ${(concatMapStringsSep "\n" (p: "${p}/${p.libraryFile}") pkgs')}
+    '';
+    pname = "agda2hsWithPackages";
+    version = agda2hs.version;
+  in runCommandNoCC "${pname}-${version}" {
+    inherit pname version;
+    nativeBuildInputs = [ makeWrapper ];
+    passthru.unwrapped = agda2hs;
+  } ''
+    mkdir -p $out/bin
+    makeWrapper ${agda2hs}/bin/agda2hs $out/bin/agda2hs \
+      --add-flags "--with-compiler=${ghc}/bin/ghc" \
+      --add-flags "--library-file=${library-file}" \
+      --add-flags "--local-interfaces"
+    ''; # Local interfaces has been added for now: See https://github.com/agda/agda/issues/4526
+  withPackages = arg: if builtins.isAttrs arg then withPackages' arg else withPackages' { pkgs = arg; };
+in {
+  inherit withPackages;
+  agda2hs = withPackages [];
+}

--- a/flake.lock
+++ b/flake.lock
@@ -18,21 +18,6 @@
         "type": "github"
       }
     },
-    "mkAgdaDerivation": {
-      "locked": {
-        "lastModified": 1711465038,
-        "narHash": "sha256-rJFQI7/IcwSnUAdxaQkJOvzBy0BCMWCb6N0OC27LlRk=",
-        "owner": "liesnikov",
-        "repo": "mkAgdaDerivation",
-        "rev": "393785b798a8938063fff14ad681d7ef95356215",
-        "type": "github"
-      },
-      "original": {
-        "owner": "liesnikov",
-        "repo": "mkAgdaDerivation",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1711555030,
@@ -51,7 +36,6 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "mkAgdaDerivation": "mkAgdaDerivation",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -35,17 +35,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1704842529,
-        "narHash": "sha256-OTeQA+F8d/Evad33JMfuXC89VMetQbsU4qcaePchGr4=",
+        "lastModified": 1711555030,
+        "narHash": "sha256-PuFoxVlnKIIqI83o5yVFjR9XWiCSMTsHhvGoCpUNpvU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "eabe8d3eface69f5bb16c18f8662a702f50c20d5",
+        "rev": "cb11f8589769078fa154fb57ed8edd185281f1db",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "eabe8d3eface69f5bb16c18f8662a702f50c20d5",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,77 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "mkAgdaDerivation": {
+      "locked": {
+        "lastModified": 1711465038,
+        "narHash": "sha256-rJFQI7/IcwSnUAdxaQkJOvzBy0BCMWCb6N0OC27LlRk=",
+        "owner": "liesnikov",
+        "repo": "mkAgdaDerivation",
+        "rev": "393785b798a8938063fff14ad681d7ef95356215",
+        "type": "github"
+      },
+      "original": {
+        "owner": "liesnikov",
+        "repo": "mkAgdaDerivation",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1704842529,
+        "narHash": "sha256-OTeQA+F8d/Evad33JMfuXC89VMetQbsU4qcaePchGr4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "eabe8d3eface69f5bb16c18f8662a702f50c20d5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "eabe8d3eface69f5bb16c18f8662a702f50c20d5",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "mkAgdaDerivation": "mkAgdaDerivation",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
           inherit agda2hs-pkg agda2hs-hs agda2hs-expr;
         };
         devShells.default = pkgs.haskellPackages.shellFor {
-          packages = p: [agda2hs-pkg];
+          packages = p: [agda2hs-hs];
           buildInputs = with pkgs.haskellPackages; [
             cabal-install
             cabal2nix

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,7 @@
         };
         lib = {
           inherit (agda2hs) withPackages;
-          inherit agda2hs-expr agda2hs-pkg agda2hs-hs;
+          inherit agda2hs-pkg agda2hs-hs agda2hs-expr;
         };
         devShells.default = pkgs.haskellPackages.shellFor {
           packages = p: [agda2hs-pkg];

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Agda2hs";
 
-  inputs.nixpkgs.url = github:NixOS/nixpkgs/eabe8d3eface69f5bb16c18f8662a702f50c20d5;
+  inputs.nixpkgs.url = github:NixOS/nixpkgs;
   inputs.flake-utils.url = github:numtide/flake-utils;
   inputs.mkAgdaDerivation.url = github:liesnikov/mkAgdaDerivation;
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,46 @@
+{
+  description = "Agda2hs";
+
+  inputs.nixpkgs.url = github:NixOS/nixpkgs/eabe8d3eface69f5bb16c18f8662a702f50c20d5;
+  inputs.flake-utils.url = github:numtide/flake-utils;
+  inputs.mkAgdaDerivation.url = github:liesnikov/mkAgdaDerivation;
+
+  outputs = {self, nixpkgs, flake-utils, mkAgdaDerivation}:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {inherit system;};
+        haskellPackages = pkgs.haskell.packages.ghc96;
+        agda2hs-hs = haskellPackages.callCabal2nixWithOptions "agda2hs" ./. "--jailbreak" {};
+        agda2hs = pkgs.callPackage ./agda2hs.nix {
+          inherit self;
+          agda2hs = agda2hs-hs;
+          inherit (haskellPackages) ghcWithPackages;
+        };
+        agdaDerivation = pkgs.callPackage mkAgdaDerivation.lib.mkAgdaDerivation {};
+        agda2hs-lib = agdaDerivation
+          { pname = "agda2hs";
+            meta = {};
+            version = "1.3";
+            tcDir = "lib";
+            src = ./.;
+          };
+      in {
+        packages = {
+          inherit agda2hs-lib;
+          agda2hs = agda2hs.agda2hs;
+          default = agda2hs.agda2hs;
+        };
+        lib = {
+          withPackages = agda2hs.withPackages;
+        };
+        devShells.default = haskellPackages.shellFor {
+          packages = p: [agda2hs-hs];
+          buildInputs = with haskellPackages; [
+            cabal-install
+            cabal2nix
+            haskell-language-server
+            pkgs.agda
+          ];
+        };
+      });
+}


### PR DESCRIPTION
I've been using nix for CI and to build agda-core locally for https://github.com/jespercockx/agda-core and I had to write a derivation for agda2hs anyway, so I figured I'll push it upstream.

In the flake there are
* agda2hs the executable (`agda2hs`)
* agda2hs the agda library (`agda2hs-lib`)
* a derivation to build agda2hs with agda libraries (`withPackages`)

I also added a CI builder for the nix derivations.

There's some weird behavior when we compile with ghc 9.4 using nix -- an instance of MonadError can't be found.
For this to happen one must do jailbreak, because otherwise aeson and transformers don't satisfy version requirements.

```
agda2hs> Error: Setup: Encountered missing or private dependencies:
agda2hs> aeson >=2.2 && <2.3, transformers >=0.6 && <0.7
```

<details> 
  <summary>Build log for ghc 9.4 with a jailbroken package  </summary>

```
agda2hs> [ 4 of 23] Compiling Agda2Hs.Pragma   ( src/Agda2Hs/Pragma.hs, dist/build/agda2hs/agda2hs-tmp/Agda2Hs/Pragma.o )
agda2hs> src/Agda2Hs/Pragma.hs:79:45: error:
agda2hs>     • No instance for (Control.Monad.Error.Class.MonadError
agda2hs>                          TCErr
agda2hs>                          (Control.Monad.Trans.RWS.CPS.RWST
agda2hs>                             CompileEnv CompileOutput CompileState TCM))
agda2hs>         arising from a use of ‘genericError’
agda2hs>     • In the second argument of ‘($)’, namely ‘genericError msg’
agda2hs>       In the expression:
agda2hs>         setCurrentRange (srcLocToRange loc) $ genericError msg
agda2hs>       In a case alternative:
agda2hs>           Hs.ParseFailed loc msg
agda2hs>             -> setCurrentRange (srcLocToRange loc) $ genericError msg
agda2hs>    |
agda2hs> 79 |       setCurrentRange (srcLocToRange loc) $ genericError msg
agda2hs>    |                                             ^^^^^^^^^^^^
agda2hs> [ 5 of 23] Compiling AgdaInternals    ( src/AgdaInternals.hs, dist/build/agda2hs/agda2hs-tmp/AgdaInternals.o )
agda2hs> [ 6 of 23] Compiling Agda2Hs.AgdaUtils ( src/Agda2Hs/AgdaUtils.hs, dist/build/agda2hs/agda2hs-tmp/Agda2Hs/AgdaUtils.o )
agda2hs> [15 of 23] Compiling Agda2Hs.Compile.Function[boot] ( src/Agda2Hs/Compile/Function.hs-boot, dist/build/agda2hs/agda2hs-tmp/Agda2Hs/Compile/Function.o-boot )
agda2hs> [22 of 23] Compiling Paths_agda2hs    ( dist/build/agda2hs/autogen/Paths_agda2hs.hs, dist/build/agda2hs/agda2hs-tmp/Paths_agda2hs.o )
error: builder for '/nix/store/s9jv2y4ympsqlc4jrk60lhjxfv4rv6jl-agda2hs-1.3.drv' failed with exit code 1;
       last 10 log lines:
       >       In a case alternative:
       >           Hs.ParseFailed loc msg
       >             -> setCurrentRange (srcLocToRange loc) $ genericError msg
       >    |
       > 79 |       setCurrentRange (srcLocToRange loc) $ genericError msg
       >    |                                             ^^^^^^^^^^^^
       > [ 5 of 23] Compiling AgdaInternals    ( src/AgdaInternals.hs, dist/build/agda2hs/agda2hs-tmp/AgdaInternals.o )
       > [ 6 of 23] Compiling Agda2Hs.AgdaUtils ( src/Agda2Hs/AgdaUtils.hs, dist/build/agda2hs/agda2hs-tmp/Agda2Hs/AgdaUtils.o )
       > [15 of 23] Compiling Agda2Hs.Compile.Function[boot] ( src/Agda2Hs/Compile/Function.hs-boot, dist/build/agda2hs/agda2hs-tmp/Agda2Hs/Compile/Function.o-boot )
       > [22 of 23] Compiling Paths_agda2hs    ( dist/build/agda2hs/autogen/Paths_agda2hs.hs, dist/build/agda2hs/agda2hs-tmp/Paths_agda2hs.o )
```

</details>

With ghc 9.6 it builds without (almost) hiccups (current [default](https://github.com/NixOS/nixpkgs/blob/cb11f8589769078fa154fb57ed8edd185281f1db/pkgs/top-level/all-packages.nix#L16069) in nixpkgs, as of cb11f8). 
I still decided to jailbreak because the default aeson version is slightly outdated - not sure why - and overriding it to the aeson 2.2 triggers a recompilation of a lot of dependencies.

There's also a devshell derivation that should be a superset of the current shell.nix, but I haven't tested it too much.

Examples of this flake's usage: https://github.com/liesnikov/scope/blob/master/flake.nix and https://github.com/liesnikov/agda-core/blob/flakes/flake.nix

~~Finally the dependency on `mkAgdaDerivation` is due to the fact that upstream agda derivation needs an Everything file which agda2hs doesn't have. I might file a PR to nixpkgs to fix it later but for now it lives in a separate repo.~~
edit: borrowed a trick from nixpkgs to remove it