### PR TITLE
Neaten `Agda2Hs.Render`

### DIFF
--- a/agda2hs.cabal
+++ b/agda2hs.cabal
@@ -45,6 +45,7 @@ executable agda2hs
                        Agda2Hs.Compile.Utils,
                        Agda2Hs.Compile.Var,
                        Agda2Hs.Config,
+                       Agda2Hs.Language.Haskell,
                        Agda2Hs.HsUtils,
                        Agda2Hs.Pragma,
                        Agda2Hs.Render,

--- a/agda2hs.cabal
+++ b/agda2hs.cabal
@@ -46,6 +46,7 @@ executable agda2hs
                        Agda2Hs.Compile.Var,
                        Agda2Hs.Config,
                        Agda2Hs.Language.Haskell,
+                       Agda2Hs.Language.Haskell.Pretty,
                        Agda2Hs.Language.Haskell.Utils,
                        Agda2Hs.Pragma,
                        Agda2Hs.Render,

--- a/agda2hs.cabal
+++ b/agda2hs.cabal
@@ -46,7 +46,7 @@ executable agda2hs
                        Agda2Hs.Compile.Var,
                        Agda2Hs.Config,
                        Agda2Hs.Language.Haskell,
-                       Agda2Hs.HsUtils,
+                       Agda2Hs.Language.Haskell.Utils,
                        Agda2Hs.Pragma,
                        Agda2Hs.Render,
                        AgdaInternals,

--- a/src/Agda2Hs/Compile.hs
+++ b/src/Agda2Hs/Compile.hs
@@ -31,10 +31,7 @@ import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Utils
 import Agda2Hs.Pragma
 
-import qualified Language.Haskell.Exts.Extension as Hs
-import qualified Language.Haskell.Exts.Syntax as Hs
-import qualified Language.Haskell.Exts.Pretty as Hs
-
+import qualified Agda2Hs.Language.Haskell as Hs
 
 initCompileEnv :: TopLevelModuleName -> SpecialRules -> CompileEnv
 initCompileEnv tlm rewrites = CompileEnv

--- a/src/Agda2Hs/Compile.hs
+++ b/src/Agda2Hs/Compile.hs
@@ -21,8 +21,6 @@ import Agda.Utils.List
 import Agda.Utils.Null
 import Agda.Utils.Monad ( whenM, anyM, when, unless )
 
-import qualified Language.Haskell.Exts.Extension as Hs
-
 import Agda2Hs.Compile.ClassInstance ( compileInstance )
 import Agda2Hs.Compile.Data ( compileData )
 import Agda2Hs.Compile.Function ( compileFun, checkTransparentPragma, checkInlinePragma )
@@ -32,6 +30,8 @@ import Agda2Hs.Compile.Record ( compileRecord, checkUnboxPragma )
 import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Utils
 import Agda2Hs.Pragma
+
+import qualified Language.Haskell.Exts.Extension as Hs
 import qualified Language.Haskell.Exts.Syntax as Hs
 import qualified Language.Haskell.Exts.Pretty as Hs
 

--- a/src/Agda2Hs/Compile/ClassInstance.hs
+++ b/src/Agda2Hs/Compile/ClassInstance.hs
@@ -40,7 +40,7 @@ import Agda2Hs.Compile.Term
 import Agda2Hs.Compile.Type
 import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Utils
-import Agda2Hs.HsUtils
+import Agda2Hs.Language.Haskell.Utils
 
 
 enableCopatterns :: C a -> C a

--- a/src/Agda2Hs/Compile/ClassInstance.hs
+++ b/src/Agda2Hs/Compile/ClassInstance.hs
@@ -8,9 +8,6 @@ import Data.List ( nub )
 import Data.Maybe ( isNothing, mapMaybe )
 import qualified Data.HashMap.Strict as HMap
 
-import qualified Language.Haskell.Exts.Extension as Hs
-import qualified Language.Haskell.Exts.Syntax as Hs
-
 import Agda.Compiler.Backend
 import Agda.Compiler.Common ( curDefs, sortDefs )
 
@@ -40,8 +37,9 @@ import Agda2Hs.Compile.Term
 import Agda2Hs.Compile.Type
 import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Utils
-import Agda2Hs.Language.Haskell.Utils
 
+import qualified Agda2Hs.Language.Haskell as Hs
+import Agda2Hs.Language.Haskell.Utils ( hsName, pp, replaceName, unQual )
 
 enableCopatterns :: C a -> C a
 enableCopatterns = local $ \e -> e { copatternsEnabled = True }

--- a/src/Agda2Hs/Compile/ClassInstance.hs
+++ b/src/Agda2Hs/Compile/ClassInstance.hs
@@ -8,8 +8,8 @@ import Data.List ( nub )
 import Data.Maybe ( isNothing, mapMaybe )
 import qualified Data.HashMap.Strict as HMap
 
-import qualified Language.Haskell.Exts as Hs
-import Language.Haskell.Exts.Extension as Hs
+import qualified Language.Haskell.Exts.Extension as Hs
+import qualified Language.Haskell.Exts.Syntax as Hs
 
 import Agda.Compiler.Backend
 import Agda.Compiler.Common ( curDefs, sortDefs )

--- a/src/Agda2Hs/Compile/Data.hs
+++ b/src/Agda2Hs/Compile/Data.hs
@@ -1,7 +1,5 @@
 module Agda2Hs.Compile.Data where
 
-import qualified Language.Haskell.Exts.Syntax as Hs
-
 import Control.Monad ( when )
 import Agda.Compiler.Backend
 import Agda.Syntax.Common
@@ -18,7 +16,9 @@ import Agda.Utils.Impossible ( __IMPOSSIBLE__ )
 import Agda2Hs.Compile.Type ( compileDomType, compileTeleBinds )
 import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Utils
