### PR TITLE
Properly differentiate between multiple anonymous modules 

### DIFF
--- a/src/Agda2Hs/Compile.hs
+++ b/src/Agda2Hs/Compile.hs
@@ -37,6 +37,7 @@ initCompileEnv tlm rewrites = CompileEnv
   , minRecordName     = Nothing
   , locals            = []
   , compilingLocal    = False
+  , whereModules      = []
   , copatternsEnabled = False
   , rewrites          = rewrites
   }

--- a/src/Agda2Hs/Compile/Function.hs
+++ b/src/Agda2Hs/Compile/Function.hs
@@ -228,14 +228,14 @@ compileClause' curModule projName x ty c@Clause{..} = do
     -- `where` declarations (if there are any) in order to drop the arguments
     -- that correspond to the pattern variables of this clause from the calls to
     -- the functions defined in the `where` block.
-    let inWhereModule = case children of
-          []    -> id
-          (c:_) -> withCurrentModule $ qnameModule c
+    -- let inWhereModule = case children of
+    --       []    -> id
+    --       (c:_) -> withCurrentModule $ qnameModule c
 
     let Just body            = clauseBody
         Just (unArg -> typ)  = clauseType
 
-    hsBody <- inWhereModule $ compileTerm typ body
+    hsBody <- compileTerm typ body
 
     let rhs = Hs.UnGuardedRhs () hsBody
         whereBinds | null whereDecls = Nothing

--- a/src/Agda2Hs/Compile/Term.hs
+++ b/src/Agda2Hs/Compile/Term.hs
@@ -168,10 +168,9 @@ compileDef f ty args =
   ifM (isInlinedFunction f) (compileInlineFunctionApp f ty args) $ do
     reportSDoc "agda2hs.compile.term" 12 $ text "Compiling application of regular function:" <+> prettyTCM f
 
-    currentMod <- currentModule
     let defMod = qnameModule f
 
-    defIsClass <- isClassModule defMod
+    minRecord <- asks minRecordName
     -- TODO: simplify this when Agda exposes where-provenance in 'Internal' syntax
     outerWhereModules <- asks whereModules
 
@@ -180,7 +179,7 @@ compileDef f ty args =
       -- if the function comes from a where-clause
       -- or is a class-method for the class we are currently defining,
       -- we drop the module parameters
-      if defMod `elem` outerWhereModules || defIsClass && (mnameToList defMod `isPrefixOf` mnameToList currentMod) then do
+      if defMod `elem` outerWhereModules || Just defMod == minRecord then do
         npars <- size <$> lookupSection defMod
         let (pars, rest) = splitAt npars args
         ty' <- piApplyM ty pars

--- a/src/Agda2Hs/Compile/Term.hs
+++ b/src/Agda2Hs/Compile/Term.hs
@@ -180,7 +180,7 @@ compileDef f ty args =
       -- if the function is called from the same module it's defined in,
       -- we drop the module parameters
       -- NOTE(flupe): in the future we're not always gonna be erasing module parameters
-      if (f `elem` localDefs || isLocal || defIsClass) && (mnameToList defMod `isPrefixOf` mnameToList currentMod) then do
+      if f `elem` localDefs || (isLocal || defIsClass) && (mnameToList defMod `isPrefixOf` mnameToList currentMod) then do
         npars <- size <$> lookupSection defMod
         let (pars, rest) = splitAt npars args
         ty' <- piApplyM ty pars

--- a/src/Agda2Hs/Compile/Term.hs
+++ b/src/Agda2Hs/Compile/Term.hs
@@ -176,7 +176,7 @@ compileDef f ty args =
       -- if the function is called from the same module it's defined in,
       -- we drop the module parameters
       -- NOTE(flupe): in the future we're not always gonna be erasing module parameters
-      if prettyShow currentMod `isPrefixOf` prettyShow defMod then do
+      if mnameToList currentMod `isPrefixOf` mnameToList defMod then do
         npars <- size <$> (lookupSection =<< currentModule)
         let (pars, rest) = splitAt npars args
         ty' <- piApplyM ty pars

--- a/src/Agda2Hs/Compile/Term.hs
+++ b/src/Agda2Hs/Compile/Term.hs
@@ -173,13 +173,13 @@ compileDef f ty args =
 
     defIsClass <- isClassModule defMod
     -- TODO: simplify this when Agda exposes where-provenance in 'Internal' syntax
