### PR TITLE
Fix #324: Keep track of instance-only imports

### DIFF
--- a/src/Agda2Hs/Compile/ClassInstance.hs
+++ b/src/Agda2Hs/Compile/ClassInstance.hs
@@ -36,6 +36,7 @@ import Agda.Utils.Impossible ( __IMPOSSIBLE__ )
 import Agda2Hs.AgdaUtils
 import Agda2Hs.Compile.Function
 import Agda2Hs.Compile.Name
+import Agda2Hs.Compile.Term
 import Agda2Hs.Compile.Type
 import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Utils

--- a/src/Agda2Hs/Compile/ClassInstance.hs
+++ b/src/Agda2Hs/Compile/ClassInstance.hs
@@ -65,7 +65,7 @@ compileInstance :: InstanceTarget -> Definition -> C (Hs.Decl ())
 
 compileInstance (ToDerivation strategy) def@Defn{..} =
   setCurrentRangeQ defName $ do
-    reportSDoc "agda2hs.compile.instance" 13 $ 
+    reportSDoc "agda2hs.compile.instance" 13 $
       text "compiling instance" <+> prettyTCM defName <+> text "to standalone deriving"
     tellExtension Hs.StandaloneDeriving
     enableStrategy strategy
@@ -74,7 +74,7 @@ compileInstance (ToDerivation strategy) def@Defn{..} =
 
 compileInstance ToDefinition def@Defn{..} =
   enableCopatterns $ setCurrentRangeQ defName $ do
-    reportSDoc "agda2hs.compile.instance" 13 $ 
+    reportSDoc "agda2hs.compile.instance" 13 $
       text "compiling instance" <+> prettyTCM defName <+> text "to instance definition"
     ir <- compileInstRule [] (unEl defType)
     withFunctionLocals defName $ do
@@ -181,7 +181,7 @@ compileInstanceClause' curModule ty (p:ps) c
   -- reached record projection
   | ProjP _ q <- namedArg p = do
 
-    -- we put back the remaining patterns in the original clause 
+    -- we put back the remaining patterns in the original clause
     let c' = c {namedClausePats = ps}
 
     -- We want the actual field name, not the instance-opened projection.
@@ -198,9 +198,9 @@ compileInstanceClause' curModule ty (p:ps) c
     -- retrieve the type of the projection
     Just (unEl -> Pi a b) <- getDefType q ty
     -- We don't really have the information available to reconstruct the instance
-    -- head. However, all dependencies on the instance head are in erased positions, 
+    -- head. However, all dependencies on the instance head are in erased positions,
     -- so we can just use a dummy term instead
-    let instanceHead = __DUMMY_TERM__ 
+    let instanceHead = __DUMMY_TERM__
         ty' = b `absApp` instanceHead
 
     reportSDoc "agda2hs.compile.instance" 15 $
@@ -245,7 +245,7 @@ compileInstanceClause' curModule ty (p:ps) c
           text $ "raw name: " ++ prettyShow (Def n [])
         d@Defn{..} <- getConstInfo n
         let mod = if isExtendedLambdaName defName then curModule else qnameModule defName
-        (fc, rs) <- withCurrentModule mod $ 
+        (fc, rs) <- withCurrentModule mod $
           concatUnzip <$> mapM (compileInstanceClause mod defType) (funClauses theDef)
         let hd = hsName $ prettyShow $ nameConcrete $ qnameName defName
         let fc' = {- dropPatterns 1 $ -} replaceName hd uf fc

--- a/src/Agda2Hs/Compile/Imports.hs
+++ b/src/Agda2Hs/Compile/Imports.hs
@@ -25,7 +25,7 @@ type ImportDeclMap = Map (Hs.ModuleName (), Qualifier) ImportSpecMap
 
 compileImports :: String -> Imports -> TCM [Hs.ImportDecl ()]
 compileImports top is0 = do
-  let is = filter (not . (top `isPrefixOf`) . Hs.prettyPrint . importModule) is0
+  let is = filter (not . (top ==) . Hs.prettyPrint . importModule) is0
   checkClashingImports is
   let imps = Map.toList $ groupModules is
   return $ map (uncurry $ uncurry makeImportDecl) imps

--- a/src/Agda2Hs/Compile/Name.hs
+++ b/src/Agda2Hs/Compile/Name.hs
@@ -230,3 +230,10 @@ compileModuleName m = do
     text "Top-level module name for" <+> prettyTCM m <+>
     text "is" <+> text (pp tlm)
   return tlm
+
+importInstance :: QName -> C ()
+importInstance f = do
+  mod <- compileModuleName $ qnameModule f
+  unless (isPrimModule mod) $ do
+    reportSLn "agda2hs.import" 20 $ "Importing instances from " ++ pp mod
+    tellImport $ ImportInstances mod

--- a/src/Agda2Hs/Compile/Types.hs
+++ b/src/Agda2Hs/Compile/Types.hs
@@ -108,15 +108,20 @@ qualifiedAs = join
 
 -- | Encoding of a Haskell module import statement.
 data Import = Import