-import Agda2Hs.Language.Haskell.Utils
+
+import qualified Agda2Hs.Language.Haskell as Hs
+import Agda2Hs.Language.Haskell.Utils ( hsName )
 
 checkNewtype :: Hs.Name () -> [Hs.QualConDecl ()] -> C ()
 checkNewtype name cs = do

--- a/src/Agda2Hs/Compile/Data.hs
+++ b/src/Agda2Hs/Compile/Data.hs
@@ -18,7 +18,7 @@ import Agda.Utils.Impossible ( __IMPOSSIBLE__ )
 import Agda2Hs.Compile.Type ( compileDomType, compileTeleBinds )
 import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Utils
-import Agda2Hs.HsUtils
+import Agda2Hs.Language.Haskell.Utils
 
 checkNewtype :: Hs.Name () -> [Hs.QualConDecl ()] -> C ()
 checkNewtype name cs = do

--- a/src/Agda2Hs/Compile/Function.hs
+++ b/src/Agda2Hs/Compile/Function.hs
@@ -10,7 +10,9 @@ import Data.List
 import Data.Maybe ( fromMaybe, isJust )
 import qualified Data.Text as Text
 
-import qualified Language.Haskell.Exts as Hs
+import qualified Language.Haskell.Exts.Build as Hs (charP)
+import qualified Language.Haskell.Exts.Syntax as Hs
+import qualified Language.Haskell.Exts.Pretty as Hs
 
 import Agda.Compiler.Backend
 import Agda.Compiler.Common

--- a/src/Agda2Hs/Compile/Function.hs
+++ b/src/Agda2Hs/Compile/Function.hs
@@ -10,10 +10,6 @@ import Data.List
 import Data.Maybe ( fromMaybe, isJust )
 import qualified Data.Text as Text
 
-import qualified Language.Haskell.Exts.Build as Hs (charP)
-import qualified Language.Haskell.Exts.Syntax as Hs
-import qualified Language.Haskell.Exts.Pretty as Hs
-
 import Agda.Compiler.Backend
 import Agda.Compiler.Common
 
@@ -48,8 +44,10 @@ import Agda2Hs.Compile.TypeDefinition ( compileTypeDef )
 import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Utils
 import Agda2Hs.Compile.Var ( compileDBVar )
-import Agda2Hs.Language.Haskell.Utils
 
+import qualified Agda2Hs.Language.Haskell as Hs
+import Agda2Hs.Language.Haskell.Utils
+  ( Strictness, hsName, pApp, patToExp, constrainType, qualifyType )
 
 -- | Compilation rules for specific constructors in patterns.
 isSpecialCon :: QName -> Maybe (Type -> NAPs -> C (Hs.Pat ()))

--- a/src/Agda2Hs/Compile/Function.hs
+++ b/src/Agda2Hs/Compile/Function.hs
@@ -48,7 +48,7 @@ import Agda2Hs.Compile.TypeDefinition ( compileTypeDef )
 import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Utils
 import Agda2Hs.Compile.Var ( compileDBVar )
-import Agda2Hs.HsUtils
+import Agda2Hs.Language.Haskell.Utils
 
 
 -- | Compilation rules for specific constructors in patterns.

--- a/src/Agda2Hs/Compile/Function.hs-boot
+++ b/src/Agda2Hs/Compile/Function.hs-boot
@@ -1,6 +1,6 @@
 module Agda2Hs.Compile.Function where
 
-import qualified Language.Haskell.Exts.Syntax as Hs ( Match, Name )
+import qualified Agda2Hs.Language.Haskell as Hs ( Match, Name )
 import Agda.Syntax.Internal ( Clause, ModuleName, QName, Type )
 import Agda2Hs.Compile.Types ( C )
 

--- a/src/Agda2Hs/Compile/Imports.hs
+++ b/src/Agda2Hs/Compile/Imports.hs
@@ -2,13 +2,14 @@ module Agda2Hs.Compile.Imports ( compileImports, preludeImportDecl ) where
 
 import Data.Char ( isUpper )
 import Data.List ( isPrefixOf )
+import qualified Data.List as L
 import Data.Map ( Map )
 import qualified Data.Map as Map
 import Data.Set ( Set )
 import qualified Data.Set as Set
 
-import qualified Language.Haskell.Exts.Pretty as Hs
-import qualified Language.Haskell.Exts.Syntax as Hs
+import qualified Agda2Hs.Language.Haskell as Hs
+import Agda2Hs.Language.Haskell.Utils ( validVarId, validConId, pp )
 
 import Agda.Compiler.Backend
 import Agda.TypeChecking.Pretty ( text )
@@ -18,8 +19,6 @@ import Agda2Hs.AgdaUtils
 import Agda2Hs.Compile.Name
 import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Utils
-import Agda2Hs.Language.Haskell.Utils
-import qualified Data.List as L
 
 type ImportSpecMap = Map NamespacedName (Set NamespacedName)
 type ImportDeclMap = Map (Hs.ModuleName (), Qualifier) ImportSpecMap

--- a/src/Agda2Hs/Compile/Imports.hs
+++ b/src/Agda2Hs/Compile/Imports.hs
@@ -18,7 +18,7 @@ import Agda2Hs.AgdaUtils
 import Agda2Hs.Compile.Name
 import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Utils
-import Agda2Hs.HsUtils
+import Agda2Hs.Language.Haskell.Utils
 import qualified Data.List as L
 
 type ImportSpecMap = Map NamespacedName (Set NamespacedName)

--- a/src/Agda2Hs/Compile/Imports.hs
+++ b/src/Agda2Hs/Compile/Imports.hs
@@ -7,7 +7,8 @@ import qualified Data.Map as Map
 import Data.Set ( Set )
 import qualified Data.Set as Set
 
