### PR TITLE
Reorganize Monad laws, prove Applicative laws

### DIFF
--- a/lib/base/Haskell/Law/Applicative/FromMonad.agda
+++ b/lib/base/Haskell/Law/Applicative/FromMonad.agda
@@ -1,0 +1,129 @@
+module Haskell.Law.Applicative.FromMonad where
+
+open import Haskell.Prim
+
+open import Haskell.Prim.Applicative
+open import Haskell.Prim.Functor
+open import Haskell.Prim.Monad
+
+open import Haskell.Law.Applicative.Def
+open import Haskell.Law.Monad.Def as Monad
+open import Haskell.Law.Equality
+open import Haskell.Law.Functor
+open import Haskell.Law.Functor.FromMonad
+
+-------------------------------------------------------------------------------
+-- Prove the Applicative laws from the Monad laws
+
+--
+prop-PreLawfulMonad→IsLawfulApplicative
+  : ∀ ⦃ _ : Monad m ⦄ ⦃ _ : PreLawfulMonad m ⦄
+  → IsLawfulApplicative m
+--
+prop-PreLawfulMonad→IsLawfulApplicative {m} = record
+    { super = prop-PreLawfulMonad→IsLawfulFunctor
+    ; identity = midentity
+    ; composition = mcomposition
+    ; homomorphism = mhomomorphism
+    ; interchange = minterchange
+    ; functor = mfunctor
+    }
+  where
+    midentity : ∀ {a} (ma : m a) → (pure id <*> ma) ≡ ma
+    midentity {a} ma
+      rewrite def-pure-return (id {a})
+      | def-<*>->>= (return id) ma
+      = begin
+        return id >>= (λ f → ma >>= (λ x → return (f x)))
+      ≡⟨ Monad.leftIdentity _ _ ⟩
+        ma >>= (λ x → return (id x))
+      ≡⟨ Monad.rightIdentity _ ⟩
+        ma
+      ∎
+
+    mfunctor : ∀ {a b} (f : a → b) (u : m a) → fmap f u ≡ (pure f <*> u)
+    mfunctor f u = begin
+        fmap f u
+      ≡⟨ Monad.def-fmap->>= _ _ ⟩
+        (do x ← u; return (f x))
+      ≡⟨ sym (Monad.leftIdentity _ _) ⟩
+        (do f' ← return f; x ← u; return (f' x))
+      ≡⟨ cong (λ o → o >>= _) (sym (def-pure-return _)) ⟩
+        (do f' ← pure f; x ← u; return (f' x))
+      ≡⟨ sym (def-<*>->>= _ _) ⟩
+        pure f <*> u
+      ∎
+
+    mcomposition
+      : ∀ {a b c} (u : m (b → c)) (v : m (a → b)) (w : m a)
+      → (pure _∘_ <*> u <*> v <*> w) ≡ (u <*> (v <*> w))
+    mcomposition u v w
+      = begin
+        pure _∘_ <*> u <*> v <*> w
+      ≡⟨ cong (λ o → o <*> u <*> v <*> w) (def-pure-return _∘_) ⟩
+        return _∘_ <*> u <*> v <*> w
+      ≡⟨ cong (λ o → o <*> v <*> w) (def-<*>->>= _ _ ) ⟩
+        (do comp ← return _∘_; g ← u; return (comp g)) <*> v <*> w
+      ≡⟨ cong (λ o → o <*> v <*> w) (Monad.leftIdentity _ _) ⟩
+        (do g ← u; return (_∘_ g)) <*> v <*> w
+      ≡⟨ cong (λ o → o <*> w) (def-<*>->>= _ _ ) ⟩
+        (do g' ← (do g ← u; return (_∘_ g)); f ← v; return (g' f)) <*> w
+      ≡⟨ cong (λ o → o <*> w) (sym (Monad.associativity u _ _)) ⟩
+        (do g ← u; g' ← return (_∘_ g); f ← v; return (g' f)) <*> w
+      ≡⟨ cong (λ o → o <*> w) (cong-monad u (λ g → Monad.leftIdentity _ _)) ⟩
+        (do g ← u; f ← v; return (g ∘ f)) <*> w
+      ≡⟨ def-<*>->>= _ _ ⟩
+        (do gf ← (do g ← u; f ← v; return (g ∘ f)); x ← w; return (gf x))
+      ≡⟨ sym (Monad.associativity u _ _) ⟩
+        (do g ← u; gf ← (do f ← v; return (g ∘ f)); x ← w; return (gf x))
+      ≡⟨ cong-monad u (λ g → sym (Monad.associativity v _ _)) ⟩
+        (do g ← u; do f ← v; gf ← return (g ∘ f); x ← w; return (gf x))
+      ≡⟨ cong-monad u (λ g → cong-monad v (λ f → Monad.leftIdentity _ _)) ⟩
+        (do g ← u; f ← v; x ← w; return (g (f x)))
+      ≡⟨ cong-monad u (λ g → cong-monad v λ f → cong-monad w (λ x → sym (Monad.leftIdentity _ _))) ⟩
+        (do g ← u; f ← v; x ← w; y ← return (f x); return (g y))
+      ≡⟨ cong-monad u (λ g → cong-monad v λ x → Monad.associativity _ _ _) ⟩
+        (do g ← u; f ← v; y ← (do x ← w; return (f x)); return (g y))
+      ≡⟨ cong-monad u (λ g → Monad.associativity _ _ _) ⟩
+        (do g ← u; y ← (do f ← v; x ← w; return (f x)); return (g y))
+      ≡⟨ sym (def-<*>->>= _ _) ⟩
+        u <*> (do f ← v; x ← w; return (f x))
+      ≡⟨ cong (λ o → u <*> o) (sym (def-<*>->>= _ _)) ⟩
+        u <*> (v <*> w)
+      ∎
+
+    mhomomorphism
+      : ∀ {a b} (f : a → b) (x : a)
+      → (pure {m} f <*> pure x) ≡ pure (f x)
+    mhomomorphism f x = begin
+        pure {m} f <*> pure x
+      ≡⟨ cong₂ (_<*>_) (def-pure-return f) (def-pure-return x) ⟩
+        return {m} f <*> return x
+      ≡⟨ def-<*>->>= _ _ ⟩
+        (do f' ← return f; x' ← return x; return (f' x'))
+      ≡⟨ Monad.leftIdentity _ _ ⟩
+        (do x' ← return x; return (f x'))
+      ≡⟨ Monad.leftIdentity _ _ ⟩
+        return (f x)
+      ≡⟨ sym (def-pure-return _) ⟩
+        pure (f x)
+      ∎
+
+    minterchange
+      : ∀ {a b} (u : m (a → b)) (y : a)
+      → (u <*> pure y) ≡ (pure (_$ y) <*> u)
+    minterchange u y = begin
+        u <*> pure y
+      ≡⟨ cong (u <*>_) (def-pure-return _) ⟩
+        u <*> return y
+      ≡⟨ def-<*>->>= _ _ ⟩
+        (do f ← u; y' ← return y; return (f y'))
+      ≡⟨ cong-monad u (λ f → Monad.leftIdentity y _) ⟩
+        (do f ← u; return (f y))
+      ≡⟨ sym (Monad.leftIdentity _ _) ⟩
+        (do y'' ← return (_$ y); f ← u; return (y'' f))
+      ≡⟨ sym (def-<*>->>= _ _) ⟩
+        return (_$ y) <*> u
+      ≡⟨ sym (cong (_<*> u) (def-pure-return _)) ⟩
+        pure (_$ y) <*> u
+      ∎