-  { importModule    :: Hs.ModuleName ()
-  , importQualified :: Qualifier
-  , importParent    :: Maybe (Hs.Name ())
-  , importName      :: Hs.Name ()
-  , importNamespace :: Hs.Namespace ()
+  { _importModule    :: Hs.ModuleName ()
+  , _importQualified :: Qualifier
+  , _importParent    :: Maybe (Hs.Name ())
+  , _importName      :: Hs.Name ()
+  , _importNamespace :: Hs.Namespace ()
                     -- ^^ if this is a type or something like that, we can add a namespace qualifier to the import spec
                     -- now it's only useful for differentiating type operators; so for others we always put Hs.NoNamespace () here
                     -- (we don't calculate it if it's not necessary)
   }
+  | ImportInstances (Hs.ModuleName ())
+
+importModule :: Import -> Hs.ModuleName ()
+importModule (Import{ _importModule = mod }) = mod
+importModule (ImportInstances mod) = mod
 
 type Imports = [Import]
 

--- a/src/Agda2Hs/Compile/Utils.hs
+++ b/src/Agda2Hs/Compile/Utils.hs
@@ -7,6 +7,7 @@ import Control.Monad.Reader
 import Control.Monad.Writer ( tell )
 import Control.Monad.State ( put, modify )
 
+import Data.List ( isPrefixOf )
 import Data.Maybe ( isJust )
 import qualified Data.Map as M
 import Data.List ( isPrefixOf )

--- a/src/Agda2Hs/Render.hs
+++ b/src/Agda2Hs/Render.hs
@@ -104,7 +104,7 @@ prettyShowImportDecl (Hs.ImportDecl _ m qual src safe mbPkg mbName mbSpecs) =
                 ++ parenList (map prettyShowSpec ispecs)
 
       parenList :: [String] -> String
-      parenList [] = ""
+      parenList [] = "()"
       parenList (x:xs) = '(' : (x ++ go xs)
         where
           go :: [String] -> String

--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -92,6 +92,7 @@ import CustomTuples
 import ProjectionLike
 import FunCon
 import Issue308
+import Issue324
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -181,4 +182,5 @@ import CustomTuples
 import ProjectionLike
 import FunCon
 import Issue308
+import Issue324
 #-}

--- a/test/Issue324.agda
+++ b/test/Issue324.agda
@@ -1,0 +1,8 @@
+
+open import Haskell.Prelude
+open import Issue324instance
+
+test : Bool
+test = not == id
+
+{-# COMPILE AGDA2HS test #-}

--- a/test/Issue324instance.agda
+++ b/test/Issue324instance.agda
@@ -1,0 +1,9 @@
+
+open import Haskell.Prelude
+
+instance
+  eqBoolFun : Eq (Bool → Bool)
+  eqBoolFun ._==_ x y = x True == y True && x False == y False
+
+{-# COMPILE AGDA2HS eqBoolFun #-}
+

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -87,4 +87,5 @@ import CustomTuples
 import ProjectionLike
 import FunCon
 import Issue308
+import Issue324
 

--- a/test/golden/Issue324.hs
+++ b/test/golden/Issue324.hs
@@ -1,0 +1,7 @@
+module Issue324 where
+
+import Issue324instance ()
+
+test :: Bool
+test = not == id
+

--- a/test/golden/Issue324instance.hs
+++ b/test/golden/Issue324instance.hs
@@ -1,0 +1,5 @@
+module Issue324instance where
+
+instance Eq (Bool -> Bool) where
+    x == y = x True == y True && x False == y False
+

--- a/test/golden/QualifiedImports.hs
+++ b/test/golden/QualifiedImports.hs
@@ -1,6 +1,7 @@
 module QualifiedImports where
 
 import qualified Importee (Foo(MkFoo), foo)
+import QualifiedImportee ()
 import qualified QualifiedImportee as Qually (Foo, Fooable(defaultFoo, doTheFoo), foo, (!#))
 
 -- ** simple qualification

--- a/test/golden/RequalifiedImports.hs
+++ b/test/golden/RequalifiedImports.hs
@@ -1,6 +1,7 @@
 module RequalifiedImports where
 
 import OtherImportee (OtherFoo(MkFoo))
+import QualifiedImportee ()
 import qualified QualifiedImportee as A (Foo, Fooable(defaultFoo, doTheFoo), foo, (!#))
 
 -- ** conflicting imports are all replaced with the "smallest" qualifier


### PR DESCRIPTION
This fixes #324 by keeping track of instances that should be imported from other modules, and generating an empty import list if necessary.

One minor aesthetic problem is that if you have a qualified imports and you also use instances from that module, there will be two imports: one qualified one and one instance-only (unqualified) one. This could probably be fixed too by a smarter way of merging imports, but it doesn't affect correctness so I'm leaving it as-is for now.