-import qualified Language.Haskell.Exts as Hs
+import qualified Language.Haskell.Exts.Pretty as Hs
+import qualified Language.Haskell.Exts.Syntax as Hs
 
 import Agda.Compiler.Backend
 import Agda.TypeChecking.Pretty ( text )

--- a/src/Agda2Hs/Compile/Name.hs
+++ b/src/Agda2Hs/Compile/Name.hs
@@ -41,7 +41,7 @@ import Agda.Utils.Monad ( orM, whenM )
 import Agda2Hs.AgdaUtils
 import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Utils
-import Agda2Hs.HsUtils
+import Agda2Hs.Language.Haskell.Utils
 
 
 isSpecialCon :: QName -> Maybe (Hs.QName ())

--- a/src/Agda2Hs/Compile/Name.hs
+++ b/src/Agda2Hs/Compile/Name.hs
@@ -34,9 +34,8 @@ import Agda.TypeChecking.Records ( isRecordConstructor )
 import Agda.TypeChecking.Warnings ( warning )
 
 import qualified Agda.Utils.List1 as List1
-import Agda.Utils.Monad
 import Agda.Utils.Maybe ( isJust, isNothing, whenJust, fromMaybe, caseMaybeM )
-import Agda.Utils.Monad ( whenM )
+import Agda.Utils.Monad ( orM, whenM )
 
 import Agda2Hs.AgdaUtils
 import Agda2Hs.Compile.Types

--- a/src/Agda2Hs/Compile/Name.hs
+++ b/src/Agda2Hs/Compile/Name.hs
@@ -12,9 +12,6 @@ import Data.List ( intercalate, isPrefixOf, stripPrefix )
 import Data.Text ( unpack )
 import qualified Data.Map.Strict as Map
 
-import qualified Language.Haskell.Exts.Pretty as Hs
-import qualified Language.Haskell.Exts.Syntax as Hs
-
 import Agda.Compiler.Backend hiding ( topLevelModuleName )
 import Agda.Compiler.Common ( topLevelModuleName )
 
@@ -41,7 +38,9 @@ import Agda.Utils.Monad ( orM, whenM )
 import Agda2Hs.AgdaUtils
 import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Utils
-import Agda2Hs.Language.Haskell.Utils
+
+import qualified Agda2Hs.Language.Haskell as Hs
+import Agda2Hs.Language.Haskell.Utils ( hsName, hsModuleName, pp )
 
 
 isSpecialCon :: QName -> Maybe (Hs.QName ())

--- a/src/Agda2Hs/Compile/Name.hs
+++ b/src/Agda2Hs/Compile/Name.hs
@@ -12,7 +12,8 @@ import Data.List ( intercalate, isPrefixOf, stripPrefix )
 import Data.Text ( unpack )
 import qualified Data.Map.Strict as Map
 
-import qualified Language.Haskell.Exts as Hs
+import qualified Language.Haskell.Exts.Pretty as Hs
+import qualified Language.Haskell.Exts.Syntax as Hs
 
 import Agda.Compiler.Backend hiding ( topLevelModuleName )
 import Agda.Compiler.Common ( topLevelModuleName )

--- a/src/Agda2Hs/Compile/Postulate.hs
+++ b/src/Agda2Hs/Compile/Postulate.hs
@@ -10,7 +10,7 @@ import Agda.Syntax.Common.Pretty ( prettyShow )
 import Agda2Hs.Compile.Type ( compileType )
 import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Utils
-import Agda2Hs.HsUtils
+import Agda2Hs.Language.Haskell.Utils
 
 compilePostulate :: Definition -> C [Hs.Decl ()]
 compilePostulate def = do

--- a/src/Agda2Hs/Compile/Postulate.hs
+++ b/src/Agda2Hs/Compile/Postulate.hs
@@ -1,7 +1,5 @@
 module Agda2Hs.Compile.Postulate where
 
-import qualified Language.Haskell.Exts.Syntax as Hs
-
 import Agda.Compiler.Backend
 
 import Agda.Syntax.Internal
@@ -10,7 +8,9 @@ import Agda.Syntax.Common.Pretty ( prettyShow )
 import Agda2Hs.Compile.Type ( compileType )
 import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Utils
-import Agda2Hs.Language.Haskell.Utils
+
+import qualified Agda2Hs.Language.Haskell as Hs
+import Agda2Hs.Language.Haskell.Utils ( hsName, pp, hsError ) 
 
 compilePostulate :: Definition -> C [Hs.Decl ()]
 compilePostulate def = do

--- a/src/Agda2Hs/Compile/Record.hs
+++ b/src/Agda2Hs/Compile/Record.hs
@@ -30,7 +30,7 @@ import Agda2Hs.Compile.Function ( compileFun )
 import Agda2Hs.Compile.Type ( compileDomType, compileTeleBinds, compileDom, DomOutput(..) )
 import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Utils
-import Agda2Hs.HsUtils
+import Agda2Hs.Language.Haskell.Utils
 
 -- | Primitive fields and default implementations
 type MinRecord = ([Hs.Name ()], Map (Hs.Name ()) (Hs.Decl ()))

--- a/src/Agda2Hs/Compile/Record.hs
+++ b/src/Agda2Hs/Compile/Record.hs
@@ -8,7 +8,8 @@ import Data.List.NonEmpty ( NonEmpty(..) )
 import Data.Map ( Map )
 import qualified Data.Map as Map
 
-import qualified Language.Haskell.Exts as Hs
+import qualified Language.Haskell.Exts.Pretty as Hs
+import qualified Language.Haskell.Exts.Syntax as Hs
 
 import Agda.Compiler.Backend
 