--- a/lib/base/Haskell/Law/Extensionality.agda
+++ b/lib/base/Haskell/Law/Extensionality.agda
@@ -1,0 +1,12 @@
+module Haskell.Law.Extensionality where
+
+open import Haskell.Prim
+
+-------------------------------------------------------------------------------
+-- Axiom: Functions are equal if they agree on all arguments.
+--
+-- This axiom is sometimes needed for proving properties of higher-order
+-- functions, such as 'filter', 'fmap', or '(>>=)'.
+
+postulate
+  ext : ∀ {f g : a → b} → (∀ x → f x ≡ g x) → f ≡ g

--- a/lib/base/Haskell/Law/Functor/FromMonad.agda
+++ b/lib/base/Haskell/Law/Functor/FromMonad.agda
@@ -1,0 +1,33 @@
+module Haskell.Law.Functor.FromMonad where
+
+open import Haskell.Prim
+
+open import Haskell.Prim.Functor
+open import Haskell.Prim.Monad
+
+open import Haskell.Law.Monad.Def as Monad
+open import Haskell.Law.Equality
+open import Haskell.Law.Functor
+
+-------------------------------------------------------------------------------
+-- Prove the Functor laws from the Monad laws
+
+--
+prop-PreLawfulMonad→IsLawfulFunctor
+  : ∀ ⦃ _ : Monad m ⦄ ⦃ _ : PreLawfulMonad m ⦄
+  → IsLawfulFunctor m
+--
+prop-PreLawfulMonad→IsLawfulFunctor .identity fa
+  rewrite Monad.def-fmap->>= id fa
+  = Monad.rightIdentity fa
+prop-PreLawfulMonad→IsLawfulFunctor .composition fa f g
+  rewrite Monad.def-fmap->>= g (fmap f fa)
+  | Monad.def-fmap->>= f fa
+  | Monad.def-fmap->>= (g ∘ f) fa
+  = begin
+    fa >>= (return ∘ g ∘ f)
+  ≡⟨ cong-monad fa (λ x → sym (Monad.leftIdentity (f x) _)) ⟩
+    fa >>= (λ x → return (f x) >>= (return ∘ g))
+  ≡⟨ Monad.associativity _ _ _ ⟩
+    (fa >>= (return ∘ f)) >>= (return ∘ g)
+  ∎

