### PR TITLE
Add support for GHC 9.10.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]   # macOS-latest, windows-latest
-        cabal: [3.8]
-        ghc: [8.8.4, 8.10.7, 9.2.5, 9.4.3, 9.6.3]
+        cabal: [3.10.3]
+        ghc: [9.4.8, 9.6.6, 9.8.2, 9.10.1]
     steps:
     - uses: actions/checkout@v3
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'

--- a/agda2hs.cabal
+++ b/agda2hs.cabal
@@ -60,7 +60,7 @@ executable agda2hs
                        AgdaInternals,
                        Paths_agda2hs
   autogen-modules:     Paths_agda2hs
-  build-depends:       base                 >= 4.13    && < 4.20,
+  build-depends:       base                 >= 4.13    && < 4.21,
                        Agda                 >= 2.7.0   && < 2.8.0,
                        bytestring           >= 0.11.5  && < 0.13,
                        containers           >= 0.6     && < 0.8,

--- a/src/Agda2Hs/Compile.hs
+++ b/src/Agda2Hs/Compile.hs
@@ -14,6 +14,8 @@ import Agda.Syntax.TopLevelModuleName ( TopLevelModuleName )
 import Agda.Syntax.Common.Pretty ( prettyShow )
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Monad.Signature ( isInlineFun )
+import Agda.Utils.Impossible
+import Agda.Utils.List
 import Agda.Utils.Null
 import Agda.Utils.Monad ( whenM, anyM, when )
 
@@ -131,5 +133,5 @@ verifyOutput _ _ _ m ls = do
               Hs.RecDecl _ n _ -> n
           duplicateCons = filter ((> 1) . length) . group . sort  $ allCons
       when (length duplicateCons > 0) $
-        genericDocError =<< vcat (map (\x -> text $ "Cannot generate multiple constructors with the same identifier: " <> Hs.prettyPrint (head x)) duplicateCons)
+        genericDocError =<< vcat (map (\x -> text $ "Cannot generate multiple constructors with the same identifier: " <> Hs.prettyPrint (headWithDefault __IMPOSSIBLE__ x)) duplicateCons)
       return (length duplicateCons == 0)


### PR DESCRIPTION
This adds support for GHC 9.10.2, and drops support for older versions of GHC (< 9.4.8) from CI to avoid having too many different CI runs.