--- a/src/Agda2Hs/Compile/Record.hs
+++ b/src/Agda2Hs/Compile/Record.hs
@@ -8,9 +8,6 @@ import Data.List.NonEmpty ( NonEmpty(..) )
 import Data.Map ( Map )
 import qualified Data.Map as Map
 
-import qualified Language.Haskell.Exts.Pretty as Hs
-import qualified Language.Haskell.Exts.Syntax as Hs
-
 import Agda.Compiler.Backend
 
 import Agda.Syntax.Common ( Arg(unArg), defaultArg )
@@ -30,7 +27,9 @@ import Agda2Hs.Compile.Function ( compileFun )
 import Agda2Hs.Compile.Type ( compileDomType, compileTeleBinds, compileDom, DomOutput(..) )
 import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Utils
-import Agda2Hs.Language.Haskell.Utils
+
+import qualified Agda2Hs.Language.Haskell as Hs
+import Agda2Hs.Language.Haskell.Utils ( hsName, definedName, pp )
 
 -- | Primitive fields and default implementations
 type MinRecord = ([Hs.Name ()], Map (Hs.Name ()) (Hs.Decl ()))

--- a/src/Agda2Hs/Compile/Term.hs
+++ b/src/Agda2Hs/Compile/Term.hs
@@ -12,7 +12,10 @@ import Data.Maybe ( fromMaybe, isJust )
 import qualified Data.Text as Text ( unpack )
 import qualified Data.Set as Set ( singleton )
 
-import qualified Language.Haskell.Exts as Hs
+import qualified Language.Haskell.Exts.Build as Hs
+import qualified Language.Haskell.Exts.Extension as Hs
+import qualified Language.Haskell.Exts.Pretty as Hs
+import qualified Language.Haskell.Exts.Syntax as Hs
 
 import Agda.Syntax.Common.Pretty ( prettyShow )
 import qualified Agda.Syntax.Common.Pretty as P

--- a/src/Agda2Hs/Compile/Term.hs
+++ b/src/Agda2Hs/Compile/Term.hs
@@ -12,11 +12,6 @@ import Data.Maybe ( fromMaybe, isJust )
 import qualified Data.Text as Text ( unpack )
 import qualified Data.Set as Set ( singleton )
 
-import qualified Language.Haskell.Exts.Build as Hs
-import qualified Language.Haskell.Exts.Extension as Hs
-import qualified Language.Haskell.Exts.Pretty as Hs
-import qualified Language.Haskell.Exts.Syntax as Hs
-
 import Agda.Syntax.Common.Pretty ( prettyShow )
 import qualified Agda.Syntax.Common.Pretty as P
 import Agda.Syntax.Common
