### PR TITLE
Add support for custom tuples

### DIFF
--- a/agda2hs.cabal
+++ b/agda2hs.cabal
@@ -86,4 +86,5 @@ executable agda2hs
                        ViewPatterns
                        NamedFieldPuns
                        PatternSynonyms
+                       NondecreasingIndentation
   ghc-options:         -Werror -rtsopts

--- a/lib/Haskell/Extra/Erase.agda
+++ b/lib/Haskell/Extra/Erase.agda
@@ -8,7 +8,7 @@ module Haskell.Extra.Erase where
   open import Haskell.Prim.List
   open import Haskell.Law.Equality
 
-  private variable 
+  private variable
     @0 x y : a
     @0 xs  : List a
 
@@ -16,6 +16,7 @@ module Haskell.Extra.Erase where
     constructor Erased
     field @0 get : a
   open Erase public
+  {-# COMPILE AGDA2HS Erase tuple #-}
 
   infixr 4 ⟨_⟩_
   record Σ0 (@0 a : Set) (b : @0 a → Set) : Set where

--- a/lib/Haskell/Extra/Sigma.agda
+++ b/lib/Haskell/Extra/Sigma.agda
@@ -6,6 +6,7 @@ record Σ (a : Set) (b : @0 a → Set) : Set where
     fst : a
     snd : b fst
 open Σ public
+{-# COMPILE AGDA2HS Σ tuple #-}
 
 infix 2 Σ-syntax
 

--- a/lib/Haskell/Law/Eq/Instances.agda
+++ b/lib/Haskell/Law/Eq/Instances.agda
@@ -30,14 +30,14 @@ instance
   iLawfulEqNat .isEquality zero    zero    = refl
   iLawfulEqNat .isEquality zero    (suc _) = λ ()
   iLawfulEqNat .isEquality (suc _) zero    = λ ()
-  iLawfulEqNat .isEquality (suc x) (suc y) = mapReflects 
-    (cong suc) 
-    suc-injective 
+  iLawfulEqNat .isEquality (suc x) (suc y) = mapReflects
+    (cong suc)
+    suc-injective
     (isEquality x y)
 
   iLawfulEqWord : IsLawfulEq Word
-  iLawfulEqWord .isEquality x y 
-    with (w2n x) in h₁ | (w2n y) in h₂ 
+  iLawfulEqWord .isEquality x y
+    with (w2n x) in h₁ | (w2n y) in h₂
   ... | a | b  = mapReflects
     (λ h → w2n-injective x y $ sym $ trans (trans h₂ $ sym h) (sym h₁))
     (λ h → trans (sym $ trans (cong w2n (sym h)) h₁) h₂)
@@ -50,44 +50,44 @@ instance
   iLawfulEqBool .isEquality True  True  = refl
 
   iLawfulEqChar : IsLawfulEq Char
-  iLawfulEqChar .isEquality x y 
-    with (c2n x) in h₁ | (c2n y) in h₂ 
-  ... | a | b  = mapReflects { a ≡ b } { x ≡ y } { eqNat a b } 
+  iLawfulEqChar .isEquality x y
+    with (c2n x) in h₁ | (c2n y) in h₂
+  ... | a | b  = mapReflects { a ≡ b } { x ≡ y } { eqNat a b }
     (λ h → c2n-injective x y $ sym $ trans (trans h₂ $ sym h) (sym h₁))
     (λ h → trans (sym $ trans (cong c2n (sym h)) h₁) h₂)
     (isEquality a b)
 
-  iLawfulEqEither : ⦃ iEqA : Eq a ⦄ → ⦃ iEqB : Eq b ⦄ 
-    → ⦃ IsLawfulEq a ⦄ → ⦃ IsLawfulEq b ⦄ 
+  iLawfulEqEither : ⦃ iEqA : Eq a ⦄ → ⦃ iEqB : Eq b ⦄
+    → ⦃ IsLawfulEq a ⦄ → ⦃ IsLawfulEq b ⦄
     → IsLawfulEq (Either a b)
   iLawfulEqEither .isEquality (Left  _) (Right _) = λ ()
   iLawfulEqEither .isEquality (Right _) (Left  _) = λ ()
-  iLawfulEqEither .isEquality (Left  x) (Left  y) = mapReflects 
+  iLawfulEqEither .isEquality (Left  x) (Left  y) = mapReflects
     (cong Left) (Left-injective) (isEquality x y)
-  iLawfulEqEither .isEquality (Right x) (Right y) = mapReflects 
+  iLawfulEqEither .isEquality (Right x) (Right y) = mapReflects
     (cong Right) (Right-injective) (isEquality x y)
 
   iLawfulEqInt : IsLawfulEq Int
   iLawfulEqInt .isEquality (int64 x) (int64 y) = mapReflects
-    (cong int64) int64-injective (isEquality x y) 
+    (cong int64) int64-injective (isEquality x y)
 
   iLawfulEqInteger : IsLawfulEq Integer
-  iLawfulEqInteger .isEquality (pos n)    (pos m)    = mapReflects 
+  iLawfulEqInteger .isEquality (pos n)    (pos m)    = mapReflects
     (cong pos) pos-injective (isEquality n m)
-  iLawfulEqInteger .isEquality (pos _)    (negsuc _) = λ () 
+  iLawfulEqInteger .isEquality (pos _)    (negsuc _) = λ ()
   iLawfulEqInteger .isEquality (negsuc _) (pos _)    = λ ()
-  iLawfulEqInteger .isEquality (negsuc n) (negsuc m) = mapReflects 
+  iLawfulEqInteger .isEquality (negsuc n) (negsuc m) = mapReflects
     (cong negsuc) neg-injective (isEquality n m)
-  
+
   iLawfulEqList : ⦃ iEqA : Eq a ⦄ → ⦃ IsLawfulEq a ⦄ → IsLawfulEq (List a)
   iLawfulEqList .isEquality []       []      = refl
   iLawfulEqList .isEquality []       (_ ∷ _) = λ ()
   iLawfulEqList .isEquality (_ ∷ _)  []      = λ ()
-  iLawfulEqList .isEquality (x ∷ xs) (y ∷ ys) 
+  iLawfulEqList .isEquality (x ∷ xs) (y ∷ ys)
     with (x == y) in h₁
-  ... | True  = mapReflects 
-    (λ h → cong₂ (_∷_) (equality x y h₁)  h) 
-    ∷-injective-right 
+  ... | True  = mapReflects
+    (λ h → cong₂ (_∷_) (equality x y h₁)  h)
+    ∷-injective-right
     (isEquality xs ys)
   ... | False = λ h → (nequality x y h₁) (∷-injective-left h)
 
@@ -95,7 +95,7 @@ instance
   iLawfulEqMaybe .isEquality Nothing  Nothing  = refl
   iLawfulEqMaybe .isEquality Nothing  (Just _) = λ()
   iLawfulEqMaybe .isEquality (Just _) Nothing  = λ()
-  iLawfulEqMaybe .isEquality (Just x) (Just y) = mapReflects 
+  iLawfulEqMaybe .isEquality (Just x) (Just y) = mapReflects
     (cong Just) Just-injective (isEquality x y)
 
   iLawfulEqOrdering : IsLawfulEq Ordering
@@ -115,21 +115,22 @@ instance
   iLawfulEqTuple₂ .isEquality (x₁ , x₂) (y₁ , y₂)
     with (x₁ == y₁) in h₁
   ... | True  = mapReflects
-    (λ h → cong₂ _,_ (equality x₁ y₁ h₁) h) 
-    (cong snd) 
+    (λ h → cong₂ _,_ (equality x₁ y₁ h₁) h)
+    (cong snd)
     (isEquality x₂ y₂)
   ... | False = λ h → exFalso (equality' x₁ y₁ (cong fst h)) h₁
 
   iLawfulEqTuple₃ : ⦃ iEqA : Eq a ⦄ ⦃ iEqB : Eq b ⦄ ⦃ iEqC : Eq c ⦄
     → ⦃ IsLawfulEq a ⦄ → ⦃ IsLawfulEq b ⦄ → ⦃ IsLawfulEq c ⦄
     → IsLawfulEq (a × b × c)
-  iLawfulEqTuple₃ .isEquality (x₁ , x₂ , x₃) (y₁ , y₂ , y₃) 
-    with (x₁ == y₁) in h₁ 
+  iLawfulEqTuple₃ .isEquality (x₁ , x₂ , x₃) (y₁ , y₂ , y₃)
+    with (x₁ == y₁) in h₁
   ... | True  = mapReflects
-    (λ h → cong₂ (λ a (b , c) → a , b , c) (equality x₁ y₁ h₁) h) 
-    (cong λ h → snd₃ h , thd₃ h) 
+    (λ h → cong₂ (λ a (b , c) → a , b , c) (equality x₁ y₁ h₁) h)
+    (cong λ h → snd3 h , thd3 h)
     (isEquality (x₂ , x₃) (y₂ , y₃))
-  ... | False = λ h → exFalso (equality' x₁ y₁ (cong  fst₃ h)) h₁ 
+  ... | False = λ h → exFalso (equality' x₁ y₁ (cong fst3 h)) h₁
+
 
   iLawfulEqUnit : IsLawfulEq ⊤
   iLawfulEqUnit .isEquality tt tt = refl

--- a/lib/Haskell/Law/Eq/Instances.agda
+++ b/lib/Haskell/Law/Eq/Instances.agda
@@ -25,6 +25,8 @@ open import Haskell.Law.List    using ( ∷-injective-left; ∷-injective-right 
 open import Haskell.Law.Maybe
 open import Haskell.Law.Nat
 
+open _×_×_
+
 instance
   iLawfulEqNat : IsLawfulEq Nat
   iLawfulEqNat .isEquality zero    zero    = refl

--- a/lib/Haskell/Prim/Tuple.agda
+++ b/lib/Haskell/Prim/Tuple.agda
@@ -17,8 +17,17 @@ record _×_ (a b : Set) : Set where
     snd : b
 open _×_ public
 
-data _×_×_ (a b c : Set) : Set where
-  _,_,_ : a → b → c → a × b × c
+{-# COMPILE AGDA2HS _×_ tuple #-}
+
+record _×_×_ (a b c : Set) : Set where
+  no-eta-equality; pattern
+  constructor _,_,_
+  field
+    fst3 : a
+    snd3 : b
+    thd3 : c
+
+{-# COMPILE AGDA2HS _×_×_ tuple #-}
 
 uncurry : (a → b → c) → a × b → c
 uncurry f (x , y) = f x y
@@ -34,12 +43,3 @@ second f (x , y) = x , f y
 
 _***_ : (a → b) → (c → d) → a × c → b × d
 (f *** g) (x , y) = f x , g y
-
-fst₃ : (a × b × c) → a
-fst₃ (x , _ , _) = x 
-
-snd₃ : (a × b × c) → b
-snd₃ (_ , y , _) = y
-
-thd₃ : (a × b × c) → c
-thd₃ (_ , _ , z) = z

--- a/src/Agda2Hs/Compile.hs
+++ b/src/Agda2Hs/Compile.hs
@@ -91,6 +91,7 @@ compile opts tlm _ def =
         (UnboxPragma s       , Record{}  ) -> [] <$ checkUnboxPragma def
         (TransparentPragma   , Function{}) -> [] <$ checkTransparentPragma def
         (InlinePragma        , Function{}) -> [] <$ checkInlinePragma def
+        (TuplePragma b       , Record{}  ) -> return []
 
         (ClassPragma ms      , Record{}  ) -> pure <$> compileRecord (ToClass ms) def
         (NewTypePragma ds    , Record{}  ) -> pure <$> compileRecord (ToRecord True ds) def

--- a/src/Agda2Hs/Compile/Function.hs
+++ b/src/Agda2Hs/Compile/Function.hs
@@ -53,10 +53,6 @@ import Agda2Hs.HsUtils
 isSpecialCon :: QName -> Maybe (Type -> NAPs -> C (Hs.Pat ()))
 isSpecialCon qn = case prettyShow qn of
   s | s `elem` badConstructors     -> Just itsBad
-  "Haskell.Prim.Tuple._,_"         -> Just tuplePat
-  "Haskell.Prim.Tuple._×_×_._,_,_" -> Just tuplePat
-  "Haskell.Extra.Erase.Erased"     -> Just tuplePat
-  "Haskell.Extra.Sigma._,_"        -> Just tuplePat
   "Agda.Builtin.Int.Int.pos"       -> Just posIntPat
   "Agda.Builtin.Int.Int.negsuc"    -> Just negSucIntPat
   _                                -> Nothing
@@ -70,12 +66,6 @@ isSpecialCon qn = case prettyShow qn of
 
     itsBad :: Type -> NAPs -> C (Hs.Pat ())
     itsBad _ _ = genericDocError =<< "constructor `" <> prettyTCM qn <> "` not supported in patterns"
-
--- | Translate list of patterns into a Haskell n-uple pattern.
-tuplePat :: Type -> NAPs -> C (Hs.Pat ())
-tuplePat ty ps =
-  compilePats ty ps
-  <&> Hs.PTuple () Hs.Boxed
 
 -- | Translate Int.pos pattern.
 posIntPat :: Type -> NAPs -> C (Hs.Pat ())

--- a/src/Agda2Hs/Compile/Record.hs
+++ b/src/Agda2Hs/Compile/Record.hs
@@ -177,7 +177,7 @@ checkUnboxPragma def = do
   -- recRecursive can be used again after agda 2.6.4.2 is released
   -- see agda/agda#7042
   unless (all null recMutual) $ genericDocError
-    =<< text "Unboxed record" <+> prettyTCM (defName def) 
+    =<< text "Unboxed record" <+> prettyTCM (defName def)
     <+> text "cannot be recursive"
 
   TelV tel _ <- telViewUpTo recPars (defType def)

--- a/src/Agda2Hs/Compile/Type.hs
+++ b/src/Agda2Hs/Compile/Type.hs
@@ -128,7 +128,7 @@ compileType t = do
     -- TODO: we should also drop lambdas that can be erased based on their type
     -- (e.g. argument is of type Level/Size or in a Prop) but currently we do
     -- not have access to the type of the lambda here.
-    Lam argInfo restAbs 
+    Lam argInfo restAbs
       | hasQuantity0 argInfo -> underAbstraction_ restAbs compileType
       | otherwise -> genericDocError =<< text "Not supported: type-level lambda" <+> prettyTCM t
 
@@ -143,7 +143,7 @@ compileTypeArgs ty (x:xs) = do
   reportSDoc "agda2hs.compile.type" 16 $ text "compileTypeArgs x =" <+> prettyTCM x
   reportSDoc "agda2hs.compile.type" 16 $ text "                a =" <+> prettyTCM a
   reportSDoc "agda2hs.compile.type" 16 $ text "         modality =" <+> prettyTCM (getModality a)
-  let rest = compileTypeArgs (absApp b $ unArg x) xs  
+  let rest = compileTypeArgs (absApp b $ unArg x) xs
   let fail msg = genericDocError =<< (text msg <> text ":") <+> parens (prettyTCM (absName b) <+> text ":" <+> prettyTCM (unDom a))
   compileDom a >>= \case
     DODropped -> rest
@@ -200,7 +200,7 @@ compileDom a = do
   isErasable <- pure (not $ usableModality a) `or2M` canErase (unDom a)
   isClassConstraint <- pure (isInstance a) `and2M` isClassType (unDom a)
   isType <- endsInSort (unDom a)
-  return $ if 
+  return $ if
     | isErasable        -> DODropped
     | isClassConstraint -> DOInstance
     | isType            -> DOType
@@ -223,7 +223,7 @@ compileDomType x a =
       -- come from a module parameter.
       ctx <- getContextSize
       npars <- size <$> (lookupSection =<< currentModule)
-      if ctx < npars 
+      if ctx < npars
         then do
           tellExtension Hs.ScopedTypeVariables
           return $ DomForall $ Hs.UnkindedVar () $ Hs.Ident () x

--- a/src/Agda2Hs/Pragma.hs
+++ b/src/Agda2Hs/Pragma.hs
@@ -55,6 +55,7 @@ data ParsedPragma
   | UnboxPragma Strictness
   | TransparentPragma
   | NewTypePragma [Hs.Deriving ()]
+  | TuplePragma Hs.Boxed
   | DerivePragma (Maybe (Hs.DerivStrategy ()))
   deriving (Eq, Show)
 
@@ -91,6 +92,8 @@ processPragma qn = liftTCM (getUniqueCompilerPragma pragmaName qn) >>= \case
     | s == "unboxed"              -> return $ UnboxPragma Lazy
     | s == "unboxed-strict"       -> return $ UnboxPragma Strict
     | s == "transparent"          -> return TransparentPragma
+    | s == "tuple"                -> return $ TuplePragma Hs.Boxed
+    | s == "unboxed-tuple"        -> return $ TuplePragma Hs.Unboxed
     | s == newtypePragma          -> return $ NewTypePragma []
     | s == derivePragma           -> return $ DerivePragma Nothing
     | derivePragma `isPrefixOf` s -> return $ DerivePragma (parseStrategy (drop (length derivePragma + 1) s))

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -86,6 +86,7 @@ import Issue302
 import Issue309
 import Issue317
 import ErasedPatternLambda
+import CustomTuples
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -169,4 +170,5 @@ import Issue302
 import Issue309
 import Issue317
 import ErasedPatternLambda
+import CustomTuples
 #-}

--- a/test/CustomTuples.agda
+++ b/test/CustomTuples.agda
@@ -1,0 +1,50 @@
+open import Haskell.Prelude
+
+record Stuff (a : Set) : Set where
+  no-eta-equality; pattern
+  constructor stuff
+  field
+    something : Int
+    more : a
+    another : Bool
+
+{-# COMPILE AGDA2HS Stuff unboxed-tuple #-}
+
+foo : Stuff Int → Stuff Bool → Stuff Char
+foo (stuff a b c) (stuff x y z) = stuff (a + b + x) 'x' (or (c ∷ y ∷ z ∷ []))
+
+{-# COMPILE AGDA2HS foo #-}
+
+bare : Int → Char → Bool → Stuff Char
+bare = stuff
+
+{-# COMPILE AGDA2HS bare #-}
+
+section : a → Bool → Stuff a
+section = stuff 42
+
+{-# COMPILE AGDA2HS section #-}
+
+record NoStuff : Set where
+  no-eta-equality; pattern
+  constructor dontlook
+
+{-# COMPILE AGDA2HS NoStuff tuple #-}
+
+bar : NoStuff → NoStuff
+bar dontlook = dontlook
+
+{-# COMPILE AGDA2HS bar #-}
+
+-- This is legal, basically the same as an unboxed record.
+record Legal (a : Set) : Set where
+  constructor mkLegal
+  field
+    theA : a
+
+{-# COMPILE AGDA2HS Legal tuple #-}
+
+baz : Legal Int → Legal Int
+baz (mkLegal x) = mkLegal 42
+
+{-# COMPILE AGDA2HS baz #-}

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -81,4 +81,5 @@ import Issue302
 import Issue309
 import Issue317
 import ErasedPatternLambda
+import CustomTuples
 

--- a/test/golden/CustomTuples.hs
+++ b/test/golden/CustomTuples.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE UnboxedTuples, TupleSections #-}
+module CustomTuples where
+
+foo ::
+    (# Int, Int, Bool #) ->
+      (# Int, Bool, Bool #) -> (# Int, Char, Bool #)
+foo (# a, b, c #) (# x, y, z #)
+  = (# a + b + x, 'x', or [c, y, z] #)
+
+bare :: Int -> Char -> Bool -> (# Int, Char, Bool #)
+bare = (# ,, #)
+
+section :: a -> Bool -> (# Int, a, Bool #)
+section = (# 42, , #)
+
+bar :: () -> ()
+bar () = ()
+
+baz :: (Int) -> (Int)
+baz (x) = (42)
+


### PR DESCRIPTION
This PR addresses the first point in #105 by adding support for compiling an Agda record type to a Haskell tuple. The feature is designed to be pretty flexible, so you can compile any record type and `agda2hs` will just take the (compiled) field types as the tuple components. It also allows defining *unboxed* tuples, which was previously not supported by `agda2hs`. However, there are no checks in place that the [rules for unboxed tuples](https://downloads.haskell.org/~ghc/6.12.1/docs/html/users_guide/primitives.html#unboxed-tuples) are followed, so it might generate invalid Haskell code if used improperly.