### PR TITLE
Fix for #340

### DIFF
--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -85,6 +85,7 @@ import Issue305
 import Issue302
 import Issue309
 import Issue317
+import ErasedPatternLambda
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -167,4 +168,5 @@ import Issue305
 import Issue302
 import Issue309
 import Issue317
+import ErasedPatternLambda
 #-}

--- a/test/ErasedPatternLambda.agda
+++ b/test/ErasedPatternLambda.agda
@@ -1,0 +1,18 @@
+open import Haskell.Prelude
+
+Scope = List Bool
+
+data Telescope (@0 α : Scope) : @0 Scope → Set where
+  ExtendTel : ∀ {@0 x β} → Bool → Telescope (x ∷ α) β  → Telescope α (x ∷ β)
+{-# COMPILE AGDA2HS Telescope #-}
+
+caseTelBind : ∀ {@0 x α β} (tel : Telescope α (x ∷ β))
+            → ((a : Bool) (rest : Telescope (x ∷ α) β) → @0 tel ≡ ExtendTel a rest → d)
+            → d
+caseTelBind (ExtendTel a tel) f = f a tel refl
+
+{-# COMPILE AGDA2HS caseTelBind #-}
+
+checkSubst : ∀ {@0 x α β} (t : Telescope α (x ∷ β)) → Bool
+checkSubst t = caseTelBind t λ ty rest → λ where refl → True
+{-# COMPILE AGDA2HS checkSubst #-}

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -80,4 +80,5 @@ import Issue305
 import Issue302
 import Issue309
 import Issue317
+import ErasedPatternLambda
 

--- a/test/golden/ErasedPatternLambda.hs
+++ b/test/golden/ErasedPatternLambda.hs
@@ -1,0 +1,10 @@
+module ErasedPatternLambda where
+
+data Telescope = ExtendTel Bool Telescope
+
+caseTelBind :: Telescope -> (Bool -> Telescope -> d) -> d
+caseTelBind (ExtendTel a tel) f = f a tel
+
+checkSubst :: Telescope -> Bool
+checkSubst t = caseTelBind t (\ ty rest -> True)
+


### PR DESCRIPTION
This fixes #340 by compiling a pattern-matching lambda to a regular lambda in case all the proper patterns got erased.