### PR TITLE
Closes #309: Ensures we compile pattern variables correctly

### DIFF
--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -83,6 +83,7 @@ import Issue264
 import Issue301
 import Issue305
 import Issue302
+import Issue309
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -163,4 +164,5 @@ import Issue264
 import Issue301
 import Issue305
 import Issue302
+import Issue309
 #-}

--- a/test/Issue309.agda
+++ b/test/Issue309.agda
@@ -1,0 +1,7 @@
+module Issue309 where
+
+private variable @0 a : Set
+
+Ap : (p : @0 a → Set) → @0 a → Set
+Ap p x = p x
+{-# COMPILE AGDA2HS Ap #-}

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -78,4 +78,5 @@ import Issue264
 import Issue301
 import Issue305
 import Issue302
+import Issue309
 

--- a/test/golden/Issue309.hs
+++ b/test/golden/Issue309.hs
@@ -1,0 +1,4 @@
+module Issue309 where
+
+type Ap p = p
+


### PR DESCRIPTION
The old `compileTypeArgs` in this module was failing to update the context on recursive calls, causing the De Bruijn indices to get messed up. This PR relies on the existing `compileTypeArgs` instead. Closes #309 