@@ -50,7 +45,10 @@ import Agda2Hs.Compile.Type ( compileType, compileDom, DomOutput(..), compileTel
 import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Utils
 import Agda2Hs.Compile.Var ( compileDBVar )
+
+import qualified Agda2Hs.Language.Haskell as Hs
 import Agda2Hs.Language.Haskell.Utils
+  ( hsName, pp, eApp, hsLambda, hsUnqualName, hsVar )
 
 import {-# SOURCE #-} Agda2Hs.Compile.Function ( compileClause' )
 import qualified Data.List as L

--- a/src/Agda2Hs/Compile/Term.hs
+++ b/src/Agda2Hs/Compile/Term.hs
@@ -50,7 +50,7 @@ import Agda2Hs.Compile.Type ( compileType, compileDom, DomOutput(..), compileTel
 import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Utils
 import Agda2Hs.Compile.Var ( compileDBVar )
-import Agda2Hs.HsUtils
+import Agda2Hs.Language.Haskell.Utils
 
 import {-# SOURCE #-} Agda2Hs.Compile.Function ( compileClause' )
 import qualified Data.List as L

--- a/src/Agda2Hs/Compile/Type.hs
+++ b/src/Agda2Hs/Compile/Type.hs
@@ -11,9 +11,6 @@ import Data.List ( find )
 import Data.Maybe ( mapMaybe, isJust )
 import qualified Data.Set as Set ( singleton )
 
-import qualified Language.Haskell.Exts.Syntax as Hs
-import qualified Language.Haskell.Exts.Extension as Hs
-
 import Agda.Compiler.Backend hiding ( Args )
 
 import Agda.Syntax.Common
@@ -37,7 +34,9 @@ import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Utils
 import Agda2Hs.Compile.Var
 import Agda2Hs.AgdaUtils
+import qualified Agda2Hs.Language.Haskell as Hs
 import Agda2Hs.Language.Haskell.Utils
+  ( Strictness(Lazy), hsName, tApp, constrainType, qualifyType )
 
 
 -- | Type definitions from the prelude that get special translation rules.

--- a/src/Agda2Hs/Compile/Type.hs
+++ b/src/Agda2Hs/Compile/Type.hs
@@ -13,7 +13,6 @@ import qualified Data.Set as Set ( singleton )
 
 import qualified Language.Haskell.Exts.Syntax as Hs
 import qualified Language.Haskell.Exts.Extension as Hs
-import qualified Language.Haskell.Exts.Pretty as Hs
 
 import Agda.Compiler.Backend hiding ( Args )
 

--- a/src/Agda2Hs/Compile/Type.hs
+++ b/src/Agda2Hs/Compile/Type.hs
@@ -37,7 +37,7 @@ import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Utils
 import Agda2Hs.Compile.Var
 import Agda2Hs.AgdaUtils
-import Agda2Hs.HsUtils
+import Agda2Hs.Language.Haskell.Utils
 
 
 -- | Type definitions from the prelude that get special translation rules.

--- a/src/Agda2Hs/Compile/TypeDefinition.hs
+++ b/src/Agda2Hs/Compile/TypeDefinition.hs
@@ -4,8 +4,6 @@ import Control.Monad ( unless )
 
 import Data.Maybe ( fromMaybe )
 
-import qualified Language.Haskell.Exts.Syntax as Hs
-
 import Agda.Compiler.Backend
 
 import Agda.Syntax.Common ( namedArg )
@@ -21,10 +19,11 @@ import Agda2Hs.Compile.Type ( compileType, compileDom, DomOutput(..), compileTyp
 import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Utils
 import Agda2Hs.Compile.Var ( compileDBVar )
-import Agda2Hs.Language.Haskell.Utils
 import Agda.Syntax.Common.Pretty (prettyShow)
 import Agda.TypeChecking.Substitute
 
+import qualified Agda2Hs.Language.Haskell as Hs
+import Agda2Hs.Language.Haskell.Utils ( hsName )
 
 compileTypeDef :: Hs.Name () -> Definition -> C [Hs.Decl ()]
 compileTypeDef name (Defn {..}) = do

--- a/src/Agda2Hs/Compile/TypeDefinition.hs
+++ b/src/Agda2Hs/Compile/TypeDefinition.hs
@@ -21,7 +21,7 @@ import Agda2Hs.Compile.Type ( compileType, compileDom, DomOutput(..), compileTyp
 import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Utils
 import Agda2Hs.Compile.Var ( compileDBVar )
-import Agda2Hs.HsUtils
+import Agda2Hs.Language.Haskell.Utils
 import Agda.Syntax.Common.Pretty (prettyShow)
 import Agda.TypeChecking.Substitute
 

--- a/src/Agda2Hs/Compile/Types.hs
+++ b/src/Agda2Hs/Compile/Types.hs
@@ -14,7 +14,7 @@ import Data.Set ( Set )
 import Data.Map ( Map )
 import Data.String ( IsString(..) )
 
-import qualified Language.Haskell.Exts.SrcLoc as Hs
+import qualified Language.Haskell.Exts.SrcLoc as Hs (SrcSpanInfo)
 import qualified Language.Haskell.Exts.Syntax as Hs
 import qualified Language.Haskell.Exts.Extension as Hs
 import qualified Language.Haskell.Exts.Comments as Hs

--- a/src/Agda2Hs/Compile/Types.hs
+++ b/src/Agda2Hs/Compile/Types.hs
@@ -14,11 +14,6 @@ import Data.Set ( Set )
 import Data.Map ( Map )
 import Data.String ( IsString(..) )
 
-import qualified Language.Haskell.Exts.SrcLoc as Hs (SrcSpanInfo)
-import qualified Language.Haskell.Exts.Syntax as Hs
-import qualified Language.Haskell.Exts.Extension as Hs
-import qualified Language.Haskell.Exts.Comments as Hs
-
 import Agda.Compiler.Backend
 import Agda.Syntax.Position ( Range )
 import Agda.Syntax.TopLevelModuleName ( TopLevelModuleName )
@@ -26,6 +21,7 @@ import Agda.TypeChecking.Warnings ( MonadWarning )
 import Agda.Utils.Null
 import Agda.Utils.Impossible
 
+import qualified Agda2Hs.Language.Haskell as Hs
 import Agda2Hs.Language.Haskell.Utils ( Strictness )
 
 type ModuleEnv   = TopLevelModuleName

--- a/src/Agda2Hs/Compile/Types.hs
+++ b/src/Agda2Hs/Compile/Types.hs
@@ -26,7 +26,7 @@ import Agda.TypeChecking.Warnings ( MonadWarning )
 import Agda.Utils.Null
 import Agda.Utils.Impossible
 
-import Agda2Hs.HsUtils ( Strictness )
+import Agda2Hs.Language.Haskell.Utils ( Strictness )
 
 type ModuleEnv   = TopLevelModuleName
 type ModuleRes   = ()

--- a/src/Agda2Hs/Compile/Utils.hs
+++ b/src/Agda2Hs/Compile/Utils.hs
@@ -11,7 +11,9 @@ import Data.List ( isPrefixOf, stripPrefix )
 import Data.Maybe ( isJust )
 import qualified Data.Map as M
 
-import qualified Language.Haskell.Exts as Hs
+import qualified Language.Haskell.Exts.Extension as Hs
+import qualified Language.Haskell.Exts.Pretty as Hs
+import qualified Language.Haskell.Exts.Syntax as Hs
 
 import Agda.Compiler.Backend hiding ( Args )
 

--- a/src/Agda2Hs/Compile/Utils.hs
+++ b/src/Agda2Hs/Compile/Utils.hs
@@ -11,10 +11,6 @@ import Data.List ( isPrefixOf, stripPrefix )
 import Data.Maybe ( isJust )
 import qualified Data.Map as M
 
-import qualified Language.Haskell.Exts.Extension as Hs
-import qualified Language.Haskell.Exts.Pretty as Hs
-import qualified Language.Haskell.Exts.Syntax as Hs
-
 import Agda.Compiler.Backend hiding ( Args )
 
 import Agda.Syntax.Common
@@ -47,10 +43,13 @@ import Agda.Utils.Singleton
 import AgdaInternals
 import Agda2Hs.AgdaUtils ( (~~) )
 import Agda2Hs.Compile.Types
-import Agda2Hs.Language.Haskell.Utils
 import Agda2Hs.Pragma
 import qualified Data.List as L
 import Agda.Utils.Impossible ( __IMPOSSIBLE__ )
+
+import qualified Agda2Hs.Language.Haskell as Hs
+import Agda2Hs.Language.Haskell.Utils
+  ( Strictness(..), validVarName, validTypeName, validConName, hsName, pp )
 
 data HsModuleKind
   = PrimModule

--- a/src/Agda2Hs/Compile/Utils.hs
+++ b/src/Agda2Hs/Compile/Utils.hs
@@ -47,7 +47,7 @@ import Agda.Utils.Singleton
 import AgdaInternals
 import Agda2Hs.AgdaUtils ( (~~) )
 import Agda2Hs.Compile.Types
-import Agda2Hs.HsUtils
+import Agda2Hs.Language.Haskell.Utils
 import Agda2Hs.Pragma
 import qualified Data.List as L
 import Agda.Utils.Impossible ( __IMPOSSIBLE__ )

--- a/src/Agda2Hs/Language/Haskell.hs
+++ b/src/Agda2Hs/Language/Haskell.hs
@@ -11,11 +11,14 @@ module Agda2Hs.Language.Haskell
   , module Language.Haskell.Exts.Parser
   , module Language.Haskell.Exts.Pretty
   , module Language.Haskell.Exts.Syntax
+  , module Agda2Hs.Language.Haskell.Utils
   ) where
 
-import Language.Haskell.Exts.Build
+import Agda2Hs.Language.Haskell.Utils
+
+import Language.Haskell.Exts.Build hiding (pApp)
 import Language.Haskell.Exts.ExactPrint (exactPrint)
-import Language.Haskell.Exts.Extension
+import Language.Haskell.Exts.Extension hiding (Strict, Lazy)
 import Language.Haskell.Exts.Parser
 import Language.Haskell.Exts.Pretty
 import Language.Haskell.Exts.Syntax

--- a/src/Agda2Hs/Language/Haskell.hs
+++ b/src/Agda2Hs/Language/Haskell.hs
@@ -13,9 +13,11 @@ module Agda2Hs.Language.Haskell
   , module Language.Haskell.Exts.Pretty
   , module Language.Haskell.Exts.SrcLoc
   , module Language.Haskell.Exts.Syntax
+  , module Agda2Hs.Language.Haskell.Pretty
   , module Agda2Hs.Language.Haskell.Utils
   ) where
 
+import Agda2Hs.Language.Haskell.Pretty
 import Agda2Hs.Language.Haskell.Utils
 
 import Language.Haskell.Exts.Comments (Comment)

--- a/src/Agda2Hs/Language/Haskell.hs
+++ b/src/Agda2Hs/Language/Haskell.hs
@@ -1,0 +1,21 @@
+-- | Haskell syntax, parsing, pretty printing.
+--
+-- This module contains those elements of the Haskell language
+-- that are needed by Agda2hs.
+--
+-- We are mainly re-exporting @haskell-src-exts@.
+module Agda2Hs.Language.Haskell
+  ( module Language.Haskell.Exts.Build
+  , module Language.Haskell.Exts.ExactPrint
+  , module Language.Haskell.Exts.Extension
+  , module Language.Haskell.Exts.Parser
+  , module Language.Haskell.Exts.Pretty
+  , module Language.Haskell.Exts.Syntax
+  ) where
+
+import Language.Haskell.Exts.Build
+import Language.Haskell.Exts.ExactPrint (exactPrint)
+import Language.Haskell.Exts.Extension
+import Language.Haskell.Exts.Parser
+import Language.Haskell.Exts.Pretty
+import Language.Haskell.Exts.Syntax

--- a/src/Agda2Hs/Language/Haskell.hs
+++ b/src/Agda2Hs/Language/Haskell.hs
@@ -6,19 +6,23 @@
 -- We are mainly re-exporting @haskell-src-exts@.
 module Agda2Hs.Language.Haskell
   ( module Language.Haskell.Exts.Build
+  , module Language.Haskell.Exts.Comments
   , module Language.Haskell.Exts.ExactPrint
   , module Language.Haskell.Exts.Extension
   , module Language.Haskell.Exts.Parser
   , module Language.Haskell.Exts.Pretty
+  , module Language.Haskell.Exts.SrcLoc
   , module Language.Haskell.Exts.Syntax
   , module Agda2Hs.Language.Haskell.Utils
   ) where
 
 import Agda2Hs.Language.Haskell.Utils
 
+import Language.Haskell.Exts.Comments (Comment)
 import Language.Haskell.Exts.Build hiding (pApp)
 import Language.Haskell.Exts.ExactPrint (exactPrint)
 import Language.Haskell.Exts.Extension hiding (Strict, Lazy)
 import Language.Haskell.Exts.Parser
 import Language.Haskell.Exts.Pretty
+import Language.Haskell.Exts.SrcLoc (SrcSpanInfo)
 import Language.Haskell.Exts.Syntax

--- a/src/Agda2Hs/Language/Haskell/Pretty.hs
+++ b/src/Agda2Hs/Language/Haskell/Pretty.hs
@@ -1,0 +1,61 @@
+-- | Pretty printing tweaks for @haskell-src-exts@.
+module Agda2Hs.Language.Haskell.Pretty
+  ( prettyShowImportDecl
+  ) where
+
+import Language.Haskell.Exts.Pretty as Hs
+import Language.Haskell.Exts.Syntax as Hs
+
+import Agda2Hs.Language.Haskell.Utils ( pp )
+
+-- | Custom implementation of 'prettyShow' for 'Hs.ImportDecl'
+-- that supports type operators.
+--
+-- Specifically, in the IThingAll and IThingWith import specs,
+-- the "type" prefixes get before type operators if necessary.
+-- See https://github.com/haskell-suite/haskell-src-exts/pull/475
+-- If this pull request gets merged,
+-- this custom implementation will be unnecessary.
+prettyShowImportDecl :: Hs.ImportDecl () -> String
+prettyShowImportDecl (Hs.ImportDecl _ m qual src safe mbPkg mbName mbSpecs) =
+  unwords $ ("import" :) $
+            (if src  then ("{-# SOURCE #-}" :) else id) $
+            (if safe then ("safe" :) else id) $
+            (if qual then ("qualified" :) else id) $
+            maybeAppend (\ str -> show str) mbPkg $
+            (pp m :) $
+            maybeAppend (\m' -> "as " ++ pp m') mbName $
+            (case mbSpecs of {Just specs -> [prettyShowSpecList specs]; Nothing -> []})
+    where
+      maybeAppend :: (a -> String) -> Maybe a -> ([String] -> [String])
+      maybeAppend f (Just a) = (f a :)
+      maybeAppend _ Nothing  = id
+
+      prettyShowSpecList :: Hs.ImportSpecList () -> String
+      prettyShowSpecList (Hs.ImportSpecList _ b ispecs)  =
+            (if b then "hiding " else "")
+                ++ parenList (map prettyShowSpec ispecs)
+
+      parenList :: [String] -> String
+      parenList [] = "()"
+      parenList (x:xs) = '(' : (x ++ go xs)
+        where
+          go :: [String] -> String
+          go [] = ")"
+          go (x:xs) = ", " ++ x ++ go xs
+
+      -- this is why we have rewritten it
+      prettyShowSpec :: Hs.ImportSpec () -> String
+      prettyShowSpec (Hs.IVar _ name  )        = pp name
+      prettyShowSpec (Hs.IAbs _ ns name)       = let ppns = pp ns in case ppns of
+          []                                  -> pp name -- then we don't write a space before it
+          _                                   -> ppns ++ (' ' : pp name)
+      prettyShowSpec (Hs.IThingAll _ name) = let rest = pp name ++ "(..)" in
+        case name of
+          -- if it's a symbol, append a "type" prefix to the beginning
+          (Hs.Symbol _ _)                     -> pp (Hs.TypeNamespace ()) ++ (' ' : rest)
+          (Hs.Ident  _ _)                     -> rest
+      prettyShowSpec (Hs.IThingWith _ name nameList) = let rest = pp name ++ (parenList . map pp $ nameList) in
+        case name of
+          (Hs.Symbol _ _)                     -> pp (Hs.TypeNamespace ()) ++ (' ' : rest)
+          (Hs.Ident  _ _)                     -> rest

--- a/src/Agda2Hs/Language/Haskell/Utils.hs
+++ b/src/Agda2Hs/Language/Haskell/Utils.hs
@@ -1,5 +1,5 @@
 
-module Agda2Hs.HsUtils where
+module Agda2Hs.Language.Haskell.Utils where
 
 import Control.Monad ( guard )
 

--- a/src/Agda2Hs/Pragma.hs
+++ b/src/Agda2Hs/Pragma.hs
@@ -16,7 +16,7 @@ import Agda.Syntax.Position
 import Agda.Utils.FileName ( filePath )
 import Agda.Utils.Maybe.Strict ( toLazy )
 
-import Agda2Hs.HsUtils
+import Agda2Hs.Language.Haskell.Utils
 import Agda2Hs.Compile.Types
 
 pragmaName :: String

--- a/src/Agda2Hs/Pragma.hs
+++ b/src/Agda2Hs/Pragma.hs
@@ -4,10 +4,6 @@ import Data.List ( isPrefixOf )
 import Data.Maybe ( fromMaybe )
 import qualified Data.Map as Map
 
-import qualified Language.Haskell.Exts.Syntax as Hs
-import qualified Language.Haskell.Exts.Parser as Hs
-import qualified Language.Haskell.Exts.Extension as Hs
-
 import Agda.Compiler.Backend
 import Agda.Compiler.Common ( curIF )
 
@@ -16,8 +12,10 @@ import Agda.Syntax.Position
 import Agda.Utils.FileName ( filePath )
 import Agda.Utils.Maybe.Strict ( toLazy )
 
-import Agda2Hs.Language.Haskell.Utils
 import Agda2Hs.Compile.Types
+
+import qualified Agda2Hs.Language.Haskell as Hs
+import Agda2Hs.Language.Haskell.Utils ( Strictness(..), srcLocToRange )
 
 pragmaName :: String
 pragmaName = "AGDA2HS"

--- a/src/Agda2Hs/Render.hs
+++ b/src/Agda2Hs/Render.hs
@@ -12,10 +12,6 @@ import qualified Data.Set as Set
 import System.FilePath ( takeDirectory, (</>) )
 import System.Directory ( createDirectoryIfMissing )
 
-import qualified Language.Haskell.Exts.Syntax as Hs
-import qualified Language.Haskell.Exts.ExactPrint as Hs
-import qualified Language.Haskell.Exts.Extension as Hs
-
 import Agda.Compiler.Backend
 import Agda.Compiler.Common ( compileDir )
 
@@ -31,7 +27,9 @@ import Agda2Hs.Compile
 import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Imports
 import Agda2Hs.Compile.Utils ( primModules )
+import qualified Agda2Hs.Language.Haskell as Hs
 import Agda2Hs.Language.Haskell.Utils
+  ( extToName, pp, moveToTop, insertParens )
 import Agda2Hs.Pragma ( getForeignPragmas )
 
 -- Rendering --------------------------------------------------------------

--- a/src/Agda2Hs/Render.hs
+++ b/src/Agda2Hs/Render.hs
@@ -12,9 +12,7 @@ import qualified Data.Set as Set
 import System.FilePath ( takeDirectory, (</>) )
 import System.Directory ( createDirectoryIfMissing )
 
-import qualified Language.Haskell.Exts.SrcLoc as Hs
 import qualified Language.Haskell.Exts.Syntax as Hs
-import qualified Language.Haskell.Exts.Build as Hs
 import qualified Language.Haskell.Exts.ExactPrint as Hs
 import qualified Language.Haskell.Exts.Extension as Hs
 
@@ -35,8 +33,6 @@ import Agda2Hs.Compile.Imports
 import Agda2Hs.Compile.Utils ( primModules )
 import Agda2Hs.HsUtils
 import Agda2Hs.Pragma ( getForeignPragmas )
-
-import Language.Haskell.Exts as Hs (prettyPrint, prelude_mod)
 
 -- Rendering --------------------------------------------------------------
 

--- a/src/Agda2Hs/Render.hs
+++ b/src/Agda2Hs/Render.hs
@@ -74,53 +74,6 @@ moduleFileName opts name = do
 ensureDirectory :: FilePath -> IO ()
 ensureDirectory = createDirectoryIfMissing True . takeDirectory
 
--- We have to rewrite this so that in the IThingAll and IThingWith import specs,
--- the "type" prefixes get before type operators if necessary.
--- But see haskell-src-exts, PR #475. If it gets merged, this will be unnecessary.
-prettyShowImportDecl :: Hs.ImportDecl () -> String
-prettyShowImportDecl (Hs.ImportDecl _ m qual src safe mbPkg mbName mbSpecs) =
-  unwords $ ("import" :) $
-            (if src  then ("{-# SOURCE #-}" :) else id) $
-            (if safe then ("safe" :) else id) $
-            (if qual then ("qualified" :) else id) $
-            maybeAppend (\ str -> show str) mbPkg $
-            (pp m :) $
-            maybeAppend (\m' -> "as " ++ pp m') mbName $
-            (case mbSpecs of {Just specs -> [prettyShowSpecList specs]; Nothing -> []})
-    where
-      maybeAppend :: (a -> String) -> Maybe a -> ([String] -> [String])
-      maybeAppend f (Just a) = (f a :)
-      maybeAppend _ Nothing  = id
-
-      prettyShowSpecList :: Hs.ImportSpecList () -> String
-      prettyShowSpecList (Hs.ImportSpecList _ b ispecs)  =
-            (if b then "hiding " else "")
-                ++ parenList (map prettyShowSpec ispecs)
-
-      parenList :: [String] -> String
-      parenList [] = "()"
-      parenList (x:xs) = '(' : (x ++ go xs)
-        where
-          go :: [String] -> String
-          go [] = ")"
-          go (x:xs) = ", " ++ x ++ go xs
-
-      -- this is why we have rewritten it
-      prettyShowSpec :: Hs.ImportSpec () -> String
-      prettyShowSpec (Hs.IVar _ name  )        = pp name
-      prettyShowSpec (Hs.IAbs _ ns name)       = let ppns = pp ns in case ppns of
-          []                                  -> pp name -- then we don't write a space before it
-          _                                   -> ppns ++ (' ' : pp name)
-      prettyShowSpec (Hs.IThingAll _ name) = let rest = pp name ++ "(..)" in
-        case name of
-          -- if it's a symbol, append a "type" prefix to the beginning
-          (Hs.Symbol _ _)                     -> pp (Hs.TypeNamespace ()) ++ (' ' : rest)
-          (Hs.Ident  _ _)                     -> rest
-      prettyShowSpec (Hs.IThingWith _ name nameList) = let rest = pp name ++ (parenList . map pp $ nameList) in
-        case name of
-          (Hs.Symbol _ _)                     -> pp (Hs.TypeNamespace ()) ++ (' ' : rest)
-          (Hs.Ident  _ _)                     -> rest
-
 writeModule :: Options -> ModuleEnv -> IsMain -> TopLevelModuleName
             -> [(CompiledDef, CompileOutput)] -> TCM ModuleRes
 writeModule opts _ isMain m outs = do
@@ -153,7 +106,7 @@ writeModule opts _ isMain m outs = do
             else (preludeImportDecl preOpts:) <$> compileImports mod filteredImps
 
     -- Add automatic imports
-    autoImports <- (unlines' . map prettyShowImportDecl) <$> autoImportList
+    autoImports <- (unlines' . map Hs.prettyShowImportDecl) <$> autoImportList
 
     -- The comments make it hard to generate and pretty print a full module
     hsFile <- moduleFileName opts m

--- a/src/Agda2Hs/Render.hs
+++ b/src/Agda2Hs/Render.hs
@@ -31,7 +31,7 @@ import Agda2Hs.Compile
 import Agda2Hs.Compile.Types
 import Agda2Hs.Compile.Imports
 import Agda2Hs.Compile.Utils ( primModules )
-import Agda2Hs.HsUtils
+import Agda2Hs.Language.Haskell.Utils
 import Agda2Hs.Pragma ( getForeignPragmas )
 
 -- Rendering --------------------------------------------------------------

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -7,8 +7,6 @@ import Control.Monad.IO.Class ( MonadIO(liftIO) )
 import System.Console.GetOpt
 import System.Environment ( getArgs )
 
-import qualified Language.Haskell.Exts.Extension as Hs
-
 import Agda.Main
 import Agda.Compiler.Backend
 
@@ -17,6 +15,8 @@ import Agda2Hs.Compile
 import Agda2Hs.Config ( checkConfig )
 import Agda2Hs.Compile.Types
 import Agda2Hs.Render
+
+import qualified Agda2Hs.Language.Haskell as Hs
 
 import Paths_agda2hs ( version, getDataFileName )
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -7,9 +7,6 @@ import Control.Monad.IO.Class ( MonadIO(liftIO) )
 import System.Console.GetOpt
 import System.Environment ( getArgs )
 
-import qualified Language.Haskell.Exts.Syntax as Hs
-import qualified Language.Haskell.Exts.Build as Hs
-import qualified Language.Haskell.Exts.Parser as Hs
 import qualified Language.Haskell.Exts.Extension as Hs
 
 import Agda.Main


### PR DESCRIPTION
This pull request is a pure refactoring that neatens the module `Agda2Hs.Render` by moving a function and factoring out a function.

DO NOT MERGE: Builds on top of #413, merge that one first.