### PR TITLE
[ fix #373 ] enable existing-class on postulated type formers

### DIFF
--- a/src/Agda2Hs/Compile/Utils.hs
+++ b/src/Agda2Hs/Compile/Utils.hs
@@ -173,6 +173,7 @@ isClassName q = getConstInfo' q >>= \case
       ClassPragma _       -> True
       ExistingClassPragma -> True
       _                   -> False
+  Right Defn{defName = r, theDef = Axiom{}} -> processPragma r <&> (ExistingClassPragma ==)
   _                       -> return False
 
 -- | Check if the given type corresponds to a class constraint in Haskell.

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -92,6 +92,7 @@ import CustomTuples
 import ProjectionLike
 import FunCon
 import Issue308
+import Issue373
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -181,4 +182,5 @@ import CustomTuples
 import ProjectionLike
 import FunCon
 import Issue308
+import Issue373
 #-}

--- a/test/Issue373.agda
+++ b/test/Issue373.agda
@@ -1,0 +1,21 @@
+module Issue373 where
+
+open import Haskell.Prelude
+
+{-# FOREIGN AGDA2HS
+
+class MyShow a where
+  myshow :: a -> String
+
+#-}
+
+postulate
+  MyShow : Set → Set
+  myshow : {{ MyShow a }} → a → String
+
+{-# COMPILE AGDA2HS MyShow existing-class #-}
+
+anothershow : {{ MyShow a }} → a → String
+anothershow = myshow
+
+{-# COMPILE AGDA2HS anothershow #-}

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -87,4 +87,5 @@ import CustomTuples
 import ProjectionLike
 import FunCon
 import Issue308
+import Issue373
 

--- a/test/golden/Issue373.hs
+++ b/test/golden/Issue373.hs
@@ -1,0 +1,8 @@
+module Issue373 where
+
+class MyShow a where
+  myshow :: a -> String
+
+anothershow :: MyShow a => a -> String
+anothershow = myshow
+


### PR DESCRIPTION
This should fix [the problem highlighted here](https://github.com/agda/agda2hs/issues/366#issuecomment-2385463366).

We may want to add an additional check so that only postulates with the right type signatures can use `existing-class` (i.e proper type former, no class constraints).