### PR TITLE
Fix nix-shell and test it on CI

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -43,4 +43,5 @@ jobs:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v22
     - uses: DeterminateSystems/magic-nix-cache-action@v2
-    - run: nix develop -Lv -c bash -c "cabal build"
+    # for some reason this doesn't work without update, even though it doesn't download anything
+    - run: nix develop -Lv -c bash -c "cabal update; cabal v1-build"

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -12,6 +12,8 @@ on:
       - 'agda2hs.cabal'
       - 'cabal.project'
       - 'Makefile'
+      - 'flake.*'
+      - 'nix/*'
       - '.github/workflows/**.yml'
     branches: [master]
 
@@ -33,3 +35,12 @@ jobs:
     - uses: cachix/install-nix-action@v22
     - uses: DeterminateSystems/magic-nix-cache-action@v2
     - run: nix build .#${{ matrix.derivation }} --print-build-logs
+
+  nix-shell:
+    name: "Test building inside a nix shell"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v22
+    - uses: DeterminateSystems/magic-nix-cache-action@v2
+    - run: nix develop -Lv -c bash -c "cabal build"

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -6,15 +6,15 @@ let
   lib = import ./lib.nix { inherit pkgs; };
   version = "1.3";
   agdalib = pkgs.agdaPackages.mkDerivation {
-      pname = "agda2hs";
-      meta = { };
-      version = version;
-      preBuild = ''
-        echo "{-# OPTIONS --sized-types #-}" > Everything.agda
-        echo "module Everything where" >> Everything.agda
-        find lib -name '*.agda' | sed -e 's/lib\///;s/\//./g;s/\.agda$//;s/^/import /' >> Everything.agda
-      '';
-      src = ../.;
+    pname = "agda2hs";
+    meta = { };
+    version = version;
+    preBuild = ''
+      echo "{-# OPTIONS --sized-types #-}" > Everything.agda
+      echo "module Everything where" >> Everything.agda
+      find lib -name '*.agda' | sed -e 's/lib\///;s/\//./g;s/\.agda$//;s/^/import /' >> Everything.agda
+    '';
+    src = ../.;
   };
 in
 {

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -3,11 +3,24 @@
   agda2hs-hs ? (import ./lib.nix { inherit pkgs; }).agda2hs-hs,
 }:
 pkgs.haskellPackages.shellFor {
+  # This doesn't result in a shell where you can use cabal (v2-)build,
+  # due to build-tool-depends in Agda's .cabal file, so for now only v1-build works
+  # Making cabal re-install alex and happy from Hackage can work,
+  # which will be done if the user runs `cabal update` and `cabal build`.
+  # relevant issues listed in:
+  # https://gist.github.com/ScottFreeCode/ef9f254e2dd91544bba4a068852fc81f
+  # main ones are:
+  # https://github.com/haskell/cabal/issues/8434
+  # https://github.com/NixOS/nixpkgs/issues/130556
+  # https://github.com/NixOS/nixpkgs/issues/176887
   packages = p: [ agda2hs-hs ];
-  buildInputs = with pkgs.haskellPackages; [
+  nativeBuildInputs = with pkgs.haskellPackages; [
+    # related to haskell
     cabal-install
-    cabal2nix
     haskell-language-server
+    # general goodies
     pkgs.agda
+    pkgs.nixfmt-rfc-style
+    cabal2nix
   ];
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,4 +1,7 @@
-{ pkgs, agda2hs-hs }:
+{
+  pkgs ? import <nixpkgs> { },
+  agda2hs-hs ? (import ./lib.nix { inherit pkgs; }).agda2hs-hs,
+}:
 pkgs.haskellPackages.shellFor {
   packages = p: [ agda2hs-hs ];
   buildInputs = with pkgs.haskellPackages; [


### PR DESCRIPTION
It's now possible to drop into a development shell without flakes, by running `cd nix; nix-shell`.
The CI now also has a run where agda2hs is built in the shell.