### PR TITLE
Rebuild test files when appropriate

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -8,7 +8,7 @@ FAIL_MAIN=AllFailTests
 
 default : compare
 
-build/%.hs : %.agda *.agda Fail/*.agda Cubical/*.agda
+build/%.hs : %.agda *.agda Fail/*.agda Cubical/*.agda agda2hs
 	@echo == Compiling tests ==
 	$(AGDA2HS) $< -o build
 
@@ -21,7 +21,7 @@ print-fail :
 
 fail : print-fail $(patsubst Fail/%.agda,build/%.err,$(wildcard Fail/*.agda))
 
-build/%.err : Fail/%.agda force-recompile
+build/%.err : Fail/%.agda agda2hs
 	@echo Compiling $<
 	@($(AGDA2HS) $< -o build -v0 && echo "UNEXPECTED SUCCESS" || true) | sed -e 's:'$(ROOT)'::g' > $@
 


### PR DESCRIPTION
of course it wasn't all -.- sorry for the noise

- Rebuild positive also upon new `agda2hs` binary
- Rebuild negative on new `agda2hs` binary, removing `force-recompile`