### PR TITLE
Define Rezz in terms of ∃

### DIFF
--- a/test/EraseType.agda
+++ b/test/EraseType.agda
@@ -13,22 +13,22 @@ testMatch (Erased x) = Erased (x + 1)
 
 {-# COMPILE AGDA2HS testMatch #-}
 
-testRezz : Rezz Int (get testErase)
+testRezz : Rezz (get testErase)
 testRezz = rezz 42
 
 {-# COMPILE AGDA2HS testRezz #-}
 
-testRezzErase : Rezz (Erase Int) testErase
+testRezzErase : Rezz testErase
 testRezzErase = rezzErase
 
 {-# COMPILE AGDA2HS testRezzErase #-}
 
-testCong : Rezz Int (1 + get testErase)
+testCong : Rezz (1 + get testErase)
 testCong = rezzCong (1 +_) testRezz
 
 {-# COMPILE AGDA2HS testCong #-}
 
-rTail : ∀ {@0 x xs} → Rezz (List Int) (x ∷ xs) → Rezz (List Int) xs
+rTail : ∀ {@0 x xs} → Rezz {a = List Int} (x ∷ xs) → Rezz xs
 rTail = rezzTail
 
 {-# COMPILE AGDA2HS rTail #-}

--- a/test/Issue218.agda
+++ b/test/Issue218.agda
@@ -7,7 +7,7 @@ open import Haskell.Extra.Refinement
 
 module _ (@0 n : Int) where
 
-  foo : {{Rezz _ n}} → ∃ Int (_≡ n)
+  foo : {{Rezz n}} → ∃ Int (_≡ n)
   foo {{rezz n}} = n ⟨ refl ⟩
 
   {-# COMPILE AGDA2HS foo #-}


### PR DESCRIPTION
We have our own bespoke definition of `Rezz`, but actually it can be defined easily as a refinement type with `∃`. I also swapped the order of the arguments to the equality because I noticed this order is useful much more often (sorry, no backwards compatibility).