### PR TITLE
Add `containers-lib` to nix flake `packages`

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -24,12 +24,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        derivation: [agda2hs, base-lib]
+        derivation: [agda2hs, base-lib, containers-lib]
         include:
           - pretty: "Compile agda2hs"
             derivation: agda2hs
           - pretty: "Typecheck with Agda"
             derivation: base-lib
+          - pretty: "Typecheck with Agda"
+            derivation: containers-lib
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v22

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -5,10 +5,11 @@
 let
   lib = import ./lib.nix { inherit pkgs; };
   version = "1.3";
+
   base-lib = pkgs.agdaPackages.mkDerivation {
     pname = "base";
     meta = { };
-    version = version;
+    version = "4.18";
     preBuild = ''
       echo "{-# OPTIONS --sized-types #-}" > Everything.agda
       echo "module Everything where" >> Everything.agda
@@ -19,5 +20,5 @@ let
 in
 {
   inherit (lib) agda2hs;
-  base-lib = base-lib;
+  inherit base-lib;
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -17,8 +17,17 @@ let
     '';
     src = ../lib/base;
   };
+
+  containers-lib = pkgs.agdaPackages.mkDerivation {
+    pname = "containers";
+    meta = { };
+    version = "0.8";
+    buildInputs = [ base-lib ];
+    everythingFile = "./agda/containers.agda";
+    src = ../lib/containers;
+  };
 in
 {
   inherit (lib) agda2hs;
-  inherit base-lib;
+  inherit base-lib containers-lib;
 }


### PR DESCRIPTION
This pull request adds an attribute `containers-lib` to the `packages` output in `flake.nix`. In this way, users can provision the `containers-lib` using Nix.

This is an addendum to #406 to make `containers.agda-lib` useable with Nix.

Note: This pull request also changes the version of the `base-lib` attribute to match the version `4.18` of the `base` package on Hackage.