### PR TITLE
Additions to `Haskell.Law.Bool`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Haskell
 _build
 dist
 dist-newstyle
@@ -6,6 +7,9 @@ html/
 docs/build/
 *.hi
 *.o
+
+# Agda
+*.agdai
 
 # For nix users
 .direnv/**

--- a/lib/Haskell/Law/Bool.agda
+++ b/lib/Haskell/Law/Bool.agda
@@ -43,6 +43,143 @@ prop-x-||-False False = refl
 
 {-----------------------------------------------------------------------------
     Properties
+    Boolean algebra
+    https://en.wikipedia.org/wiki/Boolean_algebra_(structure)
+------------------------------------------------------------------------------}
+--
+prop-||-idem
+  : ∀ (a : Bool)
+  → (a || a) ≡ a
+--
+prop-||-idem False = refl
+prop-||-idem True = refl
+
+--
+prop-||-assoc
+  : ∀ (a b c : Bool)
+  → ((a || b) || c) ≡ (a || (b || c))
+--
+prop-||-assoc False b c = refl
+prop-||-assoc True b c = refl
+
+--
+prop-||-sym
+  : ∀ (a b : Bool)
+  → (a || b) ≡ (b || a)
+--
+prop-||-sym False False = refl
+prop-||-sym False True = refl
+prop-||-sym True False = refl
+prop-||-sym True True = refl
+
+--
+prop-||-absorb
+  : ∀ (a b : Bool)
+  → (a || (a && b)) ≡ a
+--
+prop-||-absorb False b = refl
+prop-||-absorb True b = refl
+
+--
+prop-||-identity
+  : ∀ (a : Bool)
+  → (a || False) ≡ a
+--
+prop-||-identity False = refl
+prop-||-identity True = refl
+
+--
+prop-||-&&-distribute
+  : ∀ (a b c : Bool)
+  → (a || (b && c)) ≡ ((a || b) && (a || c))
+--
+prop-||-&&-distribute False b c = refl
+prop-||-&&-distribute True b c = refl
+
+--
+prop-||-complement
+  : ∀ (a : Bool)
+  → (a || not a) ≡ True
+--
+prop-||-complement False = refl
+prop-||-complement True = refl
+
+--
+prop-&&-idem
+  : ∀ (a : Bool)
+  → (a && a) ≡ a
+--
+prop-&&-idem False = refl
+prop-&&-idem True = refl
+
+--
+prop-&&-assoc
+  : ∀ (a b c : Bool)
+  → ((a && b) && c) ≡ (a && (b && c))
+--
+prop-&&-assoc False b c = refl
+prop-&&-assoc True b c = refl
+
+--
+prop-&&-sym
+  : ∀ (a b : Bool)
+  → (a && b) ≡ (b && a)
+--
+prop-&&-sym False False = refl
+prop-&&-sym False True = refl
+prop-&&-sym True False = refl
+prop-&&-sym True True = refl
+
+--
+prop-&&-absorb
+  : ∀ (a b : Bool)
+  → (a && (a || b)) ≡ a
+--
+prop-&&-absorb False b = refl
+prop-&&-absorb True b = refl
+
+--
+prop-&&-identity
+  : ∀ (a : Bool)
+  → (a && True) ≡ a
+--
+prop-&&-identity False = refl
+prop-&&-identity True = refl
+
+--
+prop-&&-||-distribute
+  : ∀ (a b c : Bool)
+  → (a && (b || c)) ≡ ((a && b) || (a && c))
+--
+prop-&&-||-distribute False b c = refl
+prop-&&-||-distribute True b c = refl
+
+--
+prop-&&-complement
+  : ∀ (a : Bool)
+  → (a && not a) ≡ False
+--
+prop-&&-complement False = refl
+prop-&&-complement True = refl
+
+--
+prop-deMorgan-not-&&
+  : ∀ (a b : Bool)
+  → not (a && b) ≡ (not a || not b)
+--
+prop-deMorgan-not-&& False b = refl
+prop-deMorgan-not-&& True b = refl
+
+--
+prop-deMorgan-not-||
+  : ∀ (a b : Bool)
+  → not (a || b) ≡ (not a && not b)
+--
+prop-deMorgan-not-|| False b = refl
+prop-deMorgan-not-|| True b = refl
+
+{-----------------------------------------------------------------------------
+    Properties
     Other
 ------------------------------------------------------------------------------}
 

--- a/lib/Haskell/Law/Bool.agda
+++ b/lib/Haskell/Law/Bool.agda
@@ -5,6 +5,47 @@ open import Haskell.Prim.Bool
 
 open import Haskell.Law.Equality
 
+{-----------------------------------------------------------------------------
+    Properties
+    Logical operations and constants
+------------------------------------------------------------------------------}
+--
+prop-x-&&-True
+  : ∀ (x : Bool)
+  → (x && True) ≡ x
+--
+prop-x-&&-True True = refl
+prop-x-&&-True False = refl
+
+--
+prop-x-&&-False
+  : ∀ (x : Bool)
+  → (x && False) ≡ False
+--
+prop-x-&&-False True = refl
+prop-x-&&-False False = refl
+
+--
+prop-x-||-True
+  : ∀ (x : Bool)
+  → (x || True) ≡ True
+--
+prop-x-||-True True = refl
+prop-x-||-True False = refl
+
+--
+prop-x-||-False
+  : ∀ (x : Bool)
+  → (x || False) ≡ x
+--
+prop-x-||-False True = refl
+prop-x-||-False False = refl
+
+{-----------------------------------------------------------------------------
+    Properties
+    Other
+------------------------------------------------------------------------------}
+
 --------------------------------------------------
 -- &&
 


### PR DESCRIPTION
This pull request adds additional properties to `Haskell.Law.Bool`.

This pull request tries to be systematic about these additions:

* Content:
  * We add properties for logical operations `||` and `&&` that inspect the second argument, e.g. `(x || True) ≡ True`. These properties currently cannot be reached by computation, i.e. while `(True || x)` reduces to `x`, the expression `(x || True)` does not reduce further.
  * We add properties from the definition of [Boolean Algebra](https://en.wikipedia.org/wiki/Boolean_algebra_(structure)).
* Style
  * Each property begins with `--` and intersperses `--` for visual separation between type ("interesting") and implementation ("don't care").
  * Each property puts the quantified variables on one line, and the conclusion on a separate line. This is also meant to help readability.
  * Each property is prefixed with `prop-`. Agda makes no distinction between programs and proofs, but when proving properties about Haskell programs, I find it conceptually helpful to distinguish target language (Haskell) from metalanguage (Agda), and `prop-` is a very clear visual separator.
    * When typing `prop-` into my editor (VSCodium), I get suggestions for completion, and these are now filtered to be metalanguage proofs rather than target programs.
    * The `prop_` prefix is a convention used by [QuickCheck](https://hackage.haskell.org/package/QuickCheck-2.15.0.1/docs/Test-QuickCheck.html#v:quickCheckAll). Using `prop-` in Agda2hs allows me to generate Haddock documentation like this: <img width="509" alt="Screenshot 2025-01-20 at 15 56 19" src="https://github.com/user-attachments/assets/0af309a4-fd93-4f06-8782-545da6ee7e76" />
    * More generally, when writing larger programs, we will eventually face the problem of discovering properties — Hoogle for `prop-`? I think that this prefix helps as well.

The content of these additions is highly useful for an axiomatization of `Data.Set` that I would like to contribute in a later pull request.

However, the main purpose of this pull request is to test maintainer opinions regarding the `prop-` prefix style, and the other style choices.

(In order to preserve backward-compatibility, I have chosen to not remove any now-redundant properties such as `&&-sym`. This can be done is a separate pull request if desired.)