### PR TITLE
Makefile robustness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY : install agda repl libHtml test testHtml golden docs
+FILES = $(shell find src -type f)
 
 install :
 	cabal install --overwrite-policy=always
@@ -13,7 +14,7 @@ libHtml :
 	cabal run agda2hs -- --html lib/Haskell/Prelude.agda
 	cp html/Haskell.Prelude.html html/index.html
 
-test/agda2hs : src/*.hs
+test/agda2hs : $(FILES)
 	cabal install agda2hs --overwrite-policy=always --installdir=test --install-method=copy
 
 test : test/agda2hs

--- a/test/Makefile
+++ b/test/Makefile
@@ -6,7 +6,7 @@ FAIL_MAIN=AllFailTests
 .PHONY : default allTests print-fail fail compare golden \
 	html renderTranslations clean force-recompile
 
-default : allTests fail compare
+default : compare
 
 build/%.hs : %.agda *.agda Fail/*.agda Cubical/*.agda
 	@echo == Compiling tests ==
@@ -21,11 +21,11 @@ print-fail :
 
 fail : print-fail $(patsubst Fail/%.agda,build/%.err,$(wildcard Fail/*.agda))
 
-build/%.err : Fail/%.agda force-recompile allTests
+build/%.err : Fail/%.agda force-recompile
 	@echo Compiling $<
 	@($(AGDA2HS) $< -o build -v0 && echo "UNEXPECTED SUCCESS" || true) | sed -e 's:'$(ROOT)'::g' > $@
 
-compare : fail
+compare : allTests fail
 	@echo == Comparing output ==
 	@diff -r build golden
 


### PR DESCRIPTION
### Update make test trigger

`test/agda2hs` was rebuilt upon changes in `src/*.hs` only, but these are not all the source files (in fact, they're the less frequently used ones). Extend this to all files.
We can't use a Makefile wildcard here because the nest goes deeper.

### Update test make dependencies

for efficient and correct multiprocessing