--- a/lib/base/Haskell/Law/Monad/Either.agda
+++ b/lib/base/Haskell/Law/Monad/Either.agda
@@ -10,25 +10,22 @@ open import Haskell.Law.Monad.Def
 open import Haskell.Law.Applicative.Either
 
 instance
-  iLawfulMonadEither : IsLawfulMonad (Either a)
-  iLawfulMonadEither .leftIdentity _ _ = refl
+  iPreLawfulMonadEither : PreLawfulMonad (Either a)
+  iPreLawfulMonadEither = λ where
+    .leftIdentity _ _ → refl
+    .rightIdentity (Left  x) → refl
+    .rightIdentity (Right x) → refl
+    .associativity (Left  x) _ _ → refl
+    .associativity (Right x) _ _ → refl
+    .def->>->>= _ _ → refl
+    .def-pure-return _ → refl
+    .def-fmap->>= _ → λ where
+      (Left  x) → refl
+      (Right x) → refl
+    .def-<*>->>= → λ where
+      (Left  _) _ → refl
+      (Right _) (Left  _) → refl
+      (Right _) (Right _) → refl
 
-  iLawfulMonadEither .rightIdentity = λ { (Left _) → refl; (Right _) → refl }
-
-  iLawfulMonadEither .associativity = λ { (Left _) _ _ → refl; (Right _) _ _ → refl }
-
-  iLawfulMonadEither .pureIsReturn _ = refl
-
-  iLawfulMonadEither .sequence2bind =
-    λ { (Left _)  _         → refl
-      ; (Right _) (Left _)  → refl
-      ; (Right _) (Right _) → refl
-      }
-
-  iLawfulMonadEither .fmap2bind = λ { _ (Left _) → refl; _ (Right _) → refl }
-
-  iLawfulMonadEither .rSequence2rBind =
-    λ { (Left _)  _         → refl
-      ; (Right _) (Left _)  → refl
-      ; (Right _) (Right _) → refl
-      }
+  iIsLawfulMonadEither : IsLawfulMonad (Either a)
+  iIsLawfulMonadEither = record {}

