### PR TITLE
Implement 'existing' keyword for skipping compilation of a symbol

### DIFF
--- a/src/Agda2Hs/Compile.hs
+++ b/src/Agda2Hs/Compile.hs
@@ -117,7 +117,8 @@ compile genv tlm _ def =
 
       case (p , theDef def) of
         (NoPragma            , _         ) -> return []
-        (ExistingClassPragma , _         ) -> return []
+        (ExistingPragma      , _         ) -> return []
+        (ExistingClassPragma , Record{}  ) -> return []
         (UnboxPragma s       , Record{}  ) -> [] <$ checkUnboxPragma def
         (TransparentPragma   , Function{}) -> [] <$ checkTransparentPragma def
         (InlinePragma        , Function{}) -> [] <$ checkInlinePragma def

--- a/src/Agda2Hs/Compile/Utils.hs
+++ b/src/Agda2Hs/Compile/Utils.hs
@@ -195,6 +195,7 @@ hasCompilePragma q = processPragma q <&> \case
   InlinePragma{} -> True
   DefaultPragma{} -> True
   ClassPragma{} -> True
+  ExistingPragma{} -> True
   ExistingClassPragma{} -> True
   UnboxPragma{} -> True
   TransparentPragma{} -> True

--- a/src/Agda2Hs/Pragma.hs
+++ b/src/Agda2Hs/Pragma.hs
@@ -51,6 +51,7 @@ data ParsedPragma
   | InlinePragma
   | DefaultPragma [Hs.Deriving ()]
   | ClassPragma [String]
+  | ExistingPragma
   | ExistingClassPragma
   | UnboxPragma Strictness
   | TransparentPragma
@@ -89,6 +90,7 @@ processPragma qn = liftTCM (getUniqueCompilerPragma pragmaName qn) >>= \case
   Just (CompilerPragma r s)
     | "class" `isPrefixOf` s      -> return $ ClassPragma (words $ drop 5 s)
     | s == "inline"               -> return InlinePragma
+    | s == "existing"             -> return ExistingPragma
     | s == "existing-class"       -> return ExistingClassPragma
     | s == "unboxed"              -> return $ UnboxPragma Lazy
     | s == "unboxed-strict"       -> return $ UnboxPragma Strict


### PR DESCRIPTION
This is useful for things that are defined in a FOREIGN pragma, either by importing from a Haskell module or as an inline Haskell definition.

I also noticed that currently there are absolutely no checks done on the existing-class keyword, so as a hack you could just use it for any symbol that you don't want to be compiled by agda2hs but still recognized by it. This PR also changes it so that we check at least that it is applied to a record type (unless we also want it to apply to postulates?)

Note that I have not yet written any tests for this, so I'm marking it as a draft for now.