### PR TITLE
[ fix #421 ] Only compile matching instance clauses when inlining

### DIFF
--- a/test/AllTests.agda
+++ b/test/AllTests.agda
@@ -96,6 +96,7 @@ import Issue324
 import Assert
 import Issue377
 import Issue394
+import Issue421
 
 {-# FOREIGN AGDA2HS
 import Issue14
@@ -189,4 +190,5 @@ import Issue324
 import Assert
 import Issue377
 import Issue394
+import Issue421
 #-}

--- a/test/Issue421.agda
+++ b/test/Issue421.agda
@@ -1,0 +1,27 @@
+module Issue421 where
+
+open import Haskell.Prelude
+
+record Identity (a : Type) : Type where
+  constructor MkIdentity
+  field runIdentity : a
+
+open Identity public
+{-# COMPILE AGDA2HS Identity newtype #-}
+
+instance
+  iDefaultFunctorIdentity : DefaultFunctor Identity
+  iDefaultFunctorIdentity .DefaultFunctor.fmap f (MkIdentity x) = MkIdentity (f x)
+
+  iFunctorIdentity : Functor Identity
+  iFunctorIdentity = record {DefaultFunctor iDefaultFunctorIdentity}
+
+  iDefaultApplicativeIdentity : DefaultApplicative Identity
+  iDefaultApplicativeIdentity .DefaultApplicative.pure = MkIdentity
+  iDefaultApplicativeIdentity .DefaultApplicative._<*>_ (MkIdentity f) (MkIdentity x) = MkIdentity (f x)
+
+  iApplicativeIdentity : Applicative Identity
+  iApplicativeIdentity = record {DefaultApplicative iDefaultApplicativeIdentity}
+
+{-# COMPILE AGDA2HS iFunctorIdentity #-}
+{-# COMPILE AGDA2HS iApplicativeIdentity #-}      -- generates pure and (<*>) multiple times

--- a/test/golden/AllTests.hs
+++ b/test/golden/AllTests.hs
@@ -91,4 +91,5 @@ import Issue324
 import Assert
 import Issue377
 import Issue394
+import Issue421
 

--- a/test/golden/Issue421.hs
+++ b/test/golden/Issue421.hs
@@ -1,0 +1,11 @@
+module Issue421 where
+
+newtype Identity a = MkIdentity{runIdentity :: a}
+
+instance Functor Identity where
+    fmap f (MkIdentity x) = MkIdentity (f x)
+
+instance Applicative Identity where
+    pure = MkIdentity
+    MkIdentity f <*> MkIdentity x = MkIdentity (f x)
+


### PR DESCRIPTION
Fixes #421 