--- a/lib/base/Haskell/Law/Monad/IO.agda
+++ b/lib/base/Haskell/Law/Monad/IO.agda
@@ -7,6 +7,11 @@ open import Haskell.Prim.Monad
 
 open import Haskell.Law.Monad.Def
 
-open import Haskell.Law.Applicative.IO
+open import Haskell.Law.Applicative.IO using (iLawfulApplicativeIO)
 
-instance postulate iLawfulMonadIO : IsLawfulMonad IO
+instance
+  postulate
+    iPreLawfulMonadIO : PreLawfulMonad IO
+
+  iIsLawfulMonadIO : IsLawfulMonad IO
+  iIsLawfulMonadIO = record { applicative = iLawfulApplicativeIO }

--- a/lib/base/Haskell/Law/Monad/List.agda
+++ b/lib/base/Haskell/Law/Monad/List.agda
@@ -11,38 +11,33 @@ open import Haskell.Law.List
 open import Haskell.Law.Applicative.List
 
 instance
-  iLawfulMonadList :  IsLawfulMonad List
-  iLawfulMonadList .leftIdentity a k 
-    rewrite ++-[] (k a)
+  iPreLawfulMonadList : PreLawfulMonad List
+  iPreLawfulMonadList .leftIdentity _ _ = ++-[] _
+
+  iPreLawfulMonadList .rightIdentity [] = refl
+  iPreLawfulMonadList .rightIdentity (x ∷ xs)
+    rewrite iPreLawfulMonadList .PreLawfulMonad.rightIdentity xs
     = refl
 
-  iLawfulMonadList .rightIdentity [] = refl
-  iLawfulMonadList .rightIdentity (_ ∷ xs)
-    rewrite rightIdentity xs
-    = refl
-
-  iLawfulMonadList .associativity [] f g = refl
-  iLawfulMonadList .associativity (x ∷ xs) f g
+  iPreLawfulMonadList .associativity []       f g = refl
+  iPreLawfulMonadList .associativity (x ∷ xs) f g
     rewrite associativity xs f g
-      | concatMap-++-distr (f x) (xs >>= f) g
-    = refl  
-
-  iLawfulMonadList .pureIsReturn _ = refl
-
-  iLawfulMonadList .sequence2bind [] _ = refl
-  iLawfulMonadList .sequence2bind (f ∷ fs) xs 
-    rewrite sequence2bind fs xs
-      | map-concatMap f xs
+    | concatMap-++-distr (f x) (xs >>= f) g
     = refl
 
-  iLawfulMonadList .fmap2bind f [] = refl
-  iLawfulMonadList .fmap2bind f (_ ∷ xs)
-    rewrite fmap2bind f xs
+  iPreLawfulMonadList .def->>->>= _ _ = refl
+  iPreLawfulMonadList .def-pure-return _ = refl
+
+  iPreLawfulMonadList .def-fmap->>= _ [] = refl
+  iPreLawfulMonadList .def-fmap->>= f (x ∷ xs)
+    rewrite iPreLawfulMonadList .PreLawfulMonad.def-fmap->>= f xs
     = refl
 
-  iLawfulMonadList .rSequence2rBind [] mb = refl
-  iLawfulMonadList .rSequence2rBind (x ∷ ma) mb
-    rewrite rSequence2rBind ma mb 
-      | map-id mb 
+  iPreLawfulMonadList .def-<*>->>= []       xs = refl
+  iPreLawfulMonadList .def-<*>->>= (f ∷ fs) xs
+    rewrite iPreLawfulMonadList .PreLawfulMonad.def-<*>->>= fs xs
+    | map-concatMap f xs
     = refl
 
+  iIsLawfulMonadList : IsLawfulMonad List
+  iIsLawfulMonadList = record {}

--- a/lib/base/Haskell/Law/Monad/Maybe.agda
+++ b/lib/base/Haskell/Law/Monad/Maybe.agda
@@ -10,26 +10,26 @@ open import Haskell.Law.Monad.Def
 open import Haskell.Law.Applicative.Maybe
 
 instance
