### PR TITLE
Minor: Fix libaries typo in introduction.md doc file

### DIFF
--- a/docs/source/introduction.md
+++ b/docs/source/introduction.md
@@ -28,7 +28,7 @@ Once installed, the agda2hs prelude bundled with agda2hs
 can be registered in the Agda config using the `agda2hs locate` command:
 
 ```sh
-agda2hs locate >> ~/.agda/libaries
+agda2hs locate >> ~/.agda/libraries
 ```
 
 Optionally, the agda2hs prelude can also be added as a default global import:


### PR DESCRIPTION
The documentation in introduction.md has instructions for installing using cabal, where the second line says to use the command

```
agda2hs locate >> ~/.agda/libaries
```

The word libraries is misspelled which for new users could be pretty annoying subtle bug to catch after the fact.