-    outerWhereModules <- asks whereModules -- W
+    outerWhereModules <- asks whereModules
 
     (ty', args') <-
 
-      -- if the function is called from the same module it's defined in,
+      -- if the function comes from a where-clause
+      -- or is a class-method for the class we are currently defining,
       -- we drop the module parameters
-      -- NOTE(flupe): in the future we're not always gonna be erasing module parameters
       if defMod `elem` outerWhereModules || defIsClass && (mnameToList defMod `isPrefixOf` mnameToList currentMod) then do
         npars <- size <$> lookupSection defMod
         let (pars, rest) = splitAt npars args

--- a/src/Agda2Hs/Compile/Term.hs
+++ b/src/Agda2Hs/Compile/Term.hs
@@ -176,8 +176,8 @@ compileDef f ty args =
       -- if the function is called from the same module it's defined in,
       -- we drop the module parameters
       -- NOTE(flupe): in the future we're not always gonna be erasing module parameters
-      if mnameToList currentMod `isPrefixOf` mnameToList defMod then do
-        npars <- size <$> (lookupSection =<< currentModule)
+      if mnameToList defMod `isPrefixOf` mnameToList currentMod then do
+        npars <- size <$> lookupSection defMod
         let (pars, rest) = splitAt npars args
         ty' <- piApplyM ty pars
         pure (ty', rest)

--- a/src/Agda2Hs/Compile/Term.hs
+++ b/src/Agda2Hs/Compile/Term.hs
@@ -170,13 +170,17 @@ compileDef f ty args =
 
     currentMod <- currentModule
     let defMod = qnameModule f
+    defIsClass <- isClassModule defMod
+    -- TODO: simplify this when Agda exposes where-provenance in 'Internal' syntax
+    isLocal <- asks compilingLocal
+    localDefs <- asks locals -- If we're calling into a where-clause
 
     (ty', args') <-
 
       -- if the function is called from the same module it's defined in,
       -- we drop the module parameters
       -- NOTE(flupe): in the future we're not always gonna be erasing module parameters
-      if mnameToList defMod `isPrefixOf` mnameToList currentMod then do
+      if (f `elem` localDefs || isLocal || defIsClass) && (mnameToList defMod `isPrefixOf` mnameToList currentMod) then do
         npars <- size <$> lookupSection defMod
         let (pars, rest) = splitAt npars args
         ty' <- piApplyM ty pars

--- a/src/Agda2Hs/Compile/Term.hs
+++ b/src/Agda2Hs/Compile/Term.hs
@@ -170,17 +170,17 @@ compileDef f ty args =
 
     currentMod <- currentModule
     let defMod = qnameModule f
+
     defIsClass <- isClassModule defMod
     -- TODO: simplify this when Agda exposes where-provenance in 'Internal' syntax
-    isLocal <- asks compilingLocal
-    localDefs <- asks locals -- If we're calling into a where-clause
+    outerWhereModules <- asks whereModules -- W
 
     (ty', args') <-
 
       -- if the function is called from the same module it's defined in,
       -- we drop the module parameters
       -- NOTE(flupe): in the future we're not always gonna be erasing module parameters
-      if f `elem` localDefs || (isLocal || defIsClass) && (mnameToList defMod `isPrefixOf` mnameToList currentMod) then do
+      if defMod `elem` outerWhereModules || defIsClass && (mnameToList defMod `isPrefixOf` mnameToList currentMod) then do
         npars <- size <$> lookupSection defMod
         let (pars, rest) = splitAt npars args
         ty' <- piApplyM ty pars

--- a/src/Agda2Hs/Compile/Types.hs
+++ b/src/Agda2Hs/Compile/Types.hs
@@ -82,6 +82,8 @@ data CompileEnv = CompileEnv
   -- ^ keeps track of the current clause's where declarations
   , compilingLocal :: Bool
   -- ^ whether we are currently compiling a where clause or pattern-matching lambda
+  , whereModules :: [ModuleName]
+  -- ^ the where-blocks currently in scope. Hack until Agda adds where-prominence
   , copatternsEnabled :: Bool
   -- ^ whether copatterns should be allowed when compiling patterns
   , rewrites :: SpecialRules

--- a/src/Agda2Hs/Compile/Utils.hs
+++ b/src/Agda2Hs/Compile/Utils.hs
@@ -272,6 +272,9 @@ checkInstance u = do
 compileLocal :: C a -> C a
 compileLocal = local $ \e -> e { compilingLocal = True }
 
+addWhereModule :: ModuleName  -> C a -> C a
+addWhereModule mName = local $ \e -> e { whereModules = mName : whereModules e }
+
 modifyLCase :: (Int -> Int) -> CompileState -> CompileState
 modifyLCase f (CompileState {lcaseUsed = n}) = CompileState {lcaseUsed = f n}
 

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -85,6 +85,7 @@ import Issue305
 import Issue302
 import Issue309
 import Issue317
+import Issue353
 import ErasedPatternLambda
 import CustomTuples
 import ProjectionLike
@@ -170,6 +171,7 @@ import Issue305
 import Issue302
 import Issue309
 import Issue317
+import Issue353
 import ErasedPatternLambda
 import CustomTuples
 import ProjectionLike

--- a/test/BangPatterns.agda
+++ b/test/BangPatterns.agda
@@ -13,11 +13,11 @@ myFoldl f x0 (x ∷ xs) = myFoldl f (f x0 x) xs
 
 {-# COMPILE AGDA2HS myFoldl #-}
 
-foldl' : (b -> a -> b) -> Strict b -> List a -> b
-foldl' f (! x0) [] = x0
-foldl' f (! x0) (x ∷ xs) = foldl' f (! f x0 x) xs
+foldl'' : (b -> a -> b) -> Strict b -> List a -> b
+foldl'' f (! x0) [] = x0
+foldl'' f (! x0) (x ∷ xs) = foldl'' f (! f x0 x) xs
 
-{-# COMPILE AGDA2HS foldl' #-}
+{-# COMPILE AGDA2HS foldl'' #-}
 
 data LazyMaybe (a : Set ℓ) : Set ℓ where
   LazyNothing : LazyMaybe a

--- a/test/Issue353.agda
+++ b/test/Issue353.agda
@@ -1,0 +1,40 @@
+open import Haskell.Prelude
+
+module Issue353 where
+-- Calling functions between local anonymous modules removed arguments
+
+module FooBar (a : Bool) where
+    hello : Bool
+    hello = a
+    {-# COMPILE AGDA2HS hello #-}
+
+module Foo (a : Bool) where
+    -- If the name of the current module is a prefix of the called module
+    -- they would be interpreted as the same module
+    world : Bool
+    world = FooBar.hello a
+    {-# COMPILE AGDA2HS world #-}
+
+    open FooBar a
+    world2 : Bool
+    world2 = hello
+    {-# COMPILE AGDA2HS world2 #-}
+
+module _ (a : Bool) (b : Int) where
+    foo : Bool
+    foo = not a
+    {-# COMPILE AGDA2HS foo #-}
+
+module _ (b : Bool) where
+
+    bar : Bool
+    bar = foo True 0
+    {-# COMPILE AGDA2HS bar #-}
+
+    -- Still broken, since they are actually the same module here
+    -- would generate baz = bar in haskell
+    baz : Bool
+    baz = bar
+    -- {-# COMPILE AGDA2HS baz #-}
+
+-- The check is needed both for instance declarations and where-clauses

--- a/test/Issue353.agda
+++ b/test/Issue353.agda
@@ -35,6 +35,11 @@ module _ (b : Bool) where
     -- would generate baz = bar in haskell
     baz : Bool
     baz = bar
-    -- {-# COMPILE AGDA2HS baz #-}
+    {-# COMPILE AGDA2HS baz #-}
 
+    -- Still broken, because we cant differentiate this from where-blocks
+    callFromNested : Bool
+    callFromNested = nested
+      where nested = bar
+    -- {-# COMPILE AGDA2HS callFromNested #-}
 -- The check is needed both for instance declarations and where-clauses

--- a/test/Issue353.agda
+++ b/test/Issue353.agda
@@ -31,15 +31,13 @@ module _ (b : Bool) where
     bar = foo True 0
     {-# COMPILE AGDA2HS bar #-}
 
-    -- Still broken, since they are actually the same module here
-    -- would generate baz = bar in haskell
     baz : Bool
     baz = bar
     {-# COMPILE AGDA2HS baz #-}
 
-    -- Still broken, because we cant differentiate this from where-blocks
     callFromNested : Bool
     callFromNested = nested
       where nested = bar
-    -- {-# COMPILE AGDA2HS callFromNested #-}
+    {-# COMPILE AGDA2HS callFromNested #-}
+
 -- The check is needed both for instance declarations and where-clauses

--- a/test/Where.agda
+++ b/test/Where.agda
@@ -51,6 +51,8 @@ ex4 b = mult 42
 ex4' : Bool → Nat
 ex4' b = mult (bool2nat b)
   where
+    extra : Nat
+    extra = 14
     mult : Nat → Nat
     mult n = bump n (bool2nat b)
       where
@@ -58,7 +60,7 @@ ex4' b = mult (bool2nat b)
         bump x y = go (x * y) (n - bool2nat b)
           where
             go : Nat → Nat → Nat
-            go z w = z + x + w + y + n + bool2nat b
+            go z w = z + x + w + y + n + bool2nat b + extra
 
 -- with pattern matching and multiple clauses
 ex5 : List Nat → Nat

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -80,6 +80,7 @@ import Issue305
 import Issue302
 import Issue309
 import Issue317
+import Issue353
 import ErasedPatternLambda
 import CustomTuples
 import ProjectionLike

--- a/test/golden/BangPatterns.hs
+++ b/test/golden/BangPatterns.hs
@@ -8,9 +8,9 @@ myFoldl :: (b -> a -> b) -> b -> [a] -> b
 myFoldl f x0 [] = x0
 myFoldl f x0 (x : xs) = myFoldl f (f x0 x) xs
 
-foldl' :: (b -> a -> b) -> b -> [a] -> b
-foldl' f !x0 [] = x0
-foldl' f !x0 (x : xs) = foldl' f (f x0 x) xs
+foldl'' :: (b -> a -> b) -> b -> [a] -> b
+foldl'' f !x0 [] = x0
+foldl'' f !x0 (x : xs) = foldl'' f (f x0 x) xs
 
 data LazyMaybe a = LazyNothing
                  | LazyJust a

--- a/test/golden/Issue353.hs
+++ b/test/golden/Issue353.hs
@@ -18,3 +18,9 @@ bar b = foo True 0
 baz :: Bool -> Bool
 baz b = bar b
 
+callFromNested :: Bool -> Bool
+callFromNested b = nested
+  where
+    nested :: Bool
+    nested = bar b
+

--- a/test/golden/Issue353.hs
+++ b/test/golden/Issue353.hs
@@ -1,0 +1,17 @@
+module Issue353 where
+
+hello :: Bool -> Bool
+hello a = a
+
+world :: Bool -> Bool
+world a = hello a
+
+world2 :: Bool -> Bool
+world2 a = hello a
+
+foo :: Bool -> Int -> Bool
+foo a b = not a
+
+bar :: Bool -> Bool
+bar b = foo True 0
+

--- a/test/golden/Issue353.hs
+++ b/test/golden/Issue353.hs
@@ -15,3 +15,6 @@ foo a b = not a
 bar :: Bool -> Bool
 bar b = foo True 0
 
+baz :: Bool -> Bool
+baz b = bar b
+

--- a/test/golden/Where.hs
+++ b/test/golden/Where.hs
@@ -44,6 +44,8 @@ ex4 b = mult 42
 ex4' :: Bool -> Natural
 ex4' b = mult (bool2nat b)
   where
+    extra :: Natural
+    extra = 14
     mult :: Natural -> Natural
     mult n = bump n (bool2nat b)
       where
@@ -51,7 +53,7 @@ ex4' b = mult (bool2nat b)
         bump x y = go (x * y) (n - bool2nat b)
           where
             go :: Natural -> Natural -> Natural
-            go z w = z + x + w + y + n + bool2nat b
+            go z w = z + x + w + y + n + bool2nat b + extra
 
 ex5 :: [Natural] -> Natural
 ex5 [] = zro


### PR DESCRIPTION
<s>Partial fix for issue</s> Fixes #353.

Instead of checking if the prettyprinted qualified module name is a prefix to determine if a module is contained within another, we check if the actual list of `Name` is a prefix, which uses the internal hashes.

With this fix, calling another function within the same local module will still cause an issue, but at least calling other modules won't cause arguments to magically disappear.

I am also not completely sure if the direction of the check is correct? Wouldn't we want to skip arguments only if calling a function from a surrounding module, rather than only when calling into a submodule? The current version is mostly equivalent to an equality check, since you can't call into a where-clause from outside of it