-  iLawfulMonadMaybe : IsLawfulMonad Maybe
-  iLawfulMonadMaybe .leftIdentity _ _ = refl
+  iPreLawfulMonadMaybe : PreLawfulMonad Maybe
+  iPreLawfulMonadMaybe = λ where
+    .leftIdentity _ _ → refl
+    .rightIdentity → λ where
+      Nothing  → refl
+      (Just _) → refl
+    .associativity → λ where
+      Nothing  _ _ → refl
+      (Just _) _ _ → refl
 
-  iLawfulMonadMaybe .rightIdentity = λ { Nothing → refl; (Just _) → refl }
+    .def->>->>= _ _ → refl
+    .def-pure-return _ → refl
 
-  iLawfulMonadMaybe .associativity = λ { Nothing _ _ → refl; (Just _) _ _ → refl }
+    .def-fmap->>= _ → λ where
+      Nothing → refl
+      (Just _) → refl
+    .def-<*>->>= → λ where
+      Nothing  _        → refl
+      (Just _) Nothing  → refl
+      (Just _) (Just _) → refl
 
-  iLawfulMonadMaybe .pureIsReturn _ = refl
-
-  iLawfulMonadMaybe .sequence2bind =
-    λ { Nothing  _        → refl
-      ; (Just _) Nothing  → refl
-      ; (Just _) (Just _) → refl
-      }
-
-  iLawfulMonadMaybe .fmap2bind = λ { _ Nothing → refl; _ (Just _) → refl }
-
-  iLawfulMonadMaybe .rSequence2rBind =
-    λ { Nothing  _        → refl
-      ; (Just _) Nothing  → refl
-      ; (Just _) (Just _) → refl
-      }
-
+  iIsLawfulMonadMaybe : IsLawfulMonad Maybe
+  iIsLawfulMonadMaybe = record {}


### PR DESCRIPTION
This pull request reorganizes the `IsLawfulMonad` class.

The main reason for this reorganization is that `IsLawfulFunctor` and `IsLawfulApplicative` are actually consequences of `MonadLaws` and `IsDefaultMonad`. However, this fact is difficult to use in the old definition as the other two classes are used as superclasses.

Context: #411

### Comments

While not in the scope of this pull request, possible future reorganizations are:

1. Drop the `IsLawfulApplicative` superclass from `IsLawfulMonad` and make it a global consequence instead, i.e. add a global `instance _ : {{IsLawfulMonad m}} → IsLawfulApplicative m`.

    This has the slight drawback that the existing instance of `IsLawfulApplicative` need to be removed while making sure that `Haskell.Law.Applicative` re-exports the global instance. Then again, the `IsLawfulMonad` instance is the easiest way to prove `IsLawfulApplicative`, and in the spirit of proof-irrelevance, we don't actually care how we have proven `IsLawfulMonad`.

2. Merge the `IsDefaultMonad` class into the `Monad` class.

    Reason: In Haskell, it is traditional to expect the `Monad` constraint to imply the laws mentioned in the documentation. For usage sites, this means that `Monad` is sufficient, the `IsLawfulMonad` constraint is conceptually implied by the `Monad` class. This conceptual model works until we actually have to formalize proofs, at which point we want to develop proofs incrementally. For incremental development of proofs, the separation between "implementation" (`Monad`) and "properties" (`IsLawfulMonad`) is very useful, but I would argue that this case rarely happens specifically for the `Monad` class, where instances are seldomly defined by library users. (In contrast, `Eq` and `Ord` are frequently defined by library users for their own data types, and the separation of `IsLawfulEq` and `IsLawfulOrd` is more valueable.)

    As a first step towards conceptual unification, I would propose to merge `IsDefaultMonad` into the `Monad` class, as the equality to the default implementations is uncontroversial.

5. Merge the `IsLawfulMonad` class into the `Monad` class. Same reasoning as in 2., but more extreme.