### PR TITLE
Don't crash on parse errors in deriving clauses

### DIFF
--- a/src/Agda2Hs/HsUtils.hs
+++ b/src/Agda2Hs/HsUtils.hs
@@ -17,6 +17,8 @@ import Agda.Syntax.Position
 import Agda.Utils.FileName ( mkAbsolute )
 import Agda.Utils.List ( initLast )
 import Agda.Utils.Maybe.Strict ( toStrict )
+import System.FilePath (isAbsolute)
+import Agda.Utils.Maybe (boolToMaybe)
 
 -- Names ------------------------------------------------------------------
 
@@ -199,7 +201,7 @@ cloc (ConName l _) = l
 
 srcSpanToRange :: SrcSpan -> Range
 srcSpanToRange (SrcSpan file l1 c1 l2 c2) =
-  intervalToRange (toStrict $ Just $ mkRangeFile (mkAbsolute file) Nothing) $ Interval (pos l1 c1) (pos l2 c2)
+  intervalToRange (toStrict $ boolToMaybe (isAbsolute file) $ mkRangeFile (mkAbsolute file) Nothing) $ Interval (pos l1 c1) (pos l2 c2)
   where pos l c = Pn () 0 (fromIntegral l) (fromIntegral c)
 
 srcLocToRange :: SrcLoc -> Range

--- a/test/AllFailTests.agda
+++ b/test/AllFailTests.agda
@@ -39,3 +39,4 @@ import Fail.NonCanonicalSuperclass
 import Fail.Issue125
 import Fail.Issue357a
 import Fail.Issue357b
+import Fail.DerivingParseFailure

--- a/test/Fail/DerivingParseFailure.agda
+++ b/test/Fail/DerivingParseFailure.agda
@@ -1,0 +1,6 @@
+module Fail.DerivingParseFailure where
+
+record Example : Set where
+{-# COMPILE AGDA2HS Example deriving !& #-}
+-- {-# COMPILE AGDA2HS Example deriving Show via Foo #-}
+-- {-# COMPILE AGDA2HS Example deriving (Show, Eq, Ord) class #-}

--- a/test/golden/DerivingParseFailure.err
+++ b/test/golden/DerivingParseFailure.err
@@ -1,0 +1,2 @@
+test/Fail/DerivingParseFailure.agda:4,1-44
+Parse error: !&


### PR DESCRIPTION
It turns out that if you don't specify a file-name, then the Haskell parser [haskell-src-exts uses the filename `<unknown>.hs`](https://hackage.haskell.org/package/haskell-src-exts-1.23.1/docs/src/Language.Haskell.Exts.ParseMonad.html#defaultParseMode),
which we afterwards try to parse as an absolute filepath to extract the location of the error, which causes a crash.

Since the location from the Haskell parser wouldn't be accurate anyways, we change it to just report the entire pragma as the location of the error.

This PR also makes the code for converting Haskell locations into Agda locations return `Nothing` for the filename, instead of crashing if there is no valid filename in the error. This might not be desired since we should be able to provide a more helpful filename and location and this could make it easier to miss the issues with bad error reporting. That change currently has no impact, since this PR also prevents it from triggering.

Fixes #351