### PR TITLE
New (simpler but more robust) implementation of canonicity check

### DIFF
--- a/lib/Haskell/Prim/Foldable.agda
+++ b/lib/Haskell/Prim/Foldable.agda
@@ -88,29 +88,35 @@ open Foldable ⦃...⦄ public
 {-# COMPILE AGDA2HS Foldable existing-class #-}
 
 -- ** instances
-private
-  mkFoldable : DefaultFoldable t → Foldable t
-  mkFoldable x = record {DefaultFoldable x}
-
-  foldMap=_ : (∀ {b a} → ⦃ Monoid b ⦄ → (a → b) → t a → b) → Foldable t
-  foldMap= x = record {DefaultFoldable (record {foldMap = x})}
 instance
-  iFoldableList : Foldable List
-  iFoldableList = foldMap= foldMapList
+  iDefaultFoldableList : DefaultFoldable List
+  iDefaultFoldableList .DefaultFoldable.foldMap = foldMapList
     where
       foldMapList : ⦃ Monoid b ⦄ → (a → b) → List a → b
       foldMapList f []       = mempty
       foldMapList f (x ∷ xs) = f x <> foldMapList f xs
 
-  iFoldableMaybe : Foldable Maybe
-  iFoldableMaybe = foldMap= λ where
+  iFoldableList : Foldable List
+  iFoldableList = record {DefaultFoldable iDefaultFoldableList}
+
+  iDefaultFoldableMaybe : DefaultFoldable Maybe
+  iDefaultFoldableMaybe .DefaultFoldable.foldMap = λ where
     _ Nothing  → mempty
     f (Just x) → f x
 
-  iFoldableEither : Foldable (Either a)
-  iFoldableEither = foldMap= λ where
+  iFoldableMaybe : Foldable Maybe
+  iFoldableMaybe = record {DefaultFoldable iDefaultFoldableMaybe}
+
+  iDefaultFoldableEither : DefaultFoldable (Either a)
+  iDefaultFoldableEither .DefaultFoldable.foldMap = λ where
     _ (Left _)  → mempty
     f (Right x) → f x
 
+  iFoldableEither : Foldable (Either a)
+  iFoldableEither = record {DefaultFoldable iDefaultFoldableEither}
+
+  iDefaultFoldablePair : DefaultFoldable (a ×_)
+  iDefaultFoldablePair .DefaultFoldable.foldMap = λ f (_ , x) → f x
+
   iFoldablePair : Foldable (a ×_)
-  iFoldablePair = foldMap= λ f (_ , x) → f x
+  iFoldablePair = record {DefaultFoldable iDefaultFoldablePair}

--- a/lib/Haskell/Prim/Functor.agda
+++ b/lib/Haskell/Prim/Functor.agda
@@ -45,34 +45,45 @@ void = tt <$_
 infixl 1 _<&>_
 infixl 4 _<$>_ _$>_
 
--- ** instances
-private
-  mkFunctor : DefaultFunctor t → Functor t
-  mkFunctor x = record {DefaultFunctor x}
-
-  fmap=_ : (∀ {a b} → (a → b) → f a → f b) → Functor f
-  fmap= x = record {DefaultFunctor (record {fmap = x})}
 instance
-  iFunctorList : Functor List
-  iFunctorList = fmap= map
+  iDefaultFunctorList : DefaultFunctor List
+  iDefaultFunctorList .DefaultFunctor.fmap = map
 
-  iFunctorMaybe : Functor Maybe
-  iFunctorMaybe = fmap= λ where
+  iFunctorList : Functor List
+  iFunctorList = record{DefaultFunctor iDefaultFunctorList}
+
+  iDefaultFunctorMaybe : DefaultFunctor Maybe
+  iDefaultFunctorMaybe .DefaultFunctor.fmap = λ where
     f Nothing  → Nothing
     f (Just x) → Just (f x)
 
-  iFunctorEither : Functor (Either a)
-  iFunctorEither = fmap= λ where
+  iFunctorMaybe : Functor Maybe
+  iFunctorMaybe = record{DefaultFunctor iDefaultFunctorMaybe}
+
+  iDefaultFunctorEither : DefaultFunctor (Either a)
+  iDefaultFunctorEither .DefaultFunctor.fmap = λ where
     f (Left  x) → Left x
     f (Right y) → Right (f y)
 
+  iFunctorEither : Functor (Either a)
+  iFunctorEither = record{DefaultFunctor iDefaultFunctorEither}
+
+  iDefaultFunctorFun : DefaultFunctor (λ b → a → b)
+  iDefaultFunctorFun .DefaultFunctor.fmap = _∘_
+
   iFunctorFun : Functor (λ b → a → b)
-  iFunctorFun = fmap= _∘_
+  iFunctorFun = record{DefaultFunctor iDefaultFunctorFun}
+
+  iDefaultFunctorTuple₂ : DefaultFunctor (a ×_)
+  iDefaultFunctorTuple₂ .DefaultFunctor.fmap = λ f (x , y) → x , f y
 
   iFunctorTuple₂ : Functor (a ×_)
-  iFunctorTuple₂ = fmap= λ f (x , y) → x , f y
+  iFunctorTuple₂ = record{DefaultFunctor iDefaultFunctorTuple₂}
+
+  iDefaultFunctorTuple₃ : DefaultFunctor (a × b ×_)
+  iDefaultFunctorTuple₃ .DefaultFunctor.fmap = λ where f (x , y , z) → x , y , f z
 
   iFunctorTuple₃ : Functor (a × b ×_)
-  iFunctorTuple₃ = fmap= λ where f (x , y , z) → x , y , f z
+  iFunctorTuple₃ = record{DefaultFunctor iDefaultFunctorTuple₃}
 
 instance postulate iFunctorIO : Functor IO

--- a/lib/Haskell/Prim/Monad.agda
+++ b/lib/Haskell/Prim/Monad.agda
@@ -72,25 +72,43 @@ private
   bind=_ : ⦃ Applicative m ⦄ → (∀ {a b} → m a → (a → m b) → m b) → Monad m
   bind= x = record {DefaultMonad (record {_>>=_ = x})}
 instance
+  iDefaultMonadList : DefaultMonad List
+  iDefaultMonadList .DefaultMonad._>>=_ = flip concatMap
+
   iMonadList : Monad List
-  iMonadList = bind= flip concatMap
+  iMonadList = record {DefaultMonad iDefaultMonadList}
+
+  iDefaultMonadMaybe : DefaultMonad Maybe
+  iDefaultMonadMaybe .DefaultMonad._>>=_ = flip (maybe Nothing)
 
   iMonadMaybe : Monad Maybe
-  iMonadMaybe = bind= flip (maybe Nothing)
+  iMonadMaybe = record {DefaultMonad iDefaultMonadMaybe}
+
+  iDefaultMonadEither : DefaultMonad (Either a)
+  iDefaultMonadEither .DefaultMonad._>>=_ = flip (either Left)
 
   iMonadEither : Monad (Either a)
-  iMonadEither = bind= flip (either Left)
+  iMonadEither = record {DefaultMonad iDefaultMonadEither}
+
+  iDefaultMonadFun : DefaultMonad (λ b → a → b)
+  iDefaultMonadFun .DefaultMonad._>>=_ = λ f k r → k (f r) r
 
   iMonadFun : Monad (λ b → a → b)
-  iMonadFun = bind= λ f k r → k (f r) r
+  iMonadFun = record {DefaultMonad iDefaultMonadFun}
+
+  iDefaultMonadTuple₂ : ⦃ Monoid a ⦄ → DefaultMonad (a ×_)
+  iDefaultMonadTuple₂ .DefaultMonad._>>=_ = λ (a , x) k → first (a <>_) (k x)
 
   iMonadTuple₂ : ⦃ Monoid a ⦄ → Monad (a ×_)
-  iMonadTuple₂ = bind= λ (a , x) k → first (a <>_) (k x)
+  iMonadTuple₂ = record {DefaultMonad iDefaultMonadTuple₂}
 
-  iMonadTuple₃ : ⦃ Monoid a ⦄ → ⦃ Monoid b ⦄ → Monad (a × b ×_)
-  iMonadTuple₃ = bind= λ where
+  iDefaultMonadTuple₃ : ⦃ Monoid a ⦄ → ⦃ Monoid b ⦄ → DefaultMonad (a × b ×_)
+  iDefaultMonadTuple₃ .DefaultMonad._>>=_ = λ where
     (a , b , x) k → case k x of λ where
       (a₁ , b₁ , y) → a <> a₁ , b <> b₁ , y
+
+  iMonadTuple₃ : ⦃ Monoid a ⦄ → ⦃ Monoid b ⦄ → Monad (a × b ×_)
+  iMonadTuple₃ = record {DefaultMonad iDefaultMonadTuple₃}
 
 instance postulate iMonadIO : Monad IO
 

--- a/lib/Haskell/Prim/Monoid.agda
+++ b/lib/Haskell/Prim/Monoid.agda
@@ -70,50 +70,61 @@ record DefaultMonoid (a : Set) : Set where
 open Monoid ⦃...⦄ public
 {-# COMPILE AGDA2HS Monoid existing-class #-}
 -- ** instances
-private
-  infix 0 mempty=_
-  mempty=_ : ⦃ Semigroup a ⦄ → a → Monoid a
-  mempty= x = record {DefaultMonoid (record {mempty = x})}
-
-  mkMonoid : DefaultMonoid a → Monoid a
-  mkMonoid x = record {DefaultMonoid x}
 instance
+  iDefaultMonoidList : DefaultMonoid (List a)
+  iDefaultMonoidList .DefaultMonoid.mempty = []
+
   iMonoidList : Monoid (List a)
-  iMonoidList = mempty= []
+  iMonoidList = record{DefaultMonoid iDefaultMonoidList}
+
+  iDefaultMonoidMaybe : ⦃ Semigroup a ⦄ → DefaultMonoid (Maybe a)
+  iDefaultMonoidMaybe .DefaultMonoid.mempty = Nothing
 
   iMonoidMaybe : ⦃ Semigroup a ⦄ → Monoid (Maybe a)
-  iMonoidMaybe = mempty= Nothing
+  iMonoidMaybe = record{DefaultMonoid iDefaultMonoidMaybe}
+
+  iDefaultMonoidFun : ⦃ Monoid b ⦄ → DefaultMonoid (a → b)
+  iDefaultMonoidFun .DefaultMonoid.mempty = λ _ → mempty
 
   iMonoidFun : ⦃ Monoid b ⦄ → Monoid (a → b)
-  iMonoidFun = mempty= λ _ → mempty
+  iMonoidFun = record{DefaultMonoid iDefaultMonoidFun}
+
+  iDefaultMonoidUnit : DefaultMonoid ⊤
+  iDefaultMonoidUnit .DefaultMonoid.mempty = tt
 
   iMonoidUnit : Monoid ⊤
-  iMonoidUnit = mempty= tt
+  iMonoidUnit = record{DefaultMonoid iDefaultMonoidUnit}
+
+  iDefaultMonoidTuple₂ : ⦃ Monoid a ⦄ → ⦃ Monoid b ⦄ → DefaultMonoid (a × b)
+  iDefaultMonoidTuple₂ .DefaultMonoid.mempty = (mempty , mempty)
 
   iMonoidTuple₂ : ⦃ Monoid a ⦄ → ⦃ Monoid b ⦄ → Monoid (a × b)
-  iMonoidTuple₂ = mempty= (mempty , mempty)
+  iMonoidTuple₂ = record{DefaultMonoid iDefaultMonoidTuple₂}
+
+  iDefaultMonoidTuple₃ : ⦃ Monoid a ⦄ → ⦃ Monoid b ⦄ → ⦃ Monoid c ⦄ → DefaultMonoid (a × b × c)
+  iDefaultMonoidTuple₃ .DefaultMonoid.mempty = (mempty , mempty , mempty)
 
   iMonoidTuple₃ : ⦃ Monoid a ⦄ → ⦃ Monoid b ⦄ → ⦃ Monoid c ⦄ →  Monoid (a × b × c)
-  iMonoidTuple₃ = mempty= (mempty , mempty , mempty)
+  iMonoidTuple₃ = record{DefaultMonoid iDefaultMonoidTuple₃}
 
 open DefaultMonoid
 
 MonoidEndo : Monoid (a → a)
-MonoidEndo = mkMonoid λ where
-  .mempty → id
-  .super ._<>_ → _∘_
+MonoidEndo = record {DefaultMonoid (λ where
+      .mempty → id
+      .super ._<>_ → _∘_)}
 
 MonoidEndoᵒᵖ : Monoid (a → a)
-MonoidEndoᵒᵖ = mkMonoid λ where
+MonoidEndoᵒᵖ = record {DefaultMonoid (λ where
   .mempty      → id
-  .super ._<>_ → flip _∘_
+  .super ._<>_ → flip _∘_) }
 
 MonoidConj : Monoid Bool
-MonoidConj = mkMonoid λ where
+MonoidConj = record {DefaultMonoid (λ where
   .mempty      → True
-  .super ._<>_ → _&&_
+  .super ._<>_ → _&&_)}
 
 MonoidDisj : Monoid Bool
-MonoidDisj = mkMonoid λ where
+MonoidDisj = record {DefaultMonoid (λ where
   .mempty      → False
-  .super ._<>_ → _||_
+  .super ._<>_ → _||_)}

--- a/lib/Haskell/Prim/Show.agda
+++ b/lib/Haskell/Prim/Show.agda
@@ -70,59 +70,90 @@ shows : ⦃ Show a ⦄ → a → ShowS
 shows = showsPrec 0
 
 {-# COMPILE AGDA2HS Show existing-class #-}
+
 -- ** instances
-private
-  infix 0 showsPrec=_ show=_
-
-  showsPrec=_ : (Int → a → ShowS) → Show a
-  showsPrec=_ x = record {Show₁ (record {showsPrec = x})}
-
-  show=_ : (a → String) → Show a
-  show= x = record {Show₂ (record {show = x})}
 instance
+  iShow₂Nat : Show₂ Nat
+  iShow₂Nat .Show₂.show = primStringToList ∘ primShowNat
+
   iShowNat : Show Nat
-  iShowNat = show= (primStringToList ∘ primShowNat)
+  iShowNat = record {Show₂ iShow₂Nat}
+
+  iShow₂Integer : Show₂ Integer
+  iShow₂Integer .Show₂.show = showInteger
 
   iShowInteger : Show Integer
-  iShowInteger = show= showInteger
+  iShowInteger = record {Show₂ iShow₂Integer}
+
+  iShow₂Int : Show₂ Int
+  iShow₂Int .Show₂.show = showInt
 
   iShowInt : Show Int
-  iShowInt = show= showInt
+  iShowInt = record{Show₂ iShow₂Int}
+
+  iShow₂Word : Show₂ Word
+  iShow₂Word .Show₂.show = showWord
 
   iShowWord : Show Word
-  iShowWord = show= showWord
+  iShowWord = record{Show₂ iShow₂Word}
+
+  iShow₂Double : Show₂ Double
+  iShow₂Double .Show₂.show = primStringToList ∘ primShowFloat
 
   iShowDouble : Show Double
-  iShowDouble = show= (primStringToList ∘ primShowFloat)
+  iShowDouble = record{Show₂ iShow₂Double}
+
+  iShow₂Bool : Show₂ Bool
+  iShow₂Bool .Show₂.show = λ where False → "False"; True → "True"
 
   iShowBool : Show Bool
-  iShowBool = show= λ where False → "False"; True → "True"
+  iShowBool = record{Show₂ iShow₂Bool}
+
+  iShow₁Char : Show₁ Char
+  iShow₁Char .Show₁.showsPrec _ = showString ∘ primStringToList ∘ primShowChar
 
   iShowChar : Show Char
-  iShowChar = showsPrec= λ _ → showString ∘ primStringToList ∘ primShowChar
+  iShowChar = record{Show₁ iShow₁Char}
+
+  iShow₁List : ⦃ Show a ⦄ → Show₁ (List a)
+  iShow₁List .Show₁.showsPrec _ = showList
 
   iShowList : ⦃ Show a ⦄ → Show (List a)
-  iShowList = showsPrec= λ _ → showList
+  iShowList = record{Show₁ iShow₁List}
+
 private
   showApp₁ : ⦃ Show a ⦄ → Int → String → a → ShowS
   showApp₁ p tag x = showParen (p > 10) $
     showString tag ∘ showString " " ∘ showsPrec 11 x
+
 instance
-  iShowMaybe : ⦃ Show a ⦄ → Show (Maybe a)
-  iShowMaybe = showsPrec= λ where
+  iShow₁Maybe : ⦃ Show a ⦄ → Show₁ (Maybe a)
+  iShow₁Maybe .Show₁.showsPrec = λ where
     p Nothing  → showString "Nothing"
     p (Just x) → showApp₁ p "Just" x
 
-  iShowEither : ⦃ Show a ⦄ → ⦃ Show b ⦄ → Show (Either a b)
-  iShowEither = showsPrec= λ where
+  iShowMaybe : ⦃ Show a ⦄ → Show (Maybe a)
+  iShowMaybe = record{Show₁ iShow₁Maybe}
+
+  iShow₁Either : ⦃ Show a ⦄ → ⦃ Show b ⦄ → Show₁ (Either a b)
+  iShow₁Either .Show₁.showsPrec = λ where
     p (Left  x) → showApp₁ p "Left"  x
     p (Right y) → showApp₁ p "Right" y
 
+  iShowEither : ⦃ Show a ⦄ → ⦃ Show b ⦄ → Show (Either a b)
+  iShowEither = record{Show₁ iShow₁Either}
+
 instance
-  iShowTuple₂ : ⦃ Show a ⦄ → ⦃ Show b ⦄ → Show (a × b)
-  iShowTuple₂ = showsPrec= λ _ → λ where
+  iShow₁Tuple₂ : ⦃ Show a ⦄ → ⦃ Show b ⦄ → Show₁ (a × b)
+  iShow₁Tuple₂ .Show₁.showsPrec = λ _ → λ where
     (x , y) → showString "(" ∘ shows x ∘ showString ", " ∘ shows y ∘ showString ")"
 
-  iShowTuple₃ : ⦃ Show a ⦄ → ⦃ Show b ⦄ → ⦃ Show c ⦄ → Show (a × b × c)
-  iShowTuple₃ = showsPrec= λ _ → λ where
+  iShowTuple₂ : ⦃ Show a ⦄ → ⦃ Show b ⦄ → Show (a × b)
+  iShowTuple₂ = record{Show₁ iShow₁Tuple₂}
+
+  iShow₁Tuple₃ : ⦃ Show a ⦄ → ⦃ Show b ⦄ → ⦃ Show c ⦄ → Show₁ (a × b × c)
+  iShow₁Tuple₃ .Show₁.showsPrec = λ _ → λ where
     (x , y , z) → showString "(" ∘ shows x ∘ showString ", " ∘ shows y ∘ showString ", " ∘ shows z ∘ showString ")"
+
+  iShowTuple₃ : ⦃ Show a ⦄ → ⦃ Show b ⦄ → ⦃ Show c ⦄ → Show (a × b × c)
+  iShowTuple₃ = record{Show₁ iShow₁Tuple₃}

--- a/test/Issue301.agda
+++ b/test/Issue301.agda
@@ -27,8 +27,9 @@ instance
   MyDataSemigroup ._<>_ = _><_
 {-# COMPILE AGDA2HS MyDataSemigroup #-}
 
-myDataDefaultMonoid : DefaultMonoid (MyData a)
-DefaultMonoid.mempty myDataDefaultMonoid = Nuttin'
+instance
+  myDataDefaultMonoid : DefaultMonoid (MyData a)
+  DefaultMonoid.mempty myDataDefaultMonoid = Nuttin'
 
 instance
   MyDataMonoid : Monoid (MyData a)

--- a/test/golden/ExplicitInstance2.err
+++ b/test/golden/ExplicitInstance2.err
@@ -1,2 +1,2 @@
 test/Fail/ExplicitInstance2.agda:13,1-5
-No instance of type HasDefault Bool was found in scope.
+illegal instance:  λ { .Fail.ExplicitInstance2.theDefault → True }


### PR DESCRIPTION
This is an attempt to resolve the issue with the canonicity check that I encountered in https://github.com/agda/agda2hs/pull/350 by implementing it in a completely different way. Instead of re-inferring the instance and checking it for equality with the given one, we instead traverse the term and check that its head symbol is an instance (either a global instance `Def` or a local instance `Var`), and that all its recursive instance arguments are canonical too.

Due to the upstream issue https://github.com/agda/agda/issues/7449, this has the annoying effect that instances need to be given in a form that does not reduce unless projected, or if they reduce then the reduct should be a valid instance itself. This should not be a problem for user-written instances, but for the instances in the Prelude it means we cannot make use of most of the tricks that were there to avoid boilerplate. Instead, I just bit the bullet and made the code in it quite a bit more verbose in order to make it pass the new canonicity check.

Happy to get feedback on the general idea as well as the implementation details.