### PR TITLE
Update version bounds in agda2hs.cabal

### DIFF
--- a/agda2hs.cabal
+++ b/agda2hs.cabal
@@ -75,7 +75,7 @@ executable agda2hs
                        text                 >= 2.0.2   && < 2.2,
                        deepseq              >= 1.4.4   && < 1.6,
                        yaml                 >= 0.11    && < 0.12,
-                       aeson                >= 2.2     && < 2.3,
+                       aeson                >= 2.0.3   && < 2.3,
   default-language:    Haskell2010
   default-extensions:  LambdaCase
                        RecordWildCards


### PR DESCRIPTION
Experimentally, I managed to install `agda2hs` with aeson 2.0.3.0 and GHC 8.8.4 (the oldest version currently supported by `agda2hs`). Versions of aeson before 2.0 do not seem to build easily and anyway increasing the bound to cross major versions might not be such a good idea, so I think this is a decent compromise.